### PR TITLE
feat: Distribution & Polish (v0.6.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,20 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          for dir in */; do
+            for file in "$dir"*; do
+              filename=$(basename "$file")
+              sha256sum "$file" | sed "s|.*/||" > "${filename}.sha256"
+              mv "$file" .
+            done
+          done
+          rm -rf */
+          cat *.sha256
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: artifacts/**/*
+          files: artifacts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-19
+
+### Added
+
+- Install script (`curl -fsSL .../install.sh | sh`) — detects OS/arch, downloads the right binary
+- Homebrew formula (`brew install CorvidLabs/tap/fledge`)
+- Nix flake (`nix run github:CorvidLabs/fledge`)
+- `fledge completions --install` — auto-installs shell completions for bash, zsh, or fish
+- SHA256 checksums in GitHub releases
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."

--- a/Formula/fledge.rb
+++ b/Formula/fledge.rb
@@ -1,0 +1,50 @@
+class Fledge < Formula
+  desc "Corvid-themed project scaffolding CLI — get your projects ready to fly"
+  homepage "https://github.com/CorvidLabs/fledge"
+  license "MIT"
+  version "0.6.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-aarch64"
+      sha256 "PLACEHOLDER"
+
+      def install
+        bin.install "fledge-macos-aarch64" => "fledge"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-x86_64"
+      sha256 "PLACEHOLDER"
+
+      def install
+        bin.install "fledge-macos-x86_64" => "fledge"
+      end
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-linux-x86_64"
+      sha256 "PLACEHOLDER"
+
+      def install
+        bin.install "fledge-linux-x86_64" => "fledge"
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To generate shell completions:
+        fledge completions bash > $(brew --prefix)/etc/bash_completion.d/fledge
+        fledge completions zsh > $(brew --prefix)/share/zsh/site-functions/_fledge
+        fledge completions fish > $(brew --prefix)/share/fish/vendor_completions.d/fledge.fish
+    EOS
+  end
+
+  test do
+    assert_match "fledge", shell_output("#{bin}/fledge --version")
+  end
+end

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 Fledge is evolving from a project scaffolding tool into a full dev-lifecycle CLI — scaffold, spec, build, ship, monitor — all from one opinionated Rust binary.
 
-## Current State (v0.5.0)
+## Current State (v0.6.0)
 
-Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A.
+Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A. Distribution via Homebrew, install script, Nix flake, and shell completions auto-install.
 
 ---
 
@@ -40,10 +40,10 @@ Bring GitHub ops and AI assistance into the CLI.
 
 Make fledge easy to install everywhere.
 
-- [ ] Homebrew formula (#12)
-- [ ] Install script (`curl | sh`)
-- [ ] Nix package (#12)
-- [ ] Shell completions auto-install
+- [x] Homebrew formula (#12)
+- [x] Install script (`curl | sh`)
+- [x] Nix package (#12)
+- [x] Shell completions auto-install (`fledge completions --install`)
 
 ## 1.0 — Lanes & Plugins
 

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Fledge installer — downloads the latest release binary for your platform.
+# Usage: curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/dist/install.sh | sh
+
+set -eu
+
+REPO="CorvidLabs/fledge"
+INSTALL_DIR="${FLEDGE_INSTALL_DIR:-/usr/local/bin}"
+
+main() {
+    need_cmd curl
+    need_cmd uname
+    need_cmd chmod
+    need_cmd mkdir
+
+    local os arch artifact version
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    artifact="$(artifact_name "$os" "$arch")"
+    version="$(latest_version)"
+
+    if [ -z "$version" ]; then
+        err "could not determine latest version"
+    fi
+
+    say "Installing fledge $version ($os/$arch)..."
+
+    local url="https://github.com/$REPO/releases/download/$version/$artifact"
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    local tmpfile="$tmpdir/fledge"
+
+    say "Downloading $url"
+    curl -fsSL "$url" -o "$tmpfile" || err "download failed — check that $version has a binary for $os/$arch"
+
+    chmod +x "$tmpfile"
+
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$tmpfile" "$INSTALL_DIR/fledge"
+    else
+        say "Installing to $INSTALL_DIR (requires sudo)"
+        sudo mv "$tmpfile" "$INSTALL_DIR/fledge"
+    fi
+
+    rm -rf "$tmpdir"
+
+    say "Installed fledge $version to $INSTALL_DIR/fledge"
+    say ""
+    say "Run 'fledge --help' to get started."
+}
+
+detect_os() {
+    local uname_s
+    uname_s="$(uname -s)"
+    case "$uname_s" in
+        Linux*)  echo "linux" ;;
+        Darwin*) echo "macos" ;;
+        MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+        *) err "unsupported OS: $uname_s" ;;
+    esac
+}
+
+detect_arch() {
+    local uname_m
+    uname_m="$(uname -m)"
+    case "$uname_m" in
+        x86_64|amd64)  echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        *) err "unsupported architecture: $uname_m" ;;
+    esac
+}
+
+artifact_name() {
+    local os="$1" arch="$2"
+    case "$os" in
+        linux)   echo "fledge-linux-x86_64" ;;
+        macos)   echo "fledge-macos-$arch" ;;
+        windows) echo "fledge-windows-x86_64.exe" ;;
+    esac
+}
+
+latest_version() {
+    curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
+        | grep '"tag_name"' \
+        | head -1 \
+        | sed 's/.*"tag_name": *"//;s/".*//'
+}
+
+say() {
+    printf "  %s\n" "$@"
+}
+
+err() {
+    say "Error: $1" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        err "need '$1' (not found)"
+    fi
+}
+
+main

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Fledge — corvid-themed project scaffolding CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "fledge";
+          version = "0.6.0";
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.Security
+            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
+
+          postInstall = ''
+            installShellCompletion --cmd fledge \
+              --bash <($out/bin/fledge completions bash) \
+              --zsh <($out/bin/fledge completions zsh) \
+              --fish <($out/bin/fledge completions fish)
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Corvid-themed project scaffolding CLI";
+            homepage = "https://github.com/CorvidLabs/fledge";
+            license = licenses.mit;
+            mainProgram = "fledge";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            clippy
+            rustfmt
+          ];
+        };
+      });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,12 @@ enum Commands {
     List,
     /// Generate shell completions
     Completions {
-        /// Shell to generate completions for
+        /// Shell to generate completions for (auto-detects if omitted with --install)
         #[arg(value_enum)]
-        shell: Shell,
+        shell: Option<Shell>,
+        /// Install completions to the standard location for your shell
+        #[arg(long)]
+        install: bool,
     },
     /// Manage global configuration
     Config {
@@ -425,8 +428,22 @@ fn run() -> Result<()> {
                 question: question.join(" "),
             })?;
         }
