### PR TITLE
feat(docs): Initialize mdBook documentation with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Build & Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdbook
+        run: |
+          mkdir mdbook
+          curl --proto '=https' --tlsv1.2 -sSfL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=mdbook
+          echo "$(pwd)/mdbook" >> $GITHUB_PATH
+
+      - name: Build documentation
+        run: mdbook build docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 *.swp
 *.swo
 .DS_Store
+docs/book/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,9 @@
+[book]
+title = "fledge Documentation"
+authors = ["CorvidLabs"]
+language = "en"
+description = "Get your projects ready to fly. A fast, opinionated project scaffolding CLI built in Rust."
+
+[output.html]
+git-repository-url = "https://github.com/CorvidLabs/fledge"
+edit-url-template = "https://github.com/CorvidLabs/fledge/edit/main/docs/{path}"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+
+- [Introduction](./introduction.md)
+- [Getting Started](./getting-started.md)
+  - [Installation](./getting-started/installation.md)
+  - [Quick Start](./getting-started/quick-start.md)
+- [CLI Reference](./cli-reference.md)
+- [Template Authoring Guide](./template-authoring.md)
+- [Configuration](./configuration.md)

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1,0 +1,121 @@
+# CLI Reference
+
+Complete reference for all fledge commands and options.
+
+## fledge init `<name>`
+
+Create a new project from a template.
+
+### Usage
+
+```
+fledge init <name> [OPTIONS]
+```
+
+### Arguments
+
+- `<name>` — Project name
+
+### Options
+
+- `-t, --template <TEMPLATE>` — Template to use (skip interactive selection)
+- `-o, --output <OUTPUT>` — Parent directory for the project [default: `.`]
+- `--no-git` — Skip git init and initial commit
+- `--no-install` — Skip dependency installation (post-create hooks)
+- `--refresh` — Force re-clone of cached remote templates
+- `--dry-run` — Show what would be created without writing anything
+- `-y, --yes` — Skip all confirmation prompts (accept defaults)
+
+### Examples
+
+```bash
+# Create with defaults
+fledge init my-tool --template rust-cli
+
+# Preview before creating
+fledge init my-app --template react-app --dry-run
+
+# Skip all prompts
+fledge init my-lib --template rust-lib --yes
+
+# Specify output directory
+fledge init my-project --template ts-bun -o ~/projects
+```
+
+---
+
+## fledge list
+
+List all available templates (built-in + configured).
+
+### Usage
+
+```
+fledge list
+```
+
+Shows template name, description, and source (built-in or configured repo).
+
+---
+
+## fledge tui
+
+Interactive terminal UI for browsing templates and scaffolding projects.
+
+*Requires `--features tui` at install time.*
+
+### Usage
+
+```
+fledge tui [OPTIONS]
+```
+
+### Options
+
+- `-o, --output <OUTPUT>` — Parent directory for the project [default: `.`]
+- `--no-git` — Skip git init and initial commit
+
+### Navigation
+
+- **Arrow keys** — Browse templates
+- **Tab** — Fill in project variables
+- **Enter** — Confirm and create
+
+The TUI provides an interactive experience for users who prefer guided project creation.
+
+---
+
+## fledge completions `<shell>`
+
+Generate shell completions for your shell.
+
+### Usage
+
+```
+fledge completions <shell>
+```
+
+### Supported Shells
+
+- `bash`
+- `zsh`
+- `fish`
+- `powershell`
+
+### Examples
+
+```bash
+# Bash
+fledge completions bash >> ~/.bashrc
+
+# Zsh
+fledge completions zsh > ~/.zfunc/_fledge
+
+# Fish
+fledge completions fish > ~/.config/fish/completions/fledge.fish
+
+# PowerShell
+fledge completions powershell | Out-String | Out-File -FilePath $PROFILE -Append
+```
+
+After adding completions, reload your shell or start a new terminal session to enable them.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,112 @@
+# Configuration
+
+Configure fledge to customize defaults and add custom template repositories.
+
+## Config File Location
+
+fledge reads configuration from:
+
+```
+~/.config/fledge/config.toml
+```
+
+## Configuration Sections
+
+### defaults
+
+Set default values for project creation:
+
+```toml
+[defaults]
+author = "Your Name"
+github_org = "YourOrg"
+license = "MIT"
+```
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `author` | Default author name | falls back to `git config user.name` |
+| `github_org` | Default GitHub organization | `CorvidLabs` |
+| `license` | Default license for new projects | `MIT` |
+
+If `author` is not set, fledge falls back to your git config:
+
+```bash
+git config user.name
+```
+
+### templates
+
+Configure template locations and repositories:
+
+```toml
+[templates]
+paths = ["~/my-templates", "~/work/templates"]
+repos = ["CorvidLabs/fledge-templates", "myorg/templates"]
+```
+
+| Key | Description |
+|-----|-------------|
+| `paths` | Local directories containing template files (relative to home) |
+| `repos` | GitHub repositories to search for templates (`owner/repo` format) |
+
+### github
+
+Configure GitHub access for private template repositories:
+
+```toml
+[github]
+token = "ghp_..."
+```
+
+| Key | Description |
+|-----|-------------|
+| `token` | GitHub personal access token for private repos |
+
+**Note:** fledge checks GitHub token in order:
+1. `FLEDGE_GITHUB_TOKEN` environment variable
+2. `GITHUB_TOKEN` environment variable
+3. `token` in config file
+
+## Complete Example Config
+
+```toml
+[defaults]
+author = "Leif"
+github_org = "CorvidLabs"
+license = "MIT"
+
+[templates]
+paths = ["~/.fledge/templates", "~/projects/templates"]
+repos = ["CorvidLabs/fledge-templates", "my-org/my-templates"]
+
+[github]
+token = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+```
+
+## Environment Variables
+
+fledge respects the following environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `FLEDGE_GITHUB_TOKEN` | GitHub token (overrides config) |
+| `GITHUB_TOKEN` | GitHub token (fallback) |
+
+Example:
+
+```bash
+export FLEDGE_GITHUB_TOKEN="ghp_..."
+fledge init my-project --template private-org/private-template
+```
+
+## Defaults Behavior
+
+When creating a project, fledge uses this priority for defaults:
+
+1. Command-line arguments (highest priority)
+2. Config file settings
+3. Git config (for author)
+4. Built-in defaults (lowest priority)
+
+For example, if you set `author = "Leif"` in your config, fledge will use that unless you provide a different author when prompted.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Learn how to install fledge and create your first project.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,37 @@
+# Installation
+
+## From crates.io
+
+The easiest way to install fledge is from crates.io:
+
+```bash
+cargo install fledge
+```
+
+## With TUI Support
+
+fledge includes an optional interactive terminal UI for browsing and selecting templates. To enable it, install with the `tui` feature:
+
+```bash
+cargo install fledge --features tui
+```
+
+## From Source
+
+If you prefer to build from source, clone the repository and install:
+
+```bash
+git clone https://github.com/CorvidLabs/fledge.git
+cd fledge && cargo install --path .
+```
+
+## Verify Installation
+
+After installation, verify fledge works:
+
+```bash
+fledge --version
+fledge list
+```
+
+You should see fledge's version and a list of available built-in templates.

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -1,0 +1,67 @@
+# Quick Start
+
+## Create Your First Project
+
+The simplest way to get started is to create a new project:
+
+```bash
+fledge init my-tool --template rust-cli
+```
+
+This creates a new Rust CLI project in a `my-tool` directory with all the scaffolding you need.
+
+## Browse Templates Interactively
+
+If you're not sure which template to use, let fledge guide you:
+
+```bash
+fledge init my-project
+```
+
+You'll be prompted to select a template and fill in project variables.
+
+## Use a Remote GitHub Template
+
+Any GitHub repository can be a template source. Use the `owner/repo` syntax:
+
+```bash
+fledge init my-app --template CorvidLabs/fledge-templates/react-app
+```
+
+## Preview Changes with Dry Run
+
+Before committing to creating a project, preview what would be generated:
+
+```bash
+fledge init my-tool --template rust-cli --dry-run
+```
+
+## Skip All Prompts with Defaults
+
+If you want to skip confirmations and use defaults, use `--yes`:
+
+```bash
+fledge init my-tool --template rust-cli --yes
+```
+
+## List Available Templates
+
+See all available templates (built-in and configured):
+
+```bash
+fledge list
+```
+
+## Built-in Templates
+
+fledge comes with several built-in templates ready to use:
+
+| Template | Description |
+|----------|-------------|
+| `rust-cli` | Rust CLI application with clap, CI, and release automation |
+| `rust-lib` | Rust library crate with docs and publishing workflow |
+| `swift-pkg` | Swift package with Package.swift, CI, and coding conventions |
+| `ts-bun` | TypeScript project with Bun runtime |
+| `angular-app` | Angular application with mobile-first setup |
+
+Each template includes sensible defaults, CI/CD workflows, and best practices for its language ecosystem.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+Get your projects ready to fly.
+
+**fledge** is a fast, opinionated project scaffolding CLI built in Rust. Create new projects from templates — local or remote — with smart defaults, Tera-powered rendering, and zero boilerplate.
+
+## Why fledge?
+
+- **Fast** — native Rust binary, no runtime dependencies
+- **Smart defaults** — pulls author/org from git config, renders dates, computes name variants automatically
+- **Remote templates** — use any GitHub repo as a template source with `owner/repo` syntax
+- **Extensible** — create your own templates with a simple `template.toml` manifest
+- **Safe** — remote template hooks require explicit confirmation before running
+- **Optional TUI** — interactive template browser with `--features tui`
+
+fledge is designed to eliminate boilerplate setup when starting new projects. Whether you're scaffolding a Rust CLI, a Swift package, or a TypeScript project, fledge provides a consistent, powerful templating system with sensible defaults that just work.

