### PR TITLE
fix: upgrade spec-sync to v4.3.2, use bare module names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run spec-sync
         id: specsync
-        uses: CorvidLabs/spec-sync@v4.3.1
+        uses: CorvidLabs/spec-sync@v4.3.2
         with:
           strict: true
           comment: false

--- a/specs/checks/checks.spec.md
+++ b/specs/checks/checks.spec.md
@@ -7,8 +7,8 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/github/github.spec.md
-  - specs/config/config.spec.md
+  - github
+  - config
 ---
 
 # Checks

--- a/specs/deps/deps.spec.md
+++ b/specs/deps/deps.spec.md
@@ -7,7 +7,7 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/run/run.spec.md
+  - run
 ---
 
 # Deps

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -7,7 +7,7 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/run/run.spec.md
+  - run
 ---
 
 # Doctor

--- a/specs/issues/issues.spec.md
+++ b/specs/issues/issues.spec.md
@@ -7,8 +7,8 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/github/github.spec.md
-  - specs/config/config.spec.md
+  - github
+  - config
 ---
 
 # Issues

--- a/specs/prs/prs.spec.md
+++ b/specs/prs/prs.spec.md
@@ -7,8 +7,8 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/github/github.spec.md
-  - specs/config/config.spec.md
+  - github
+  - config
 ---
 
 # Prs

--- a/specs/publish/publish.spec.md
+++ b/specs/publish/publish.spec.md
@@ -7,8 +7,8 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/config/config.spec.md
-  - specs/templates/templates.spec.md
+  - config
+  - templates
 ---
 
 # Publish

--- a/specs/search/search.spec.md
+++ b/specs/search/search.spec.md
@@ -7,7 +7,7 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/config/config.spec.md
+  - config
 ---
 
 # Search

--- a/specs/update/update.spec.md
+++ b/specs/update/update.spec.md
@@ -7,9 +7,9 @@ files:
 
 db_tables: []
 depends_on:
-  - specs/init/init.spec.md
-  - specs/templates/templates.spec.md
-  - specs/remote/remote.spec.md
+  - init
+  - templates
+  - remote
 ---
 
 # Update


### PR DESCRIPTION
## Summary
- Bumps spec-sync CI action from v4.3.1 to v4.3.2 (fixes bare module name resolution in `depends_on` — [CorvidLabs/spec-sync#257](https://github.com/CorvidLabs/spec-sync/issues/257))
- Reverts path-format workarounds in all 8 specs to clean bare module names (e.g. `specs/github/github.spec.md` → `github`)

## Test plan
- [ ] CI spec-check passes with `--strict` using bare module names
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)