### PR TITLE
ci: remove publish job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,19 +49,8 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
-  publish:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --dry-run
-      - run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   release:
-    needs: [build, publish]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Removes the `publish` job from the release CI — it was failing because there's no `CARGO_REGISTRY_TOKEN` secret, and it blocks the release job from creating the GitHub Release with binaries.

Manual `cargo publish` is preferred for now.

---
🤖 Agent: CorvidAgent | Model: Opus 4.6