### PR TITLE
fix: embed templates in binary for cargo install users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 chrono = "0.4"
 dirs = "6"
 regex-lite = "0.1"
+include_dir = "0.7"
 ratatui = { version = "0.29.0", optional = true }
 crossterm = { version = "0.29.0", optional = true }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
+use include_dir::{include_dir, Dir};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tera::Tera;
 use walkdir::WalkDir;
+
+static EMBEDDED_TEMPLATES: Dir = include_dir!("$CARGO_MANIFEST_DIR/templates");
 
 #[derive(Debug, Deserialize)]
 pub struct TemplateManifest {
@@ -140,8 +143,52 @@ fn builtin_template_dir() -> PathBuf {
         }
     }
 
-    // Fallback: current directory
-    PathBuf::from("templates")
+    // CWD fallback (e.g. running from repo root)
+    let cwd_path = PathBuf::from("templates");
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+
+    // Extract embedded templates to cache directory
+    extract_embedded_templates()
+}
+
+fn extract_embedded_templates() -> PathBuf {
+    let version = env!("CARGO_PKG_VERSION");
+    let cache_dir = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("fledge")
+        .join(format!("templates-v{}", version));
+
+    // If already extracted for this version, reuse it
+    if cache_dir.exists() {
+        return cache_dir;
+    }
+
+    if let Err(e) = extract_dir_recursive(&EMBEDDED_TEMPLATES, &cache_dir) {
+        eprintln!("Warning: failed to extract embedded templates: {}", e);
+    }
+
+    cache_dir
+}
+
+fn extract_dir_recursive(dir: &Dir, target: &Path) -> Result<()> {
+    std::fs::create_dir_all(target)
+        .with_context(|| format!("creating {}", target.display()))?;
+
+    for file in dir.files() {
+        let file_path = target.join(file.path().file_name().unwrap_or_default());
+        std::fs::write(&file_path, file.contents())
+            .with_context(|| format!("writing {}", file_path.display()))?;
+    }
+
+    for subdir in dir.dirs() {
+        let subdir_name = subdir.path().file_name().unwrap_or_default();
+        let subdir_target = target.join(subdir_name);
+        extract_dir_recursive(subdir, &subdir_target)?;
+    }
+
+    Ok(())
 }
 
 fn load_templates_from_dir(dir: &Path, templates: &mut Vec<Template>) -> Result<()> {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use include_dir::{include_dir, Dir};
+use include_dir::{Dir, include_dir};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -173,8 +173,7 @@ fn extract_embedded_templates() -> PathBuf {
 }
 
 fn extract_dir_recursive(dir: &Dir, target: &Path) -> Result<()> {
-    std::fs::create_dir_all(target)
-        .with_context(|| format!("creating {}", target.display()))?;
+    std::fs::create_dir_all(target).with_context(|| format!("creating {}", target.display()))?;
 
     for file in dir.files() {
         let file_path = target.join(file.path().file_name().unwrap_or_default());


### PR DESCRIPTION
## Summary
- Templates are now compiled into the binary using `include_dir`, so `cargo install fledge` users no longer get "No templates found" errors
- On first use, templates are extracted to `~/.cache/fledge/templates-v{version}/` and reused from there
- Each version gets its own cache dir, so upgrades automatically pick up new templates

## Test plan
- [x] All 96 tests pass (86 unit + 10 integration)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Install via `cargo install --path .` and run `fledge list` from a non-repo directory
- [ ] Run `fledge init my-project` from `/tmp` — should find templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)