### PR TITLE
feat: add `fledge config` subcommand

### DIFF
--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -1,6 +1,6 @@
 ---
 module: config
-version: 3
+version: 4
 status: active
 files:
   - src/config.rs
@@ -27,6 +27,10 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `GitHubConfig` | Struct holding optional GitHub token for authenticated access |
 | `load` | Loads config from disk or returns defaults if file is missing |
 | `config_path` | Returns the platform-appropriate path to the config file |
+| `save` | Serializes config to TOML and writes to disk, creating parent directories if needed |
+| `get` | Returns a config value by dotted key (e.g. `defaults.author`), or `None` if unset/unknown |
+| `set` | Sets a config value by dotted key; errors on unknown key |
+| `unset` | Removes a config value by dotted key; errors on unknown key |
 | `author_or_git` | Returns author from config, falling back to `git config user.name` |
 | `github_org` | Returns the configured GitHub org, if any |
 | `license` | Returns the configured license, defaulting to "MIT" |
@@ -54,6 +58,10 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 |----------|-----------|-------------|
 | `Config::load` | `() -> Result<Self>` | Load config from disk or return defaults |
 | `Config::config_path` | `() -> PathBuf` | Returns path to config file |
+| `Config::save` | `(&self) -> Result<()>` | Serialize config to TOML and write to disk, creating parent dirs if needed |
+| `Config::get` | `(&self, key: &str) -> Option<String>` | Get a config value by dotted key (e.g. `defaults.author`) |
+| `Config::set` | `(&mut self, key: &str, value: &str) -> Result<()>` | Set a config value by dotted key, errors on unknown key |
+| `Config::unset` | `(&mut self, key: &str) -> Result<()>` | Remove a config value by dotted key, errors on unknown key |
 | `Config::author_or_git` | `(&self) -> Option<String>` | Author from config, falling back to `git config user.name` |
 | `Config::github_org` | `(&self) -> Option<String>` | GitHub org from config |
 | `Config::license` | `(&self) -> String` | License from config, defaulting to "MIT" |
@@ -68,6 +76,9 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 3. `~/` prefix in template paths is expanded to the user's home directory
 4. GitHub token resolution order: `FLEDGE_GITHUB_TOKEN` env → `GITHUB_TOKEN` env → config file
 5. Template repos default to empty list
+6. `save` creates parent directories if they don't exist
+7. `get`/`set`/`unset` accept dotted keys: `defaults.author`, `defaults.github_org`, `defaults.license`, `github.token`
+8. `set`/`unset` return an error for unknown keys
 
 ## Behavioral Examples
 
@@ -83,6 +94,30 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 - **When** `author_or_git()` is called
 - **Then** runs `git config user.name` and returns the result
 
+### Scenario: Set a config value
+
+- **Given** config exists with default values
+- **When** `set("defaults.author", "Leif")` is called followed by `save()`
+- **Then** config file is updated with `author = "Leif"` under `[defaults]`
+
+### Scenario: Get a config value
+
+- **Given** config has `defaults.github_org = "CorvidLabs"`
+- **When** `get("defaults.github_org")` is called
+- **Then** returns `Some("CorvidLabs")`
+
+### Scenario: Unset a config value
+
+- **Given** config has `defaults.author = "Leif"`
+- **When** `unset("defaults.author")` is called followed by `save()`
+- **Then** `defaults.author` is `None` in the saved config
+
+### Scenario: Unknown key error
+
+- **Given** any config state
+- **When** `set("invalid.key", "value")` is called
+- **Then** returns an error listing valid keys
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -90,6 +125,8 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | Malformed TOML | Returns parse error |
 | File not readable | Returns IO error |
 | `git config user.name` fails | `author_or_git()` returns `None` |
+| Unknown key passed to `set`/`unset` | Returns error with list of valid keys |
+| Config directory doesn't exist on `save` | Creates parent directories automatically |
 
 ## Dependencies
 
@@ -116,3 +153,4 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | 2026-04-18 | CorvidAgent | Initial spec |
 | 2026-04-18 | CorvidAgent | v2: filled in exported function descriptions, re-validated against source |
 | 2026-04-18 | CorvidAgent | v3: add GitHubConfig, github_token(), template_repos(), templates.repos field |
+| 2026-04-19 | CorvidAgent | v4: add save(), get(), set(), unset() for CLI config management |

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,54 @@ impl Config {
             .join("config.toml")
     }
 
