### PR TITLE
Release v0.3.0 — Template Ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 Fledge is evolving from a project scaffolding tool into a full dev-lifecycle CLI — scaffold, spec, build, ship, monitor — all from one opinionated Rust binary.
 
-## Current State (v0.2.1)
+## Current State (v0.3.0)
 
-Shipped: `init`, `list`, `config`, `create-template`, `search`, `completions`, TUI (feature-gated). 5 built-in templates, hook security, dry-run support.
+Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `completions`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax.
 
 ---
 
@@ -12,10 +12,10 @@ Shipped: `init`, `list`, `config`, `create-template`, `search`, `completions`, T
 
 Complete the template story: discovery, publishing, versioning, and more built-in templates.
 
-- [ ] `fledge search` improvements (#4) — already functional, polish UX
-- [ ] `fledge publish` — publish templates to GitHub with `fledge-template` topic (#6)
-- [ ] Template versioning and compatibility checks (#13)
-- [ ] Additional built-in templates: Python, Go, monorepo (#9)
+- [x] `fledge search` improvements (#4) — GitHub template discovery with topic-based search
+- [x] `fledge publish` — publish templates to GitHub with `fledge-template` topic (#6)
+- [x] Template versioning and compatibility checks (#13)
+- [x] Additional built-in templates: Python, Go, monorepo (#9)
 - [ ] CorvidLabs template collection and org defaults (#8)
 - [ ] Publish to crates.io (#2)
 


### PR DESCRIPTION
## Summary

- Bumps version from 0.2.1 → 0.3.0
- Updates ROADMAP.md to reflect completed 0.3 milestone items

### What's in 0.3.0

- **`fledge search`** — GitHub template discovery with topic-based search (#31)
- **`fledge publish`** — Publish templates to GitHub with `fledge-template` topic (#37)
- **Template versioning** — `min_fledge_version` checks + `@ref` version pinning (#38)
- **3 new built-in templates** — Python CLI, Go CLI, monorepo (#39)

### Remaining 0.3 items (deferred)

- CorvidLabs template collection and org defaults (#8) — organizational/external
- Publish to crates.io (#2) — done at release time

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 10 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)