### PR TITLE
docs: comprehensive documentation update for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-19
+
+### Added
+
+- `fledge run` — task runner with `fledge.toml` support, `--init` scaffolding, language-aware defaults (Rust, Node, Go, Python, Ruby, Java/Gradle/Maven)
+- `fledge checks` — view CI/CD check status for any branch with `--json` output
+- `fledge changelog` — generate changelogs from git tags and conventional commits with `--limit`, `--tag`, `--unreleased`, `--json` flags
+
+### Fixed
+
+- Made fledge fully language-agnostic — `.gitignore` template covers all ecosystems, upgrade message links to install docs instead of assuming `cargo install`
+- Split Java detection into Gradle/Maven, reinstated `/target/` in `.gitignore`
+- Removed invalid `--prompt` flag from Claude CLI calls in `fledge ask`/`fledge review`
+
 ## [0.6.0] - 2026-04-19
 
 ### Added
@@ -15,11 +29,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fledge completions --install` — auto-installs shell completions for bash, zsh, or fish
 - SHA256 checksums in GitHub releases
 
-## [Unreleased]
+## [0.5.0] - 2026-04-19
 
 ### Added
 
-- `fledge config` subcommand — set/get/list/wizard for global configuration
+- `fledge issues` — list and view GitHub issues with `--state`, `--label`, `--json` filters
+- `fledge prs` — list and view GitHub pull requests with `--state`, `--json` filters
+- `fledge review` — AI-powered code review of current changes via Claude CLI
+- `fledge ask` — ask questions about your codebase via Claude CLI
+
+## [0.4.0] - 2026-04-19
+
+### Added
+
+- `fledge update` — re-apply source template to existing projects with `--dry-run` and `--refresh`
+- `fledge spec check` — validate spec-sync specifications against source code
+- `fledge spec init` — initialize spec-sync configuration
+- `fledge spec new` — scaffold a new spec module
+- `fledge work start` — begin a feature branch with naming conventions
+- `fledge work pr` — create a PR from the current branch
+- `fledge work status` — show current branch and PR status
+
+## [0.3.0] - 2026-04-19
+
+### Added
+
+- `fledge search` — template discovery via GitHub topics
+- `fledge publish` — publish templates to GitHub with `fledge-template` topic
+- `fledge create-template` — scaffold a new fledge template
+- Template versioning and compatibility checks (`min_fledge_version`)
+- Version pinning for remote templates with `@ref` syntax
+- Additional built-in templates: `python-cli`, `go-cli`, `node-cli`, `node-lib`, `monorepo`, `static-site`
+
+### Changed
+
+- `fledge config` — full subcommand interface (get/set/unset/add/remove/list/path)
 - mdBook documentation site on GitHub Pages
 
 ## [0.1.0] - 2026-04-18
@@ -27,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Core scaffolding engine with Tera template rendering
-- 5 built-in templates: `rust-cli`, `rust-lib`, `python-cli`, `node-ts`, `static-site`
+- 5 built-in templates: `rust-cli`, `rust-lib`, `swift-pkg`, `ts-bun`, `angular-app`
 - Remote template support via `owner/repo` GitHub syntax
 - Interactive prompts with dialoguer for project configuration
 - Hook system with `pre_create` and `post_create` lifecycle hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,25 @@ cargo fmt --check
 - `src/templates.rs` — Template loading and Tera rendering
 - `src/config.rs` — Global config (~/.config/fledge/config.toml)
 - `src/prompts.rs` — Interactive prompts (dialoguer)
+- `src/run.rs` — Task runner (fledge.toml, language detection)
+- `src/changelog.rs` — Changelog generation from git tags
+- `src/checks.rs` — CI/CD status viewer
+- `src/spec.rs` — Spec-sync management
+- `src/work.rs` — Feature branch and PR workflow
+- `src/issues.rs` — GitHub issues
+- `src/prs.rs` — GitHub pull requests
+- `src/review.rs` — AI-powered code review
+- `src/ask.rs` — AI-powered codebase Q&A
+- `src/search.rs` — Template discovery via GitHub
+- `src/publish.rs` — Template publishing to GitHub
+- `src/update.rs` — Template re-application
+- `src/create_template.rs` — Template scaffolding
+- `src/versioning.rs` — Version management
+- `src/github.rs` — Shared GitHub API helpers
+- `src/remote.rs` — Remote template fetching and caching
 - `specs/` — spec-sync specifications (source of truth)
 - `templates/` — Built-in project templates
+- `docs/` — mdBook documentation site
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 Get your projects ready to fly.
 
-A fast, opinionated project scaffolding CLI built in Rust. Create new projects from templates — local or remote — with smart defaults, Tera-powered rendering, and zero boilerplate.
+A fast, opinionated dev-lifecycle CLI built in Rust. Scaffold projects from templates, manage specs, run tasks, check CI, review code, and ship — all from one binary.
 
 ## Why fledge?
 
 - **Fast** — native Rust binary, no runtime dependencies
 - **Smart defaults** — pulls author/org from git config, renders dates, computes name variants automatically
 - **Remote templates** — use any GitHub repo as a template source with `owner/repo` syntax
+- **Full lifecycle** — scaffolding, specs, tasks, CI checks, changelogs, GitHub ops, AI review
+- **Language-agnostic** — auto-detects Rust, Node, Go, Python, Ruby, Java and adapts defaults
 - **Extensible** — create your own templates with a simple `template.toml` manifest
 - **Safe** — remote template hooks require explicit confirmation before running
 - **Optional TUI** — interactive template browser with `--features tui`
@@ -21,6 +23,15 @@ cargo install fledge
 
 # With TUI support
 cargo install fledge --features tui
+
+# Homebrew
+brew install CorvidLabs/tap/fledge
+
+# Install script
+curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/install.sh | sh
+
+# Nix
+nix run github:CorvidLabs/fledge
 
 # From source
 git clone https://github.com/CorvidLabs/fledge.git
@@ -42,11 +53,15 @@ fledge init my-app --template CorvidLabs/fledge-templates/react-app
 # Preview what would be created
 fledge init my-tool --template rust-cli --dry-run
 
-# Skip all prompts with defaults
-fledge init my-tool --template rust-cli --yes
+# Run project tasks
+fledge run build
+fledge run test
 
-# List available templates
-fledge list
+# Check CI status
+fledge checks
+
+# Generate a changelog
+fledge changelog
 ```
 
 ## Built-in Templates
