### PR TITLE
feat: add shell completions and colored error output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::Shell;
 use console::style;
 use std::path::PathBuf;
 
@@ -48,6 +49,12 @@ enum Commands {
     },
     /// List available templates
     List,
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
     /// Interactive TUI for browsing and scaffolding templates (requires --features tui)
     #[cfg(feature = "tui")]
     Tui {
@@ -60,7 +67,14 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{} {:#}", style("error:").red().bold(), e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -87,6 +101,9 @@ fn main() -> Result<()> {
         }
         Commands::List => {
             list_templates()?;
+        }
+        Commands::Completions { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "fledge", &mut std::io::stdout());
         }
         #[cfg(feature = "tui")]
         Commands::Tui { output, no_git } => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -153,6 +153,47 @@ fn cli_version_flag() {
 }
 
 #[test]
+fn cli_completions_bash() {
+    let bin = cargo_bin();
+    let output = Command::new(&bin)
+        .args(["completions", "bash"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("_fledge"));
+    assert!(stdout.contains("init"));
+    assert!(stdout.contains("list"));
+}
+
+#[test]
+fn cli_completions_zsh() {
+    let bin = cargo_bin();
+    let output = Command::new(&bin)
+        .args(["completions", "zsh"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("compdef") || stdout.contains("_fledge"));
+}
+
+#[test]
+fn cli_completions_fish() {
+    let bin = cargo_bin();
+    let output = Command::new(&bin)
+        .args(["completions", "fish"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("fledge"));
+}
+
+#[test]
 fn cli_dry_run_does_not_create_files() {
     let bin = cargo_bin();
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Add `fledge completions <shell>` subcommand (bash, zsh, fish, PowerShell) via `clap_complete`
- Errors now print with colored `error:` prefix instead of plain anyhow debug output
- 3 new integration tests for completion generation

Closes #10 (remaining items — `--dry-run` and `--yes` were already merged in #15).

## Usage

```bash
# Bash
fledge completions bash > ~/.local/share/bash-completion/completions/fledge

# Zsh
fledge completions zsh > ~/.zfunc/_fledge

# Fish
fledge completions fish > ~/.config/fish/completions/fledge.fish
```

## Test plan

- [x] All 96 tests pass (86 unit + 10 integration)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` passes
- [x] Verified completions output for bash, zsh, and fish

---
🤖 Agent: CorvidAgent | Model: Opus 4.6