### PR TITLE
feat: add `fledge create-template` command

### DIFF
--- a/.specsync/registry.toml
+++ b/.specsync/registry.toml
@@ -2,6 +2,7 @@
 name = "fledge"
 
 [specs]
+create_template = "specs/create_template/create_template.spec.md"
 config = "specs/config/config.spec.md"
 init = "specs/init/init.spec.md"
 prompts = "specs/prompts/prompts.spec.md"

--- a/specs/create_template/context.md
+++ b/specs/create_template/context.md
@@ -1,0 +1,29 @@
+---
+spec: create_template.spec.md
+---
+
+## Key Decisions
+
+- Interactive prompts with sensible defaults for all fields — no required answers
+- Generated `template.toml` uses TOML string formatting via `{:?}` for proper escaping
+- Hooks and custom prompts are opt-in to keep the default scaffold minimal
+- Includes both a `README.md` (author-facing docs) and `README.md.tera` (example rendered file)
+- The `src/` directory is created as a hint but left empty — authors fill it with their template files
+
+## Files to Read First
+
+- `src/create_template.rs` — all scaffolding logic
+- `src/main.rs` — `CreateTemplate` variant in `Commands` enum
+- `specs/create_template/create_template.spec.md` — formal API and invariants
+
+## Current Status
+
+- Full implementation with interactive prompts (name, description, render globs, hooks, prompts)
+- Generates valid `template.toml`, example `.tera` file, `.gitignore`, and author README
+- 5 unit tests covering scaffold output, manifest validity, and error cases
+- Spec at v1
+
+## Notes
+
+- The command is `fledge create-template <name>` (clap converts underscores to hyphens)
+- Uses `dialoguer` for interactive prompts, consistent with the rest of the CLI

--- a/specs/create_template/create_template.spec.md
+++ b/specs/create_template/create_template.spec.md
@@ -1,0 +1,111 @@
+---
+module: create_template
+version: 1
+status: active
+files:
+  - src/create_template.rs
+
+db_tables: []
+depends_on:
+  - templates
+---
+
+# Create Template
+
+## Purpose
+
+Scaffolds a new fledge template project with a valid `template.toml` manifest, example files, and author documentation. Makes it trivial for anyone to create and share templates.
+
+## Public API
+
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `CreateTemplateOptions` | Options struct for the create-template command (name, output directory) |
+| `run` | Entry point that checks for existing directory, gathers interactive answers, and scaffolds the template |
+
+### Structs & Enums
+
+| Type | Description |
+|------|-------------|
+| `CreateTemplateOptions` | Command options: template name and output parent directory |
+
+### Traits
+
+| Trait | Description |
+|-------|-------------|
+
+### Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `run` | `(CreateTemplateOptions) -> Result<()>` | Validate target doesn't exist, prompt user, scaffold template directory |
+
+## Invariants
+
+1. Fails immediately if target directory already exists
+2. Generated `template.toml` is always valid TOML parseable as `TemplateManifest`
+3. `template.toml` always includes `[template]` and `[files]` sections
+4. `template.toml` always ignores itself (`template.toml` in ignore list)
+5. Interactive prompts provide sensible defaults for all fields
+6. Hooks section is only included when user opts in
+7. Custom prompts section is only included when user opts in
+8. Scaffolded template includes example `.tera` file demonstrating variable substitution
+9. Scaffolded template includes author-facing README with testing instructions
+
+## Behavioral Examples
+
+### Scenario: Basic template creation
+
+- **Given** directory `my-template` does not exist in the output directory
+- **When** `run(CreateTemplateOptions { name: "my-template", output: "." })` is called and user accepts defaults
+- **Then** creates `my-template/` with `template.toml`, `README.md`, `README.md.tera`, `.gitignore`
+
+### Scenario: Target directory already exists
+
+- **Given** directory `my-template` already exists
+- **When** `run(CreateTemplateOptions { name: "my-template", output: "." })` is called
+- **Then** returns error "Directory 'my-template' already exists"
+
+### Scenario: User opts into hooks
+
+- **Given** user confirms "Include post-create hooks?"
+- **When** template is scaffolded
+- **Then** `template.toml` contains a `[hooks]` section with commented examples
+
+### Scenario: User opts out of custom prompts
+
+- **Given** user declines "Include custom prompts?"
+- **When** template is scaffolded
+- **Then** `template.toml` has no `[prompts]` section
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Target directory already exists | Returns error with directory path |
+| Cannot create target directory | Returns IO error with context |
+| Interactive prompt fails (e.g., non-TTY) | Returns dialoguer error |
+
+## Dependencies
+
+### Consumes
+
+| Crate/Module | What is used |
+|-------------|-------------|
+| `dialoguer` | `Input`, `Confirm` for interactive prompts |
+| `console` | `style` for colored output |
+| `anyhow` | Error handling |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `main` | `run()`, `CreateTemplateOptions` for the `create-template` subcommand |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-04-19 | CorvidAgent | Initial spec |

