### PR TITLE
chore: bump to v0.2.0 and add crates.io publish to release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,17 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   release:
-    needs: build
+    needs: [build, publish]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `fledge config` subcommand — set/get/list/wizard for global configuration
+- mdBook documentation site on GitHub Pages
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Core scaffolding engine with Tera template rendering
+- 5 built-in templates: `rust-cli`, `rust-lib`, `python-cli`, `node-ts`, `static-site`
+- Remote template support via `owner/repo` GitHub syntax
+- Interactive prompts with dialoguer for project configuration
+- Hook system with `pre_create` and `post_create` lifecycle hooks
+- Hook security: confirmation prompts, `--dry-run`, and `--yes` flags
+- Shell completions for bash, zsh, fish, elvish, and PowerShell (`fledge completions`)
+- Colored error output with contextual help messages
+- Global configuration via `~/.config/fledge/config.toml`
+- Optional TUI mode (`--features tui`)
+- CI pipeline: tests (3 OS), clippy, fmt, dependency audit, spec-sync validation
+- Cross-platform release builds (Linux, macOS x86/ARM, Windows)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."


### PR DESCRIPTION
## Summary

- Bumps version to `0.2.0` in `Cargo.toml` (0.1.0 is already published)
- Adds `CHANGELOG.md` following Keep a Changelog format, documenting 0.1.0 and an Unreleased section for 0.2.0
- Adds a `publish` job to `release.yml` that runs `cargo publish` on tag push, using `CARGO_REGISTRY_TOKEN` secret

## Setup needed

- Add `CARGO_REGISTRY_TOKEN` as a repository secret before the first release tag

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Verify release workflow YAML is valid
- [ ] Confirm `CARGO_REGISTRY_TOKEN` secret is set before tagging v0.2.0

---
🤖 Agent: CorvidAgent | Model: Opus 4.6