+    pub fn save(&self) -> Result<()> {
+        let path = Self::config_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self)?;
+        std::fs::write(&path, content)?;
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> Option<String> {
+        match key {
+            "defaults.author" => self.defaults.author.clone(),
+            "defaults.github_org" => self.defaults.github_org.clone(),
+            "defaults.license" => self.defaults.license.clone(),
+            "github.token" => self.github.token.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
+        match key {
+            "defaults.author" => self.defaults.author = Some(value.to_string()),
+            "defaults.github_org" => self.defaults.github_org = Some(value.to_string()),
+            "defaults.license" => self.defaults.license = Some(value.to_string()),
+            "github.token" => self.github.token = Some(value.to_string()),
+            _ => anyhow::bail!(
+                "Unknown config key '{}'. Valid keys: defaults.author, defaults.github_org, defaults.license, github.token",
+                key
+            ),
+        }
+        Ok(())
+    }
+
+    pub fn unset(&mut self, key: &str) -> Result<()> {
+        match key {
+            "defaults.author" => self.defaults.author = None,
+            "defaults.github_org" => self.defaults.github_org = None,
+            "defaults.license" => self.defaults.license = None,
+            "github.token" => self.github.token = None,
+            _ => anyhow::bail!(
+                "Unknown config key '{}'. Valid keys: defaults.author, defaults.github_org, defaults.license, github.token",
+                key
+            ),
+        }
+        Ok(())
+    }
+
     pub fn author_or_git(&self) -> Option<String> {
         if let Some(ref author) = self.defaults.author {
             return Some(author.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,11 @@ enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+    /// Manage global configuration
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
     /// Interactive TUI for browsing and scaffolding templates (requires --features tui)
     #[cfg(feature = "tui")]
     Tui {
@@ -65,6 +70,31 @@ enum Commands {
         #[arg(long)]
         no_git: bool,
     },
+}
+
+#[derive(clap::Subcommand)]
+enum ConfigAction {
+    /// Get a config value
+    Get {
+        /// Config key (e.g. defaults.github_org)
+        key: String,
+    },
+    /// Set a config value
+    Set {
+        /// Config key (e.g. defaults.github_org)
+        key: String,
+        /// Value to set
+        value: String,
+    },
+    /// Remove a config value
+    Unset {
+        /// Config key (e.g. defaults.github_org)
+        key: String,
+    },
+    /// Show all config values
+    List,
+    /// Show config file path
+    Path,
 }
 
 fn main() {
@@ -102,6 +132,9 @@ fn run() -> Result<()> {
         Commands::List => {
             list_templates()?;
         }
+        Commands::Config { action } => {
+            handle_config(action)?;
+        }
         Commands::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "fledge", &mut std::io::stdout());
         }
@@ -112,6 +145,91 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn handle_config(action: ConfigAction) -> Result<()> {
+    match action {
+        ConfigAction::Get { key } => {
+            let config = config::Config::load()?;
+            match config.get(&key) {
+                Some(value) => println!("{}", value),
+                None => {
+                    if matches!(
+                        key.as_str(),
+                        "defaults.author"
+                            | "defaults.github_org"
+                            | "defaults.license"
+                            | "github.token"
+                    ) {
+                        println!("{} {} is not set", style("*").cyan().bold(), key);
+                    } else {
+                        anyhow::bail!(
+                            "Unknown config key '{}'. Valid keys: defaults.author, defaults.github_org, defaults.license, github.token",
+                            key
+                        );
+                    }
+                }
+            }
+        }
+        ConfigAction::Set { key, value } => {
+            let mut config = config::Config::load()?;
+            config.set(&key, &value)?;
+            config.save()?;
+            println!(
+                "{} Set {} = {}",
+                style("✓").green().bold(),
+                style(&key).cyan(),
+                style(&value).green()
+            );
+        }
+        ConfigAction::Unset { key } => {
+            let mut config = config::Config::load()?;
+            config.unset(&key)?;
+            config.save()?;
+            println!("{} Unset {}", style("✓").green().bold(), style(&key).cyan());
+        }
+        ConfigAction::List => {
+            let config = config::Config::load()?;
+            let path = config::Config::config_path();
+            println!(
+                "{} Config: {}\n",
+                style("*").cyan().bold(),
+                style(path.display()).dim()
+            );
+            print_config_entry("defaults.author", &config.defaults.author);
+            print_config_entry("defaults.github_org", &config.defaults.github_org);
+            print_config_entry("defaults.license", &config.defaults.license);
+            print_config_entry(
+                "github.token",
+                &config.github.token.as_ref().map(|_| "***".to_string()),
+            );
+            if !config.templates.paths.is_empty() {
+                println!(
+                    "  {:<24} {}",
+                    style("templates.paths").cyan(),
+                    config.templates.paths.join(", ")
+                );
+            }
+            if !config.templates.repos.is_empty() {
+                println!(
+                    "  {:<24} {}",
+                    style("templates.repos").cyan(),
+                    config.templates.repos.join(", ")
+                );
+            }
+        }
+        ConfigAction::Path => {
+            println!("{}", config::Config::config_path().display());
+        }
+    }
+    Ok(())
+}
+
+fn print_config_entry(key: &str, value: &Option<impl std::fmt::Display>) {
+    match value {
+        Some(v) => println!("  {:<24} {}", style(key).cyan(), v),
+        None => println!("  {:<24} {}", style(key).cyan(), style("(not set)").dim()),
+    }
 }
 
 fn list_templates() -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds `fledge config` subcommand with `get`, `set`, `unset`, `list`, and `path` operations
- Users can now configure defaults (author, github_org, license, github token) via CLI instead of editing `~/.config/fledge/config.toml` by hand
- `fledge config list` shows all values with masked token; `fledge config path` prints the config file location

## Usage

```bash
fledge config set defaults.github_org CorvidLabs
fledge config set defaults.author "Leif"
fledge config set defaults.license MIT
fledge config list
fledge config get defaults.github_org
fledge config unset defaults.github_org
```

Closes #7

## Test plan

- [ ] `fledge config set defaults.github_org Foo` → creates/updates config file
- [ ] `fledge config get defaults.github_org` → prints `Foo`
- [ ] `fledge config list` → shows all keys with values
- [ ] `fledge config unset defaults.github_org` → removes the value
- [ ] `fledge config path` → prints config file path
- [ ] `fledge init` uses configured defaults (no prompt for set values)
- [ ] Invalid key returns helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)