@@ -58,19 +73,22 @@ fledge list
 | `swift-pkg` | Swift package with Package.swift, CI, and coding conventions |
 | `ts-bun` | TypeScript project with Bun runtime |
 | `angular-app` | Angular application with mobile-first setup |
+| `python-cli` | Python CLI with Click, tests, and packaging |
+| `go-cli` | Go CLI with Cobra, Makefile, and CI |
+| `node-cli` | Node.js CLI with TypeScript |
+| `node-lib` | Node.js library with TypeScript and npm publishing |
+| `monorepo` | Monorepo with workspace tooling |
+| `static-site` | Static site with build pipeline |
 
 ## CLI Reference
 
-### `fledge init <name>`
+### Scaffolding
+
+#### `fledge init <name>`
 
 Create a new project from a template.
 
 ```
-fledge init <name> [OPTIONS]
-
-Arguments:
-  <name>              Project name
-
 Options:
   -t, --template      Template to use (skip interactive selection)
   -o, --output        Parent directory for the project [default: .]
@@ -81,36 +99,177 @@ Options:
   -y, --yes           Skip all confirmation prompts (accept defaults)
 ```
 
-### `fledge list`
+#### `fledge list`
 
 List all available templates (built-in + configured).
 
-### `fledge tui` *(requires `--features tui`)*
+#### `fledge create-template <name>`
 
-Interactive terminal UI for browsing templates and scaffolding projects. Navigate with arrow keys, fill in variables with Tab, confirm with Enter.
+Scaffold a new fledge template with `template.toml` manifest.
 
 ```
-fledge tui [OPTIONS]
-
 Options:
-  -o, --output        Parent directory for the project [default: .]
-      --no-git        Skip git init and initial commit
+  -o, --output        Parent directory for the template [default: .]
 ```
 
-### `fledge completions <shell>`
+#### `fledge search [query]`
 
-Generate shell completions for your shell. Supported: `bash`, `zsh`, `fish`, `powershell`.
+Search for templates on GitHub by keyword.
 
-```bash
-# Bash
-fledge completions bash >> ~/.bashrc
-
-# Zsh
-fledge completions zsh > ~/.zfunc/_fledge
-
-# Fish
-fledge completions fish > ~/.config/fish/completions/fledge.fish
 ```
