### PR TITLE
chore: bump version to 0.4.0 and update roadmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 Fledge is evolving from a project scaffolding tool into a full dev-lifecycle CLI — scaffold, spec, build, ship, monitor — all from one opinionated Rust binary.
 
-## Current State (v0.3.0)
+## Current State (v0.4.0)
 
-Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `completions`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax.
+Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands.
 
 ---
 
@@ -23,10 +23,10 @@ Complete the template story: discovery, publishing, versioning, and more built-i
 
 Move beyond scaffolding. Fledge stays with you after `init`.
 
-- [ ] `fledge update` — re-apply template to existing projects (#11)
-- [ ] `fledge spec` — integrate spec-sync (`check`, `sync`, `init`)
-- [ ] `fledge work start` — begin a feature branch with conventions
-- [ ] `fledge work pr` — create PR from current branch
+- [x] `fledge update` — re-apply template to existing projects (#11)
+- [x] `fledge spec` — integrate spec-sync (`check`, `init`, `new`) (#32)
+- [x] `fledge work start` — begin a feature branch with conventions (#33)
+- [x] `fledge work pr` — create PR from current branch (#33)
 
 ## 0.5 — GitHub & AI Integration
 


### PR DESCRIPTION
## Summary

- Bumps version from 0.3.0 to 0.4.0
- Updates roadmap to mark all 0.4 Project Lifecycle features as complete

Should be merged after PRs #41, #42, and #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)