### PR TITLE
fix: remove invalid --prompt flag from claude CLI calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -20,9 +20,7 @@ pub fn run(options: AskOptions) -> Result<()> {
         options.question
     );
 
-    let status = Command::new("claude")
-        .args(["--print", "--prompt", &prompt])
-        .status()?;
+    let status = Command::new("claude").args(["--print", &prompt]).status()?;
 
     if !status.success() {
         bail!("claude CLI exited with an error.");

--- a/src/review.rs
+++ b/src/review.rs
@@ -49,9 +49,7 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         diff
     );
 
-    let status = Command::new("claude")
-        .args(["--print", "--prompt", &prompt])
-        .status()?;
+    let status = Command::new("claude").args(["--print", &prompt]).status()?;
 
     if !status.success() {
         bail!("claude CLI exited with an error.");

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -340,6 +340,7 @@ fn clone_template_for_fields(tpl: &Template) -> Template {
                 name: tpl.manifest.template.name.clone(),
                 description: tpl.manifest.template.description.clone(),
                 min_fledge_version: tpl.manifest.template.min_fledge_version.clone(),
+                version: tpl.manifest.template.version.clone(),
             },
             prompts,
             files: FileRules {


### PR DESCRIPTION
## Summary
- Fixes `fledge ask` and `fledge review` commands that were broken due to passing `--prompt` to the `claude` CLI, which doesn't support that flag
- The prompt is passed as a positional argument instead

## Test plan
- [ ] `fledge ask "what does this project do"` — should invoke claude successfully
- [ ] `fledge review` — should invoke claude with the review prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)