+Options:
+  -l, --limit         Maximum number of results [default: 20]
+      --json          Output results as JSON
+```
+
+#### `fledge publish [path]`
+
+Publish a template to GitHub as a repository with `fledge-template` topic.
+
+```
+Options:
+      --org           Publish under a GitHub organization
+      --private       Create as a private repository
+      --description   Override the repository description
+```
+
+#### `fledge update`
+
+Re-apply the source template to an existing project (update scaffolding).
+
+```
+Options:
+      --dry-run       Show what would change without writing anything
+      --refresh       Force re-clone of cached remote templates
+  -y, --yes           Skip all confirmation prompts
+```
+
+### Project Lifecycle
+
+#### `fledge run [task]`
+
+Run a project task defined in `fledge.toml`. Auto-detects your project type and generates sensible defaults with `--init`.
+
+```
+Options:
+      --init          Create a starter fledge.toml with language-aware defaults
+  -l, --list          List available tasks
+```
+
+#### `fledge spec <action>`
+
+Manage spec-sync specifications (source of truth for modules).
+
+```
+Subcommands:
+  check               Validate specs against source code (--strict for warnings as errors)
+  init                Initialize spec-sync configuration
+  new <name>          Scaffold a new spec module
+```
+
+#### `fledge work <action>`
+
+Feature branch and PR workflow.
+
+```
+Subcommands:
+  start <name>        Start a new feature branch (--base to specify base branch)
+  pr                  Create a PR from current branch (--title, --body, --draft)
+  status              Show current branch and PR status
+```
+
+#### `fledge changelog`
+
+Generate a changelog from git tags and conventional commits.
+
+```
+Options:
+  -l, --limit         Number of releases to show [default: 10]
+  -t, --tag           Show a specific tag only
+      --unreleased    Show unreleased changes since the latest tag
+      --json          Output as JSON
+```
+
+### GitHub Integration
+
+#### `fledge issues [view <number>]`
+
+List and view GitHub issues.
+
+```
+Options:
+  -s, --state         Filter by state: open, closed, all [default: open]
+  -l, --limit         Maximum number of results [default: 20]
+      --label         Filter by label
+      --json          Output results as JSON
+```
+
+#### `fledge prs [view <number>]`
+
+List and view GitHub pull requests.
+
+```
+Options:
+  -s, --state         Filter by state: open, closed, all [default: open]
+  -l, --limit         Maximum number of results [default: 20]
+      --json          Output results as JSON
+```
+
+#### `fledge checks`
+
+View CI/CD check status for a branch.
+
+```
+Options:
+  -b, --branch        Branch to check [default: current branch]
+      --json          Output results as JSON
+```
+
+### AI-Powered
+
+#### `fledge review`
+
+AI-powered code review of current changes via Claude CLI.
+
+```
+Options:
+  -b, --base          Base branch to diff against [default: auto-detect]
+  -f, --file          Review only a specific file
+```
+
+#### `fledge ask <question>`
+
+Ask a question about your codebase via Claude CLI.
+
+### Configuration
+
+#### `fledge config <action>`
+
+Manage global configuration (`~/.config/fledge/config.toml`).
+
+```
+Subcommands:
+  get <key>           Get a config value
+  set <key> <value>   Set a config value
+  unset <key>         Remove a config value
+  add <key> <value>   Add a value to a list (templates.paths, templates.repos)
+  remove <key> <value> Remove a value from a list
+  list                Show all config values
+  path                Show config file path
+```
+
+#### `fledge completions [shell]`
+
+Generate or install shell completions (bash, zsh, fish, powershell).
+
+```
+Options:
+      --install       Auto-install completions to the standard location
+```
+
+#### `fledge tui` *(requires `--features tui`)*
+
+Interactive terminal UI for browsing templates and scaffolding projects.
 
 ## Remote Templates
 
@@ -123,6 +282,9 @@ fledge init my-app --template user/my-template
 # Use a specific template from a collection
 fledge init my-app --template CorvidLabs/templates/python-api
 
+# Pin to a specific version/ref
+fledge init my-app --template user/my-template@v1.0.0
+
 # Force re-download of a cached template
 fledge init my-app --template user/my-template --refresh
 ```
@@ -131,7 +293,7 @@ Remote templates are cloned and cached locally. Post-create hooks from remote te
 
 ### Template Repositories
 
-You can register template repos in your config so they appear in `fledge list`:
+Register template repos in your config so they appear in `fledge list`:
 
 ```toml
 # ~/.config/fledge/config.toml
@@ -157,172 +319,26 @@ repos = ["CorvidLabs/fledge-templates"]         # GitHub repos to include in tem
 token = "ghp_..."         # for private template repos (also reads FLEDGE_GITHUB_TOKEN / GITHUB_TOKEN env vars)
 ```
 
-If `author` is not set, fledge falls back to `git config user.name`. The GitHub token is checked in order: `FLEDGE_GITHUB_TOKEN` env var → `GITHUB_TOKEN` env var → config file.
+If `author` is not set, fledge falls back to `git config user.name`. The GitHub token is checked in order: `FLEDGE_GITHUB_TOKEN` env var -> `GITHUB_TOKEN` env var -> config file.
 
 ## Creating Templates
 