--- a/docs/src/template-authoring.md
+++ b/docs/src/template-authoring.md
@@ -1,0 +1,287 @@
+# Template Authoring Guide
+
+Create your own templates to share with your team or the community.
+
+## Overview
+
+A template is a directory with a `template.toml` manifest and any number of template files. Files are rendered through [Tera](https://keats.github.io/tera/) (a Jinja2-like engine) before being written.
+
+### Directory Structure
+
+```
+my-template/
+├── template.toml          # manifest (required)
+├── src/
+│   └── main.rs            # template files — Tera syntax supported
+├── README.md
+├── Cargo.toml
+└── .github/
+    └── workflows/
+        └── ci.yml
+```
+
+## template.toml Reference
+
+The `template.toml` manifest defines template metadata, prompts, file rules, and hooks.
+
+### Basic Structure
+
+```toml
+[template]
+name = "my-template"                           # template name (used in --template flag)
+description = "A short description"            # shown in fledge list
+min_fledge_version = "0.1.0"                   # optional minimum fledge version
+
+[prompts]
+# Each key becomes a template variable. Values have `message` and optional `default`.
+description = { message = "Project description", default = "A new project" }
+port = { message = "Default port", default = "3000" }
+
+# Defaults can use Tera expressions referencing earlier variables:
+repo_url = { message = "Repository URL", default = "https://github.com/{{ github_org }}/{{ project_name }}" }
+
+[files]
+render = ["**/*.rs", "**/*.toml", "**/*.md", "**/*.yml"]   # files to render through Tera
+copy = ["**/*.png", "**/*.ico"]                             # files to copy as-is (binary files)
+ignore = ["template.toml"]                                  # files to exclude from output
+
+[hooks]
+post_create = ["cargo fmt", "npm install"]     # commands to run after scaffolding
+```
+
+### Section: template
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `name` | string | Yes | Used with `--template` flag |
+| `description` | string | No | Shown in `fledge list` |
+| `min_fledge_version` | string | No | Minimum fledge version required |
+
+### Section: prompts
+
+Define custom variables that will be prompted to the user. Each prompt becomes a template variable.
+
+```toml
+[prompts]
+# Simple prompt with default
+description = { message = "Project description", default = "A new project" }
+
+# Prompt without default (required)
+main_author = { message = "Primary author" }
+
+# Default can reference earlier variables
+repo_url = { message = "Repository URL", default = "https://github.com/{{ github_org }}/{{ project_name }}" }
+```
+
+### Section: files
+
+Define which files to render, copy, or ignore.
+
+**Rules are applied in order and first match wins.**
+
+- **`render`** — glob patterns for files that should be processed through Tera
+- **`copy`** — glob patterns for files that should be copied as-is (binary files, images)
+- **`ignore`** — glob patterns for files to exclude entirely
+
+Files not matching any rule are rendered by default.
+
+```toml
+[files]
+render = ["**/*.rs", "**/*.toml", "**/*.md", "**/*.yml"]
+copy = ["**/*.png", "**/*.ico", "assets/**"]
+ignore = ["template.toml", "node_modules/**"]
+```
+
+### Section: hooks
+
+Commands to run after scaffolding is complete, inside the newly created project directory.
+
+```toml
+[hooks]
+post_create = ["cargo fmt", "cargo test", "git add -A && git commit -m 'Initial commit'"]
+```
+
+For local (built-in) templates, hooks run automatically. For remote templates, fledge shows the commands and asks for confirmation unless `--yes` is passed.
+
+## Built-in Variables
+
+These variables are always available in your templates — no need to define them in `[prompts]`:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `project_name` | The project name as provided by the user | `my-cool-app` |
+| `project_name_snake` | Snake case version | `my_cool_app` |
+| `project_name_pascal` | PascalCase version | `MyCoolApp` |
+| `author` | From config, git, or prompted | `Leif` |
+| `github_org` | From config or prompted (default: `CorvidLabs`) | `CorvidLabs` |
+| `license` | From config (default: `MIT`) | `MIT` |
+| `year` | Current year | `2026` |
+| `date` | Current date | `2026-04-18` |
+
+## Tera Syntax
+
+Templates use [Tera](https://keats.github.io/tera/docs/) syntax. Common patterns:
+
+### Variable Substitution
+
+```
+# {{ project_name }}
+
+{{ description }}
+```
+
+### Conditionals
+
+```
+{% if license == "MIT" %}
+This project is MIT licensed.
+{% endif %}
+```
+
+### Loops
+
+```
+{% for dep in dependencies %}
+- {{ dep }}
+{% endfor %}
+```
+
+### Filters
+
+```
+Project slug: {{ project_name | slugify }}
+Uppercase: {{ author | upper }}
+```
+
+### Complete Example
+
+```
+# {{ project_name }}
+
+{{ description }}
+
+## Author
+
+Created by {{ author }} ({{ github_org }}) in {{ year }}.
+
+{% if license == "MIT" %}
+This project is MIT licensed.
+{% endif %}
+
+## Quick Start
+
+```
+cd {{ project_name_snake }}
+cargo build
+```
+```
+
+## Creating a Template from Scratch
+
+### 1. Create the template directory
+
+```bash
+mkdir python-api && cd python-api
+```
+
+### 2. Create template.toml
+
+```toml
+[template]
+name = "python-api"
+description = "Python FastAPI project with Docker"
+
+[prompts]
+description = { message = "Project description", default = "A FastAPI application" }
+python_version = { message = "Python version", default = "3.12" }
+
+[files]
+render = ["**/*.py", "**/*.toml", "**/*.md", "**/*.yml", "Dockerfile"]
+ignore = ["template.toml"]
+
+[hooks]
+post_create = ["python -m venv .venv"]
+```
+
+### 3. Create template files
+
+```python
+# app/main.py
+"""{{ description }}"""
+from fastapi import FastAPI
+
+app = FastAPI(title="{{ project_name_pascal }}")
+
+@app.get("/")
+def root():
+    return {"name": "{{ project_name }}"}
+```
+
+```dockerfile
+# Dockerfile
+FROM python:{{ python_version }}-slim
+WORKDIR /app
+COPY . .
+RUN pip install -e .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0"]
+```
+
+### 4. Test locally
+
+```bash
+fledge init test-api --template ./python-api --dry-run
+fledge init test-api --template ./python-api
+```
+
+## Testing Templates
+
+### Point to Local Template Directory
+
+Add your template directory to config:
+
+```toml
+# ~/.config/fledge/config.toml
+[templates]
+paths = ["~/dev/my-templates"]
+```
+
+Or use it directly as a path:
+
+```bash
+fledge init test-project --template ./my-template
+```
+
+### Iterate and Test
+
+1. Edit template files
+2. Run `fledge init test-output --template my-template`
+3. Inspect the output
+4. Delete test output and repeat
+
+## Sharing Templates
+
+### Use a GitHub Repository
+
+Any GitHub repository can be a template source. Use the `owner/repo` syntax:
+
+```bash
+fledge init my-app --template user/my-template
+```
+
+### Register Template Repositories
+
+Users can register your template repo in their config to have it appear in `fledge list`:
+
+```toml
+# ~/.config/fledge/config.toml
+[templates]
+repos = ["CorvidLabs/fledge-templates", "myorg/templates"]
+```
+
+### Best Practices
+
+- **Clear names** — use descriptive template names
+- **Good docs** — include a README explaining what the template does
+- **Sensible defaults** — prompt for what's necessary, provide defaults for everything else
+- **Test hooks** — ensure post-create hooks are idempotent and handle missing tools gracefully
+- **Version requirements** — use `min_fledge_version` to signal breaking changes


### PR DESCRIPTION
## Summary

Resolves #19 — complete mdBook documentation setup with GitHub Pages deployment.

- ✅ Initialized mdBook structure in `docs/` directory with `book.toml` and `src/SUMMARY.md`
- ✅ Created comprehensive chapters:
  - **Introduction** — why fledge, feature highlights
  - **Getting Started** — installation (crates.io, source) and quick start examples
  - **CLI Reference** — all commands (init, list, tui, completions) with full options
  - **Template Authoring Guide** — complete guide to creating custom templates with template.toml reference, Tera syntax, examples
  - **Configuration** — config.toml reference, environment variables, defaults behavior
- ✅ Content pulled from existing README.md for consistency
- ✅ GitHub Actions workflow (`.github/workflows/docs.yml`) for automatic build and deployment to GitHub Pages
- ✅ Configured to deploy on push to `main` with mdBook v0.5.2
- ✅ Added `docs/book/` to `.gitignore` to exclude build artifacts

## Testing

Documentation builds successfully with `mdbook build docs` and is ready for GitHub Pages deployment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)