### PR TITLE
fix: patch v0.6.1 — missing version field in TemplateInfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -340,6 +340,7 @@ fn clone_template_for_fields(tpl: &Template) -> Template {
                 name: tpl.manifest.template.name.clone(),
                 description: tpl.manifest.template.description.clone(),
                 min_fledge_version: tpl.manifest.template.min_fledge_version.clone(),
+                version: tpl.manifest.template.version.clone(),
             },
             prompts,
             files: FileRules {


### PR DESCRIPTION
## Summary

- Adds missing `version` field to `TemplateInfo` constructor in `tui.rs` — fixes compile error
- Bumps version to 0.6.1 for crates.io republish (v0.6.0 was published before this fix landed)

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — 10/10 pass
- [x] `cargo clippy` — no warnings
- [ ] Merge, then `cargo publish` to push v0.6.1 to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)