-A template is a directory with a `template.toml` manifest and any number of files. Files are rendered through [Tera](https://keats.github.io/tera/) (a Jinja2-like engine) before being written.
+See the [Template Authoring Guide](https://corvidlabs.github.io/fledge/template-authoring.html) for full documentation on creating and publishing templates.
 
-### Directory Structure
+A template is a directory with a `template.toml` manifest and any number of files rendered through [Tera](https://keats.github.io/tera/) (a Jinja2-like engine).
 
-```
-my-template/
-├── template.toml          # manifest (required)
-├── src/
-│   └── main.rs            # template files — Tera syntax supported
-├── README.md
-├── Cargo.toml
-└── .github/
-    └── workflows/
-        └── ci.yml
-```
-
-### template.toml Reference
-
-```toml
-[template]
-name = "my-template"                           # template name (used in --template flag)
-description = "A short description"            # shown in fledge list
-min_fledge_version = "0.1.0"                   # optional minimum fledge version
-
-[prompts]
-# Each key becomes a template variable. Values have `message` and optional `default`.
-description = { message = "Project description", default = "A new project" }
-port = { message = "Default port", default = "3000" }
-
-# Defaults can use Tera expressions referencing earlier variables:
-repo_url = { message = "Repository URL", default = "https://github.com/{{ github_org }}/{{ project_name }}" }
-
-[files]
-render = ["**/*.rs", "**/*.toml", "**/*.md", "**/*.yml"]   # files to render through Tera
-copy = ["**/*.png", "**/*.ico"]                             # files to copy as-is (binary files)
-ignore = ["template.toml"]                                  # files to exclude from output
-
-[hooks]
-post_create = ["cargo fmt", "npm install"]     # commands to run after scaffolding
-```
-
-### Built-in Variables
-
-These are always available in your templates — no need to define them in `[prompts]`:
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `project_name` | The project name as provided by the user | `my-cool-app` |
-| `project_name_snake` | Snake case version | `my_cool_app` |
-| `project_name_pascal` | PascalCase version | `MyCoolApp` |
-| `author` | From config, git, or prompted | `Leif` |
-| `github_org` | From config or prompted (default: `CorvidLabs`) | `CorvidLabs` |
-| `license` | From config (default: `MIT`) | `MIT` |
-| `year` | Current year | `2026` |
-| `date` | Current date | `2026-04-18` |
-
-### Tera Syntax
-
-Templates use [Tera](https://keats.github.io/tera/docs/) syntax:
-
-```
-# {{ project_name }}
-
-{{ description }}
-
-## Author
-
-Created by {{ author }} ({{ github_org }}) in {{ year }}.
-
-{% if license == "MIT" %}
-This project is MIT licensed.
-{% endif %}
-```
-
-### File Rules
-
-- **`render`** — glob patterns for files that should be processed through Tera. Template variables (`{{ project_name }}`, etc.) are replaced with actual values.
-- **`copy`** — glob patterns for files that should be copied as-is. Use for binary files (images, fonts) that would break if parsed.
-- **`ignore`** — glob patterns for files to exclude from the output entirely. `template.toml` should always be listed here.
-
-Files not matching any rule are rendered by default.
-
-### Post-Create Hooks
-
-Commands listed in `hooks.post_create` run inside the newly created project directory after all files are written. Use them for dependency installation, formatting, or other setup:
-
-```toml
-[hooks]
-post_create = ["bun install", "bun run format"]
-```
-
-For local (built-in) templates, hooks run automatically. For remote templates, fledge shows the commands and asks for confirmation before running — unless `--yes` is passed.
-
-### Testing Templates Locally
-
-Point fledge at your template directory during development:
+Quick example:
 
 ```bash
-# Add your template directory to config
-# ~/.config/fledge/config.toml
-[templates]
-paths = ["~/dev/my-templates"]
+# Scaffold a new template
+fledge create-template my-template
 
-# Or use it directly as a remote-style path
-fledge init test-project --template ./my-template
-```
+# Edit template.toml and template files
+# Test it
+fledge init test-project --template ./my-template --dry-run
 
-Then iterate: edit template files, run `fledge init test-output --template my-template`, inspect the output, delete and repeat.
-
-### Example: Creating a Template from Scratch
-
-```bash
-mkdir my-template && cd my-template
-```
-
-Create `template.toml`:
-
-```toml
-[template]
-name = "python-api"
-description = "Python FastAPI project with Docker"
-
-[prompts]
-description = { message = "Project description", default = "A FastAPI application" }
-python_version = { message = "Python version", default = "3.12" }
-
-[files]
-render = ["**/*.py", "**/*.toml", "**/*.md", "**/*.yml", "Dockerfile"]
-ignore = ["template.toml"]
-
-[hooks]
-post_create = ["python -m venv .venv"]
-```
-
-Create template files using Tera variables:
-
-```python
-# app/main.py
-"""{{ description }}"""
-from fastapi import FastAPI
-
-app = FastAPI(title="{{ project_name_pascal }}")
-
-@app.get("/")
-def root():
-    return {"name": "{{ project_name }}"}
-```
-
-```dockerfile
-# Dockerfile
-FROM python:{{ python_version }}-slim
-WORKDIR /app
-COPY . .
-RUN pip install -e .
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0"]
-```
-
-Test it:
-
-```bash
-fledge init test-api --template python-api --dry-run
-fledge init test-api --template python-api
+# Publish to GitHub
+fledge publish ./my-template
 ```
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 Fledge is evolving from a project scaffolding tool into a full dev-lifecycle CLI — scaffold, spec, build, ship, monitor — all from one opinionated Rust binary.
 
-## Current State (v0.6.0)
+## Current State (v0.7.0)
 
-Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A. Distribution via Homebrew, install script, Nix flake, and shell completions auto-install.
+Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, `checks`, `run`, `changelog`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A, CI/CD status, task runner with language-aware defaults, changelog generation from git history. Distribution via Homebrew, install script, Nix flake, and shell completions auto-install.
 
 ---
 
@@ -17,7 +17,7 @@ Complete the template story: discovery, publishing, versioning, and more built-i
 - [x] Template versioning and compatibility checks (#13)
 - [x] Additional built-in templates: Python, Go, monorepo (#9)
 - [ ] CorvidLabs template collection and org defaults (#8)
-- [ ] Publish to crates.io (#2)
+- [x] Publish to crates.io (#2)
 
 ## 0.4 — Project Lifecycle
 
@@ -45,11 +45,28 @@ Make fledge easy to install everywhere.
 - [x] Nix package (#12)
 - [x] Shell completions auto-install (`fledge completions --install`)
 
+## 0.7 — Task Runner & Observability
+
+Run tasks, check CI, and generate changelogs — fledge becomes your daily driver.
+
+- [x] `fledge run` — task runner with `fledge.toml`, language-aware defaults (#49)
+- [x] `fledge checks` — view CI/CD status for any branch (#49)
+- [x] `fledge changelog` — generate changelogs from git tags and conventional commits (#53)
+- [x] Language-agnostic support — auto-detects Rust, Node, Go, Python, Ruby, Java (#51)
+
+## 0.8 — Project Health (planned)
+
+Dependency management, project metrics, and environment diagnostics.
+
+- [ ] `fledge deps` — dependency health check (outdated packages, audit, license scan)
+- [ ] `fledge metrics` — project stats (LOC, test coverage, complexity, churn)
+- [ ] `fledge doctor` — environment diagnostics (toolchain versions, missing deps, config issues)
+
 ## 1.0 — Lanes & Plugins
 
 Extensible workflow automation — the Fastlane model, but in Rust.
 
-- [ ] Lane system — composable, typed workflow pipelines
+- [ ] Lane system — composable, typed workflow pipelines (#36)
 - [ ] Plugin architecture (Rust or WASM)
 - [ ] Community lane registry
 - [ ] Full end-to-end dev lifecycle coverage

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,3 +7,4 @@
 - [CLI Reference](./cli-reference.md)
 - [Template Authoring Guide](./template-authoring.md)
 - [Configuration](./configuration.md)
+- [Changelog](./changelog.md)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,0 +1,25 @@
+# Changelog
+
+fledge can auto-generate changelogs from your git history. You can also view the full project changelog below.
+
+## Using `fledge changelog`
+
+```bash
+# Show recent releases
+fledge changelog
+
+# Show unreleased changes
+fledge changelog --unreleased
+
+# Export as JSON
+fledge changelog --json
+
+# Show a specific release
+fledge changelog --tag v0.7.0
+```
+
+The `changelog` command parses git tags and conventional commits, grouping them by type (features, fixes, etc.).
+
+## Project Changelog
+
+See [CHANGELOG.md](https://github.com/CorvidLabs/fledge/blob/main/CHANGELOG.md) for the full release history.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -2,21 +2,23 @@
 
 Complete reference for all fledge commands and options.
 
-## fledge init `<name>`
+## Scaffolding Commands
+
+### fledge init `<name>`
 
 Create a new project from a template.
 
-### Usage
+#### Usage
 
 ```
 fledge init <name> [OPTIONS]
 ```
 
-### Arguments
+#### Arguments
 
 - `<name>` — Project name
 
-### Options
+#### Options
 
 - `-t, --template <TEMPLATE>` — Template to use (skip interactive selection)
 - `-o, --output <OUTPUT>` — Parent directory for the project [default: `.`]
@@ -26,7 +28,7 @@ fledge init <name> [OPTIONS]
 - `--dry-run` — Show what would be created without writing anything
 - `-y, --yes` — Skip all confirmation prompts (accept defaults)
 
-### Examples
+#### Examples
 
 ```bash
 # Create with defaults
@@ -40,15 +42,18 @@ fledge init my-lib --template rust-lib --yes
 
 # Specify output directory
 fledge init my-project --template ts-bun -o ~/projects
+
+# Use a remote template pinned to a version
+fledge init my-app --template CorvidLabs/templates/react-app@v2.0
 ```
 
 ---
 
-## fledge list
+### fledge list
 
 List all available templates (built-in + configured).
 
-### Usage
+#### Usage
 
 ```
 fledge list
@@ -58,64 +63,422 @@ Shows template name, description, and source (built-in or configured repo).
 
 ---
 
-## fledge tui
+### fledge create-template `<name>`
+
+Scaffold a new fledge template with a `template.toml` manifest and example files.
+
+#### Usage
+
+```
+fledge create-template <name> [OPTIONS]
+```
+
+#### Arguments
+
+- `<name>` — Template name
+
+#### Options
+
+- `-o, --output <OUTPUT>` — Parent directory for the template [default: `.`]
+
+---
+
+### fledge search `[query]`
+
+Search for templates on GitHub using the `fledge-template` topic.
+
+#### Usage
+
+```
+fledge search [query] [OPTIONS]
+```
+
+#### Arguments
+
+- `[query]` — Keyword to filter results (optional)
+
+#### Options
+
+- `-l, --limit <LIMIT>` — Maximum number of results [default: `20`]
+- `--json` — Output results as JSON
+
+---
+
+### fledge publish `[path]`
+
+Publish a template directory to GitHub as a new repository tagged with `fledge-template`.
+
+#### Usage
+
+```
+fledge publish [path] [OPTIONS]
+```
+
+#### Arguments
+
+- `[path]` — Path to the template directory [default: `.`]
+
+#### Options
+
+- `--org <ORG>` — Publish under a GitHub organization
+- `--private` — Create as a private repository
+- `--description <DESC>` — Override the repository description
+
+---
+
+### fledge update
+
+Re-apply the source template to an existing project. Useful when the template has been updated and you want to pull in changes.
+
+#### Usage
+
+```
+fledge update [OPTIONS]
+```
+
+#### Options
+
+- `--dry-run` — Show what would change without writing anything
+- `--refresh` — Force re-clone of cached remote templates
+- `-y, --yes` — Skip all confirmation prompts
+
+---
+
+## Project Lifecycle Commands
+
+### fledge run `[task]`
+
+Run a project task defined in `fledge.toml`. If no task is specified, lists available tasks. Use `--init` to generate a starter `fledge.toml` with language-aware defaults for your project type.
+
+#### Usage
+
+```
+fledge run [task] [OPTIONS]
+```
+
+#### Arguments
+
+- `[task]` — Task name to run (lists tasks if omitted)
+
+#### Options
+
+- `--init` — Create a starter `fledge.toml` with detected project defaults
+- `-l, --list` — List available tasks
+
+#### Supported Project Types
+
+`fledge run --init` auto-detects your project and generates appropriate task definitions:
+
+| Project Type | Detection | Default Tasks |
+|--------------|-----------|---------------|
+| Rust | `Cargo.toml` | `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt` |
+| Node.js | `package.json` | `npm run build`, `npm test`, `npm run lint` |
+| Go | `go.mod` | `go build`, `go test`, `go vet` |
+| Python | `pyproject.toml` / `setup.py` | `pytest`, `ruff check`, `mypy` |
+| Ruby | `Gemfile` | `bundle exec rake`, `bundle exec rspec` |
+| Gradle | `build.gradle` | `./gradlew build`, `./gradlew test` |
+| Maven | `pom.xml` | `mvn compile`, `mvn test` |
+
+#### Examples
+
+```bash
+# Initialize task config
+fledge run --init
+
+# Run a task
+fledge run build
+fledge run test
+
+# List available tasks
+fledge run --list
+```
+
+---
+
+### fledge spec `<action>`
+
+Manage spec-sync specifications. Specs are the source of truth for module design and implementation.
+
+#### Usage
+
+```
+fledge spec <check|init|new> [OPTIONS]
+```
+
+#### Subcommands
+
+##### `fledge spec check`
+
+Validate all specs against the source code.
+
+- `--strict` — Treat warnings as errors
+
+##### `fledge spec init`
+
+Initialize spec-sync configuration for the project.
+
+##### `fledge spec new <name>`
+
+Scaffold a new spec module with all required sections.
+
+---
+
+### fledge work `<action>`
+
+Feature branch and PR workflow — start branches, create PRs, and check status.
+
+#### Usage
+
+```
+fledge work <start|pr|status> [OPTIONS]
+```
+
+#### Subcommands
+
+##### `fledge work start <name>`
+
+Start a new feature branch. The name is sanitized and prefixed with `feat/`.
+
+- `--base <BRANCH>` — Base branch to branch from [default: `main`]
+
+##### `fledge work pr`
+
+Create a pull request from the current branch.
+
+- `-t, --title <TITLE>` — PR title (auto-generated from branch name if omitted)
+- `-b, --body <BODY>` — PR body/description
+- `--draft` — Create as a draft PR
+- `--base <BRANCH>` — Target base branch for the PR
+
+##### `fledge work status`
+
+Show the current branch name and associated PR status.
+
+---
+
+### fledge changelog
+
+Generate a changelog from git tags and conventional commits. Groups commits by type (features, fixes, etc.).
+
+#### Usage
+
+```
+fledge changelog [OPTIONS]
+```
+
+#### Options
+
+- `-l, --limit <N>` — Number of releases to show [default: `10`]
+- `-t, --tag <TAG>` — Show a specific tag only
+- `--unreleased` — Show unreleased changes since the latest tag
+- `--json` — Output as JSON
+
+#### Examples
+
+```bash
+# Show recent releases
+fledge changelog
+
+# Show only unreleased changes
+fledge changelog --unreleased
+
+# Export as JSON for automation
+fledge changelog --json
+
+# Show a specific release
+fledge changelog --tag v0.7.0
+```
+
+---
+
+## GitHub Integration Commands
+
+### fledge issues `[view <number>]`
+
+List and view GitHub issues for the current repository.
+
+#### Usage
+
+```
+fledge issues [OPTIONS]
+fledge issues view <number> [OPTIONS]
+```
+
+#### Options
+
+- `-s, --state <STATE>` — Filter by state: `open`, `closed`, `all` [default: `open`]
+- `-l, --limit <N>` — Maximum number of results [default: `20`]
+- `--label <LABEL>` — Filter by label
+- `--json` — Output results as JSON
+
+---
+
+### fledge prs `[view <number>]`
+
+List and view GitHub pull requests for the current repository.
+
+#### Usage
+
+```
+fledge prs [OPTIONS]
+fledge prs view <number> [OPTIONS]
+```
+
+#### Options
+
+- `-s, --state <STATE>` — Filter by state: `open`, `closed`, `all` [default: `open`]
+- `-l, --limit <N>` — Maximum number of results [default: `20`]
+- `--json` — Output results as JSON
+
+---
+
+### fledge checks
+
+View CI/CD check status for a branch.
+
+#### Usage
+
+```
+fledge checks [OPTIONS]
+```
+
+#### Options
+
+- `-b, --branch <BRANCH>` — Branch to check [default: current branch]
+- `--json` — Output results as JSON
+
+---
+
+## AI-Powered Commands
+
+### fledge review
+
+AI-powered code review of current changes using Claude CLI. Diffs the current branch against the base branch and provides review feedback.
+
+#### Usage
+
+```
+fledge review [OPTIONS]
+```
+
+#### Options
+
+- `-b, --base <BRANCH>` — Base branch to diff against [default: auto-detect]
+- `-f, --file <FILE>` — Review only a specific file
+
+---
+
+### fledge ask `<question>`
+
+Ask a question about your codebase using Claude CLI. Provides context-aware answers based on your project's source code.
+
+#### Usage
+
+```
+fledge ask <question>
+```
+
+#### Examples
+
+```bash
+fledge ask "how does the template rendering work?"
+fledge ask "what tests cover the config module?"
+```
+
+---
+
+## Configuration Commands
+
+### fledge config `<action>`
+
+Manage global configuration stored in `~/.config/fledge/config.toml`.
+
+#### Usage
+
+```
+fledge config <get|set|unset|add|remove|list|path>
+```
+
+#### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `get <key>` | Get a config value |
+| `set <key> <value>` | Set a config value |
+| `unset <key>` | Remove a config value |
+| `add <key> <value>` | Add a value to a list key (`templates.paths`, `templates.repos`) |
+| `remove <key> <value>` | Remove a value from a list key |
+| `list` | Show all config values |
+| `path` | Show config file path |
+
+#### Valid Keys
+
+- `defaults.author` — Default author name
+- `defaults.github_org` — Default GitHub organization
+- `defaults.license` — Default license
+- `github.token` — GitHub personal access token
+- `templates.paths` — Local template directories (list)
+- `templates.repos` — GitHub template repositories (list)
+
+#### Examples
+
+```bash
+fledge config set defaults.author "Leif"
+fledge config add templates.repos "CorvidLabs/fledge-templates"
+fledge config list
+```
+
+---
+
+### fledge completions `[shell]`
+
+Generate or install shell completions.
+
+#### Usage
+
+```
+fledge completions [shell] [OPTIONS]
+```
+
+#### Arguments
+
+- `[shell]` — Shell to generate completions for: `bash`, `zsh`, `fish`, `powershell` (auto-detects with `--install`)
+
+#### Options
+
+- `--install` — Install completions to the standard location for your shell
+
+#### Examples
+
+```bash
+# Auto-install for your current shell
+fledge completions --install
+
+# Manual generation
+fledge completions bash >> ~/.bashrc
+fledge completions zsh > ~/.zfunc/_fledge
+fledge completions fish > ~/.config/fish/completions/fledge.fish
+```
+
+---
+
+### fledge tui *(requires `--features tui`)*
 
 Interactive terminal UI for browsing templates and scaffolding projects.
 
-*Requires `--features tui` at install time.*
-
-### Usage
+#### Usage
 
 ```
 fledge tui [OPTIONS]
 ```
 
-### Options
+#### Options
 
 - `-o, --output <OUTPUT>` — Parent directory for the project [default: `.`]
 - `--no-git` — Skip git init and initial commit
 
-### Navigation
+#### Navigation
 
 - **Arrow keys** — Browse templates
 - **Tab** — Fill in project variables
 - **Enter** — Confirm and create
-
-The TUI provides an interactive experience for users who prefer guided project creation.
-
----
-
-## fledge completions `<shell>`
-
-Generate shell completions for your shell.
-
-### Usage
-
-```
-fledge completions <shell>
-```
-
-### Supported Shells
-
-- `bash`
-- `zsh`
-- `fish`
-- `powershell`
-
-### Examples
-
-```bash
-# Bash
-fledge completions bash >> ~/.bashrc
-
-# Zsh
-fledge completions zsh > ~/.zfunc/_fledge
-
-# Fish
-fledge completions fish > ~/.config/fish/completions/fledge.fish
-
-# PowerShell
-fledge completions powershell | Out-String | Out-File -FilePath $PROFILE -Append
-```
-
-After adding completions, reload your shell or start a new terminal session to enable them.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -16,6 +16,30 @@ fledge includes an optional interactive terminal UI for browsing and selecting t
 cargo install fledge --features tui
 ```
 
+## Homebrew
+
+```bash
+brew install CorvidLabs/tap/fledge
+```
+
+## Install Script
+
+Download and install the latest release automatically:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/install.sh | sh
+```
+
+The script detects your OS and architecture and downloads the correct binary.
+
+## Nix
+
+```bash
+nix run github:CorvidLabs/fledge
+```
+
+Or add to your flake inputs for a permanent installation.
+
 ## From Source
 
 If you prefer to build from source, clone the repository and install:
@@ -23,6 +47,20 @@ If you prefer to build from source, clone the repository and install:
 ```bash
 git clone https://github.com/CorvidLabs/fledge.git
 cd fledge && cargo install --path .
+```
+
+## Shell Completions
+
+After installation, set up shell completions for tab-completion support:
+
+```bash
+# Auto-install for your current shell
+fledge completions --install
+
+# Or generate manually
+fledge completions bash >> ~/.bashrc
+fledge completions zsh > ~/.zfunc/_fledge
+fledge completions fish > ~/.config/fish/completions/fledge.fish
 ```
 
 ## Verify Installation

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -36,12 +36,41 @@ Before committing to creating a project, preview what would be generated:
 fledge init my-tool --template rust-cli --dry-run
 ```
 
-## Skip All Prompts with Defaults
+## Set Up Your Project
 
-If you want to skip confirmations and use defaults, use `--yes`:
+Once your project is created, initialize the task runner:
 
 ```bash
-fledge init my-tool --template rust-cli --yes
+cd my-tool
+fledge run --init    # generates fledge.toml with language-aware defaults
+fledge run build     # run the build task
+fledge run test      # run tests
+```
+
+## Start a Feature Branch
+
+Use the workflow commands to manage branches and PRs:
+
+```bash
+fledge work start add-logging    # creates feat/add-logging branch
+# ... make changes ...
+fledge work pr                   # creates a PR from current branch
+fledge work status               # check branch and PR status
+```
+
+## Check CI and Review Code
+
+```bash
+fledge checks                    # view CI/CD status
+fledge review                    # AI-powered code review
+fledge ask "how does X work?"    # ask about the codebase
+```
+
+## Generate a Changelog
+
+```bash
+fledge changelog                 # from git tags + conventional commits
+fledge changelog --unreleased    # see what's new since last tag
 ```
 
 ## List Available Templates
@@ -63,5 +92,11 @@ fledge comes with several built-in templates ready to use:
 | `swift-pkg` | Swift package with Package.swift, CI, and coding conventions |
 | `ts-bun` | TypeScript project with Bun runtime |
 | `angular-app` | Angular application with mobile-first setup |
+| `python-cli` | Python CLI with Click, tests, and packaging |
+| `go-cli` | Go CLI with Cobra, Makefile, and CI |
+| `node-cli` | Node.js CLI with TypeScript |
+| `node-lib` | Node.js library with TypeScript and npm publishing |
+| `monorepo` | Monorepo with workspace tooling |
+| `static-site` | Static site with build pipeline |
 
 Each template includes sensible defaults, CI/CD workflows, and best practices for its language ecosystem.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -2,15 +2,27 @@
 
 Get your projects ready to fly.
 
-**fledge** is a fast, opinionated project scaffolding CLI built in Rust. Create new projects from templates — local or remote — with smart defaults, Tera-powered rendering, and zero boilerplate.
+**fledge** is a fast, opinionated dev-lifecycle CLI built in Rust. Scaffold projects from templates, manage specs, run tasks, check CI, review code, and ship — all from one binary.
 
 ## Why fledge?
 
 - **Fast** — native Rust binary, no runtime dependencies
 - **Smart defaults** — pulls author/org from git config, renders dates, computes name variants automatically
 - **Remote templates** — use any GitHub repo as a template source with `owner/repo` syntax
+- **Full lifecycle** — scaffolding, specs, tasks, CI checks, changelogs, GitHub ops, AI review
+- **Language-agnostic** — auto-detects Rust, Node, Go, Python, Ruby, Java and adapts defaults
 - **Extensible** — create your own templates with a simple `template.toml` manifest
 - **Safe** — remote template hooks require explicit confirmation before running
 - **Optional TUI** — interactive template browser with `--features tui`
 
-fledge is designed to eliminate boilerplate setup when starting new projects. Whether you're scaffolding a Rust CLI, a Swift package, or a TypeScript project, fledge provides a consistent, powerful templating system with sensible defaults that just work.
+fledge is designed to be the one CLI you reach for throughout the dev lifecycle. Start a project with `init`, manage specs with `spec`, run tasks with `run`, check CI with `checks`, review code with `review`, and generate changelogs with `changelog`. Whether you're scaffolding a Rust CLI, a Go service, or a TypeScript project, fledge provides a consistent, powerful toolset with sensible defaults that just work.
+
+## What can fledge do?
+
+| Category | Commands | Description |
+|----------|----------|-------------|
+| **Scaffolding** | `init`, `list`, `create-template`, `search`, `publish`, `update` | Create projects from templates, discover and share templates |
+| **Project Lifecycle** | `run`, `spec`, `work`, `changelog` | Task runner, spec management, git workflow, changelog generation |
+| **GitHub** | `issues`, `prs`, `checks` | View issues, PRs, and CI status from the terminal |
+| **AI-Powered** | `review`, `ask` | Code review and codebase Q&A via Claude |
+| **Configuration** | `config`, `completions`, `tui` | Global settings, shell completions, interactive UI |


### PR DESCRIPTION
## Summary

- **README.md** — Complete rewrite documenting all 18 commands (was only 4), updated feature list, added install methods, streamlined template authoring section
- **CLI Reference** — Full mdBook reference for every command with usage, options, examples, and organized by category (scaffolding, lifecycle, GitHub, AI, config)
- **CHANGELOG.md** — Added missing v0.3-v0.7 entries covering all shipped features
- **ROADMAP.md** — Updated current state to v0.7.0, added v0.7 section (task runner, checks, changelog), added v0.8 planned section (deps, metrics, doctor)
- **CLAUDE.md** — Updated architecture section with all 20+ source modules
- **Introduction & Quick Start** — Expanded to cover full dev lifecycle workflow (run, work, checks, review, changelog)
- **Installation docs** — Added Homebrew, install script, Nix, and shell completions --install
- **New changelog docs page** — Added to mdBook SUMMARY

Also closed #12 (alternative install methods — all shipped in v0.6).

## Test plan

- [x] All 245 tests pass
- [x] All 20 specs pass clean (0 errors, 0 warnings)
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)