--- a/specs/create_template/requirements.md
+++ b/specs/create_template/requirements.md
@@ -1,0 +1,31 @@
+---
+spec: create_template.spec.md
+---
+
+## User Stories
+
+- As a template author, I want to scaffold a new template project so I don't have to manually create `template.toml` from scratch
+- As a template author, I want example files showing Tera variable usage so I can learn by example
+- As a template author, I want to choose which features (hooks, prompts) my template uses so the manifest stays clean
+
+## Acceptance Criteria
+
+- `fledge create-template my-template` creates a new directory with a valid template scaffold
+- Generated `template.toml` is valid TOML parseable as `TemplateManifest`
+- Interactive prompts ask for name, description, render globs, hooks, and custom prompts
+- All prompts have sensible defaults that can be accepted with Enter
+- Includes example `.tera` file demonstrating variable substitution
+- Includes author-facing README with instructions for testing locally
+- Fails with a clear error if the target directory already exists
+
+## Constraints
+
+- Must use `dialoguer` for prompts (consistent with rest of CLI)
+- Generated manifest must always pass `toml::from_str::<TemplateManifest>()`
+- `template.toml` must always include itself in the ignore list
+
+## Out of Scope
+
+- Template validation (`fledge validate`) — separate feature
+- Publishing templates to GitHub — tracked in issue #6
+- Git initialization of the template directory

--- a/specs/create_template/tasks.md
+++ b/specs/create_template/tasks.md
@@ -1,0 +1,18 @@
+---
+spec: create_template.spec.md
+---
+
+## Completed
+
+- [x] Implement `CreateTemplateOptions` struct and `run()` entry point
+- [x] Interactive prompts with defaults (name, description, render globs, hooks, prompts)
+- [x] Scaffold directory with `template.toml`, example files, README
+- [x] Generated `template.toml` validated as parseable `TemplateManifest`
+- [x] Wire into CLI as `fledge create-template <name> [-o <dir>]`
+- [x] Unit tests (5 tests covering scaffold output, manifest validity, error cases)
+- [x] Spec files (spec, context, requirements, tasks, testing)
+
+## Backlog
+
+- [ ] Add `--yes` flag to skip prompts and accept all defaults
+- [ ] Add `fledge validate` command for template validation (issue TBD)

--- a/specs/create_template/testing.md
+++ b/specs/create_template/testing.md
@@ -1,0 +1,27 @@
+---
+spec: create_template.spec.md
+---
+
+## Unit Tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `scaffold_creates_expected_files` | All expected files exist after scaffolding |
+| `scaffold_manifest_is_valid_toml` | Generated template.toml parses as TemplateManifest |
+| `scaffold_manifest_without_hooks_or_prompts` | Hooks/prompts sections excluded when not requested |
+| `scaffold_fails_if_target_exists` | Error when target directory already exists |
+| `manifest_render_globs_are_correct` | Render globs in manifest match user input |
+
+## Integration Test Ideas
+
+- Run `fledge create-template test-tpl` then `fledge init my-project -t ./test-tpl` to verify round-trip
+- Verify `fledge list` discovers a scaffolded template from an extra path
+
+## Manual Testing
+
+```bash
+cargo run -- create-template my-test-template
+ls -la my-test-template/
+cat my-test-template/template.toml
+cargo run -- init test-project -t ./my-test-template
+```