-        Commands::Completions { shell } => {
-            clap_complete::generate(shell, &mut Cli::command(), "fledge", &mut std::io::stdout());
+        Commands::Completions { shell, install } => {
+            if install {
+                install_completions(shell)?;
+            } else {
+                let shell = shell.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Shell argument is required when not using --install. Usage: fledge completions <bash|zsh|fish>"
+                    )
+                })?;
+                clap_complete::generate(
+                    shell,
+                    &mut Cli::command(),
+                    "fledge",
+                    &mut std::io::stdout(),
+                );
+            }
         }
         #[cfg(feature = "tui")]
         Commands::Tui { output, no_git } => {
@@ -558,6 +575,66 @@ fn print_config_entry(key: &str, value: &Option<impl std::fmt::Display>) {
         Some(v) => println!("  {:<24} {}", style(key).cyan(), v),
         None => println!("  {:<24} {}", style(key).cyan(), style("(not set)").dim()),
     }
+}
+
+fn install_completions(shell: Option<Shell>) -> Result<()> {
+    let shell = shell.unwrap_or_else(|| {
+        let shell_env = std::env::var("SHELL").unwrap_or_default();
+        if shell_env.ends_with("zsh") {
+            Shell::Zsh
+        } else if shell_env.ends_with("fish") {
+            Shell::Fish
+        } else {
+            Shell::Bash
+        }
+    });
+
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+
+    let dest = match shell {
+        Shell::Bash => {
+            let dir = home.join(".local/share/bash-completion/completions");
+            std::fs::create_dir_all(&dir)?;
+            dir.join("fledge")
+        }
+        Shell::Zsh => {
+            let dir = home.join(".zfunc");
+            std::fs::create_dir_all(&dir)?;
+            dir.join("_fledge")
+        }
+        Shell::Fish => {
+            let dir = home.join(".config/fish/completions");
+            std::fs::create_dir_all(&dir)?;
+            dir.join("fledge.fish")
+        }
+        _ => anyhow::bail!(
+            "auto-install not supported for {:?} — use `fledge completions <shell>` to generate manually",
+            shell
+        ),
+    };
+
+    let mut buf = Vec::new();
+    clap_complete::generate(shell, &mut Cli::command(), "fledge", &mut buf);
+    std::fs::write(&dest, buf)?;
+
+    println!(
+        "{} Installed {} completions to {}",
+        style("✓").green().bold(),
+        style(format!("{shell:?}")).cyan(),
+        style(dest.display()).dim()
+    );
+
+    if matches!(shell, Shell::Zsh) {
+        println!(
+            "\n  {}",
+            style("Add to your .zshrc if not already present:").dim()
+        );
+        println!("    fpath=(~/.zfunc $fpath)");
+        println!("    autoload -Uz compinit && compinit");
+    }
+
+    Ok(())
 }
 
 fn list_templates() -> Result<()> {


### PR DESCRIPTION
## Summary
- **Install script** (`curl -fsSL .../install.sh | sh`) — detects OS/arch, downloads the correct release binary
- **Homebrew formula** (`brew install CorvidLabs/tap/fledge`) — ready to drop into a homebrew-tap repo
- **Nix flake** (`nix run github:CorvidLabs/fledge`) — builds from source with auto completions
- **Shell completions auto-install** (`fledge completions --install`) — detects your shell and installs to the right location
- **SHA256 checksums** added to release workflow
- Version bumped to 0.6.0

## Notes
- The Homebrew formula has `PLACEHOLDER` SHA256 hashes — these get filled in after a release is cut (or we set up a homebrew-tap repo with CI to auto-update)
- The install script uses the GitHub releases API to find the latest version
- `fledge completions` now takes an optional shell arg (still required without `--install`)

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] `cargo test` — 218 tests pass (208 unit + 10 integration)
- [x] `fledge completions --install` — installs zsh completions to `~/.zfunc/_fledge`
- [x] `fledge completions bash` — still works as before
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)