### PR TITLE
fix: embed templates in binary for cargo install users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 chrono = "0.4"
 dirs = "6"
 regex-lite = "0.1"
+include_dir = "0.7"
 ratatui = { version = "0.29.0", optional = true }
 crossterm = { version = "0.29.0", optional = true }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
+use include_dir::{include_dir, Dir};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tera::Tera;
 use walkdir::WalkDir;
+
+static EMBEDDED_TEMPLATES: Dir = include_dir!("$CARGO_MANIFEST_DIR/templates");
 
 #[derive(Debug, Deserialize)]
 pub struct TemplateManifest {
@@ -140,8 +143,52 @@ fn builtin_template_dir() -> PathBuf {
         }
     }
 
-    // Fallback: current directory
-    PathBuf::from("templates")
+    // CWD fallback (e.g. running from repo root)
+    let cwd_path = PathBuf::from("templates");
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+
+    // Extract embedded templates to cache directory
+    extract_embedded_templates()
+}
+
+fn extract_embedded_templates() -> PathBuf {
+    let version = env!("CARGO_PKG_VERSION");
+    let cache_dir = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("fledge")
+        .join(format!("templates-v{}", version));
+
+    // If already extracted for this version, reuse it
+    if cache_dir.exists() {
+        return cache_dir;
+    }
+
+    if let Err(e) = extract_dir_recursive(&EMBEDDED_TEMPLATES, &cache_dir) {
+        eprintln!("Warning: failed to extract embedded templates: {}", e);
+    }
+
+    cache_dir
+}
+
+fn extract_dir_recursive(dir: &Dir, target: &Path) -> Result<()> {
+    std::fs::create_dir_all(target)
+        .with_context(|| format!("creating {}", target.display()))?;
+
+    for file in dir.files() {
+        let file_path = target.join(file.path().file_name().unwrap_or_default());
+        std::fs::write(&file_path, file.contents())
+            .with_context(|| format!("writing {}", file_path.display()))?;
+    }
+
+    for subdir in dir.dirs() {
+        let subdir_name = subdir.path().file_name().unwrap_or_default();
+        let subdir_target = target.join(subdir_name);
+        extract_dir_recursive(subdir, &subdir_target)?;
+    }
+
+    Ok(())
 }
 
 fn load_templates_from_dir(dir: &Path, templates: &mut Vec<Template>) -> Result<()> {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use include_dir::{include_dir, Dir};
+use include_dir::{Dir, include_dir};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -173,8 +173,7 @@ fn extract_embedded_templates() -> PathBuf {
 }
 
 fn extract_dir_recursive(dir: &Dir, target: &Path) -> Result<()> {
-    std::fs::create_dir_all(target)
-        .with_context(|| format!("creating {}", target.display()))?;
+    std::fs::create_dir_all(target).with_context(|| format!("creating {}", target.display()))?;
 
     for file in dir.files() {
         let file_path = target.join(file.path().file_name().unwrap_or_default());


### PR DESCRIPTION
## Summary
- Embeds all built-in templates directly into the binary using `include_dir!`, so `fledge init` and `fledge list` work when installed via `cargo install` (where the `templates/` directory isn't present)
- Falls back to filesystem templates when available, so development workflow is unchanged
- Adds `include_dir` dependency to Cargo.toml

## Test plan
- [ ] `cargo install --path .` then run `fledge list` from outside the repo — should show all 5 templates
- [ ] `fledge init my-project --template rust-cli` from a directory without `templates/` — should scaffold correctly
- [ ] Running from the repo directory still picks up filesystem templates as before

Fixes the issue where `cargo install fledge` users got "No templates found" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)