--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -1,0 +1,351 @@
+use anyhow::{Context, Result};
+use console::style;
+use dialoguer::{Confirm, Input, theme::ColorfulTheme};
+use std::path::{Path, PathBuf};
+
+pub struct CreateTemplateOptions {
+    pub name: String,
+    pub output: PathBuf,
+}
+
+struct TemplateAnswers {
+    name: String,
+    description: String,
+    render_globs: Vec<String>,
+    include_hooks: bool,
+    include_prompts: bool,
+}
+
+pub fn run(options: CreateTemplateOptions) -> Result<()> {
+    let target = options.output.join(&options.name);
+
+    if target.exists() {
+        anyhow::bail!("Directory '{}' already exists", target.display());
+    }
+
+    let answers = gather_answers(&options.name)?;
+    scaffold(&target, &answers)?;
+
+    println!(
+        "\n{} Created template at {}",
+        style("✓").green().bold(),
+        style(target.display()).cyan()
+    );
+    println!(
+        "\n  {} Edit files in {}/",
+        style("1.").dim(),
+        style(&answers.name).green()
+    );
+    println!(
+        "  {} Add .tera extension to files that need variable substitution",
+        style("2.").dim()
+    );
+    println!(
+        "  {} Test locally with: {}",
+        style("3.").dim(),
+        style(format!("fledge init my-project -t ./{}", answers.name)).cyan()
+    );
+
+    Ok(())
+}
+
+fn gather_answers(default_name: &str) -> Result<TemplateAnswers> {
+    let theme = ColorfulTheme::default();
+
+    let name: String = Input::with_theme(&theme)
+        .with_prompt("Template name")
+        .default(default_name.to_string())
+        .interact_text()?;
+
+    let description: String = Input::with_theme(&theme)
+        .with_prompt("Description")
+        .default(format!("A {} project template", name))
+        .interact_text()?;
+
+    let render_input: String = Input::with_theme(&theme)
+        .with_prompt("File patterns to render through Tera (comma-separated)")
+        .default("**/*.md, **/*.toml, **/*.json, **/*.yml".to_string())
+        .interact_text()?;
+
+    let render_globs: Vec<String> = render_input
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let include_hooks = Confirm::with_theme(&theme)
+        .with_prompt("Include post-create hooks?")
+        .default(false)
+        .interact()?;
+
+    let include_prompts = Confirm::with_theme(&theme)
+        .with_prompt("Include custom prompts?")
+        .default(true)
+        .interact()?;
+
+    Ok(TemplateAnswers {
+        name,
+        description,
+        render_globs,
+        include_hooks,
+        include_prompts,
+    })
+}
+
+fn scaffold(target: &Path, answers: &TemplateAnswers) -> Result<()> {
+    std::fs::create_dir_all(target).with_context(|| format!("creating {}", target.display()))?;
+
+    write_manifest(target, answers)?;
+    write_example_files(target)?;
+    write_readme(target, &answers.name)?;
+
+    Ok(())
+}
+
+fn write_manifest(target: &Path, answers: &TemplateAnswers) -> Result<()> {
+    let mut manifest = String::new();
+
+    manifest.push_str("[template]\n");
+    manifest.push_str(&format!("name = {:?}\n", answers.name));
+    manifest.push_str(&format!("description = {:?}\n", answers.description));
+    manifest.push_str("# min_fledge_version = \"0.2.0\"\n");
+
+    if answers.include_prompts {
+        manifest.push_str("\n[prompts.description]\n");
+        manifest.push_str("message = \"Project description\"\n");
+        manifest.push_str(&format!("default = \"A new {} project\"\n", answers.name));
+        manifest.push_str("\n# Add more prompts:\n");
+        manifest.push_str("# [prompts.database]\n");
+        manifest.push_str("# message = \"Database engine\"\n");
+        manifest.push_str("# default = \"sqlite\"\n");
+    }
+
+    manifest.push_str("\n[files]\n");
+
+    let render_arr: Vec<String> = answers
+        .render_globs
+        .iter()
+        .map(|g| format!("{:?}", g))
+        .collect();
+    manifest.push_str(&format!("render = [{}]\n", render_arr.join(", ")));
+    manifest.push_str("copy = [\"**/*.png\", \"**/*.ico\", \"**/*.woff2\"]\n");
+    manifest.push_str("ignore = [\"template.toml\"]\n");
+
+    if answers.include_hooks {
+        manifest.push_str("\n[hooks]\n");
+        manifest.push_str("post_create = [\n");
+        manifest.push_str("    # \"npm install\",\n");
+        manifest.push_str("    # \"git init\",\n");
+        manifest.push_str("]\n");
+    }
+
+    std::fs::write(target.join("template.toml"), manifest).context("writing template.toml")?;
+
+    Ok(())
+}
+
+fn write_example_files(target: &Path) -> Result<()> {
+    std::fs::create_dir_all(target.join("src"))?;
+
+    std::fs::write(
+        target.join("README.md.tera"),
+        r#"# {{ project_name }}
+
+{{ description }}
+
+## Getting Started
+
+TODO: Add setup instructions here.
+
+## License
+
+{{ license }}
+"#,
+    )?;
+
+    std::fs::write(
+        target.join(".gitignore"),
+        r#"# Build artifacts
+/target/
+/dist/
+/build/
+node_modules/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+"#,
+    )?;
+
+    Ok(())
+}
+
+fn write_readme(target: &Path, name: &str) -> Result<()> {
+    std::fs::write(
+        target.join("README.md"),
+        format!(
+            r#"# {name} — fledge template
+
+A project template for [fledge](https://github.com/CorvidLabs/fledge).
+
+## Usage
+
+Test this template locally:
+
+```bash
+fledge init my-project -t ./{name}
+```
+
+## Template structure
+
+- `template.toml` — Template manifest (name, prompts, file rules, hooks)
+- Files with `.tera` extension are rendered through Tera and the extension is stripped
+- Files matching `render` globs in template.toml are also rendered through Tera
+- Files matching `ignore` globs are not included in generated projects
+
+## Template variables
+
+These variables are available in all rendered files:
+
+| Variable | Description |
+|----------|-------------|
+| `{{{{ project_name }}}}` | Project name as provided by the user |
+| `{{{{ project_name_snake }}}}` | Snake_case version |
+| `{{{{ project_name_pascal }}}}` | PascalCase version |
+| `{{{{ author }}}}` | Author name |
+| `{{{{ github_org }}}}` | GitHub organization |
+| `{{{{ license }}}}` | License identifier |
+| `{{{{ year }}}}` | Current year |
+| `{{{{ date }}}}` | Current date (YYYY-MM-DD) |
+| `{{{{ description }}}}` | Project description (if prompt defined) |
+
+Custom prompts defined in `template.toml` also become available as variables.
+"#,
+        ),
+    )
+    .context("writing README.md")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn scaffold_creates_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("my-template");
+
+        let answers = TemplateAnswers {
+            name: "my-template".to_string(),
+            description: "A test template".to_string(),
+            render_globs: vec!["**/*.md".to_string(), "**/*.toml".to_string()],
+            include_hooks: false,
+            include_prompts: true,
+        };
+
+        scaffold(&target, &answers).unwrap();
+
+        assert!(target.join("template.toml").exists());
+        assert!(target.join("README.md").exists());
+        assert!(target.join("README.md.tera").exists());
+        assert!(target.join(".gitignore").exists());
+    }
+
+    #[test]
+    fn scaffold_manifest_is_valid_toml() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("test-tpl");
+
+        let answers = TemplateAnswers {
+            name: "test-tpl".to_string(),
+            description: "Test".to_string(),
+            render_globs: vec!["**/*.rs".to_string()],
+            include_hooks: true,
+            include_prompts: true,
+        };
+
+        scaffold(&target, &answers).unwrap();
+
+        let content = std::fs::read_to_string(target.join("template.toml")).unwrap();
+        let manifest: Result<crate::templates::TemplateManifest, _> = toml::from_str(&content);
+        assert!(
+            manifest.is_ok(),
+            "Generated template.toml should be valid: {:?}",
+            manifest.err()
+        );
+    }
+
+    #[test]
+    fn scaffold_manifest_without_hooks_or_prompts() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("bare-tpl");
+
+        let answers = TemplateAnswers {
+            name: "bare-tpl".to_string(),
+            description: "Bare template".to_string(),
+            render_globs: vec!["**/*.txt".to_string()],
+            include_hooks: false,
+            include_prompts: false,
+        };
+
+        scaffold(&target, &answers).unwrap();
+
+        let content = std::fs::read_to_string(target.join("template.toml")).unwrap();
+        assert!(!content.contains("[hooks]"));
+        assert!(!content.contains("[prompts"));
+
+        let manifest: Result<crate::templates::TemplateManifest, _> = toml::from_str(&content);
+        assert!(manifest.is_ok());
+    }
+
+    #[test]
+    fn scaffold_fails_if_target_exists() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("existing");
+        std::fs::create_dir(&target).unwrap();
+
+        let options = CreateTemplateOptions {
+            name: "existing".to_string(),
+            output: tmp.path().to_path_buf(),
+        };
+
+        let result = run(options);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn manifest_render_globs_are_correct() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("glob-tpl");
+
+        let answers = TemplateAnswers {
+            name: "glob-tpl".to_string(),
+            description: "Test".to_string(),
+            render_globs: vec![
+                "**/*.rs".to_string(),
+                "**/*.toml".to_string(),
+                "**/*.md".to_string(),
+            ],
+            include_hooks: false,
+            include_prompts: false,
+        };
+
+        scaffold(&target, &answers).unwrap();
+
+        let content = std::fs::read_to_string(target.join("template.toml")).unwrap();
+        let manifest: crate::templates::TemplateManifest = toml::from_str(&content).unwrap();
+        assert_eq!(
+            manifest.files.render,
+            vec!["**/*.rs", "**/*.toml", "**/*.md"]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use console::style;
 use std::path::PathBuf;
 
 mod config;
+mod create_template;
 mod init;
 mod prompts;
 mod remote;
@@ -59,6 +60,14 @@ enum Commands {
     Config {
         #[command(subcommand)]
         action: ConfigAction,
+    },
+    /// Scaffold a new fledge template
+    CreateTemplate {
+        /// Template name
+        name: String,
+        /// Parent directory for the template
+        #[arg(short, long, default_value = ".")]
+        output: PathBuf,
     },
     /// Interactive TUI for browsing and scaffolding templates (requires --features tui)
     #[cfg(feature = "tui")]
@@ -148,6 +157,9 @@ fn run() -> Result<()> {
         }
         Commands::Config { action } => {
             handle_config(action)?;
+        }
+        Commands::CreateTemplate { name, output } => {
+            create_template::run(create_template::CreateTemplateOptions { name, output })?;
         }
         Commands::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "fledge", &mut std::io::stdout());


### PR DESCRIPTION
## Summary

- Adds `fledge create-template <name>` command that scaffolds a new template project with interactive prompts
- Generates valid `template.toml` manifest, example `.tera` file, `.gitignore`, and author-facing README with testing instructions
- Prompts for name, description, render globs, hooks (opt-in), and custom prompts (opt-in) — all with sensible defaults

Closes #5

## Test plan

- [x] 111 unit tests pass (5 new for create-template)
- [x] 10 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual test: `cargo run -- create-template my-test` then `cargo run -- init test-project -t ./my-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)