### PR TITLE
feat: add `fledge lane` — composable workflow pipelines

### DIFF
--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,0 +1,152 @@
+---
+module: lanes
+version: 1
+status: active
+files:
+  - src/lanes.rs
+
+db_tables: []
+depends_on:
+  - run
+---
+
+# Lanes
+
+## Purpose
+
+Composable workflow pipelines defined in `fledge.toml`. Lanes chain multiple tasks (and inline commands) into named pipelines with support for parallel execution groups and configurable failure behavior.
+
+## Public API
+
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `run` | Entry point — lists or executes lanes |
+| `LaneOptions` | Options: `lane`, `list`, `init`, `dry_run`, `json` |
+
+### Structs & Enums
+
+| Type | Description |
+|------|-------------|
+| `LaneOptions` | CLI options for the lane subcommand |
+| `LaneDef` | A named lane with description, steps, and fail_fast flag |
+| `Step` | A single step: task reference, inline command, or parallel group |
+
+### Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `run` | `(LaneOptions) -> Result<()>` | Main entry — dispatch to init/list/execute |
+
+## Config Format
+
+Lanes are defined in `fledge.toml` under `[lanes]`:
+
+```toml
+# Sequential pipeline — steps reference tasks by name
+[lanes.ci]
+description = "Full CI pipeline"
+steps = ["lint", "test", "build"]
+
+# Mixed steps — task references and inline commands
+[lanes.release]
+description = "Build and publish a release"
+steps = [
+  "test",
+  { run = "cargo build --release" },
+  "publish"
+]
+
+# Parallel groups — steps inside { parallel = [...] } run concurrently
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["lint", "fmt"] },
+  "test"
+]
+
+# Failure behavior — fail_fast = false continues after failures
+[lanes.audit]
+description = "Run all audits"
+fail_fast = false
+steps = ["deps-audit", "license-check", "security-scan"]
+```
+
+### Step Types
+
+| Type | Format | Description |
+|------|--------|-------------|
+| Task reference | `"task_name"` | Runs a task defined in `[tasks]` |
+| Inline command | `{ run = "command" }` | Runs a shell command directly |
+| Parallel group | `{ parallel = ["a", "b"] }` | Runs referenced tasks concurrently |
+
+## Invariants
+
+1. Lanes are read from `fledge.toml` alongside tasks
+2. Each step in a lane is either a task reference (string), inline command (`{ run = "..." }`), or parallel group (`{ parallel = [...] }`)
+3. Task references must resolve to tasks defined in `[tasks]` — unknown references produce an error before execution
+4. Parallel groups spawn threads and collect results; if any thread fails and `fail_fast` is true, remaining steps are skipped
+5. Steps execute sequentially by default; only `{ parallel = [...] }` groups run concurrently
+6. `fail_fast` defaults to `true` — first failure stops the lane
+7. `--init` appends language-aware default lanes to an existing `fledge.toml`
+8. `--dry-run` prints the execution plan without running anything
+9. Task dependencies (deps) are resolved within each step — a task's deps run before the task itself
+
+## Behavioral Examples
+
+```
+# List lanes
+$ fledge lane
+Available lanes:
+  ci       Full CI pipeline
+  release  Build and publish a release
+
+# Run a lane
+$ fledge lane ci
+▸ Lane: ci — Full CI pipeline
+  ▸ Running task: lint
+  ▸ Running task: test
+  ▸ Running task: build
+✓ Lane ci completed (3 steps)
+
+# Dry run
+$ fledge lane ci --dry-run
+Lane: ci — Full CI pipeline
+  1. lint (task)
+  2. test (task)
+  3. build (task)
+
+# Parallel steps
+$ fledge lane check
+▸ Lane: check — Quick quality check
+  ▸ Running parallel: lint, fmt
+  ▸ Running task: test
+✓ Lane check completed (2 steps)
+
+# Init default lanes
+$ fledge lane --init
+✓ Added default lanes to fledge.toml
+```
+
+## Error Cases
+
+| Error | When | Behavior |
+|-------|------|----------|
+| No fledge.toml | File missing | Suggest `fledge run --init` |
+| No lanes defined | No `[lanes]` section | Error with guidance |
+| Unknown lane | Lane name not found | List available lanes |
+| Unknown task ref | Step references non-existent task | Error before execution with task name |
+| Step failed | Non-zero exit code | Stop lane (if fail_fast) or continue and report |
+| Already exists | `--init` when lanes already exist | Error |
+| Empty steps | Lane has no steps | Error |
+
+## Dependencies
+
+- `run` module (reuses task execution, project detection)
+
+## Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1 | 2026-04-20 | Initial spec |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -1,0 +1,927 @@
+use anyhow::{Context, Result, bail};
+use console::style;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use crate::run::detect_project_type;
+
+#[derive(Debug, Deserialize)]
+struct FledgeFileWithLanes {
+    #[serde(default)]
+    tasks: BTreeMap<String, TaskDef>,
+    #[serde(default)]
+    lanes: BTreeMap<String, LaneDef>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum TaskDef {
+    Short(String),
+    Full(TaskConfig),
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskConfig {
+    cmd: String,
+    #[serde(default)]
+    deps: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    dir: Option<String>,
+}
+
+impl TaskDef {
+    fn cmd(&self) -> &str {
+        match self {
+            TaskDef::Short(s) => s,
+            TaskDef::Full(c) => &c.cmd,
+        }
+    }
+
+    fn deps(&self) -> &[String] {
+        match self {
+            TaskDef::Short(_) => &[],
+            TaskDef::Full(c) => &c.deps,
+        }
+    }
+
+    fn env(&self) -> &BTreeMap<String, String> {
+        static EMPTY: BTreeMap<String, String> = BTreeMap::new();
+        match self {
+            TaskDef::Short(_) => &EMPTY,
+            TaskDef::Full(c) => &c.env,
+        }
+    }
+
+    fn dir(&self) -> Option<&str> {
+        match self {
+            TaskDef::Short(_) => None,
+            TaskDef::Full(c) => c.dir.as_deref(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LaneDef {
+    #[serde(default)]
+    description: Option<String>,
+    steps: Vec<Step>,
+    #[serde(default = "default_true")]
+    fail_fast: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Step {
+    TaskRef(String),
+    Inline { run: String },
+    Parallel { parallel: Vec<String> },
+}
+
+pub struct LaneOptions {
+    pub lane: Option<String>,
+    pub list: bool,
+    pub init: bool,
+    pub dry_run: bool,
+    pub json: bool,
+}
+
+pub fn run(opts: LaneOptions) -> Result<()> {
+    if opts.init {
+        return init_lanes();
+    }
+
+    let project_dir = std::env::current_dir().context("getting current directory")?;
+    let config_path = project_dir.join("fledge.toml");
+
+    if !config_path.exists() {
+        bail!(
+            "No fledge.toml found in current directory.\n  Run {} to create one.",
+            style("fledge run --init").cyan()
+        );
+    }
+
+    let content = std::fs::read_to_string(&config_path).context("reading fledge.toml")?;
+    let config: FledgeFileWithLanes = toml::from_str(&content).context("parsing fledge.toml")?;
+
+    if config.lanes.is_empty() {
+        bail!(
+            "No lanes defined in fledge.toml.\n  Add a [lanes] section or run {} to add defaults.",
+            style("fledge lane --init").cyan()
+        );
+    }
+
+    if opts.list || opts.lane.is_none() {
+        return list_lanes(&config.lanes, opts.json);
+    }
+
+    let lane_name = opts.lane.as_ref().unwrap();
+    let lane = config.lanes.get(lane_name).ok_or_else(|| {
+        let available: Vec<&str> = config.lanes.keys().map(|s| s.as_str()).collect();
+        anyhow::anyhow!(
+            "Unknown lane '{}'. Available lanes: {}",
+            lane_name,
+            available.join(", ")
+        )
+    })?;
+
+    if lane.steps.is_empty() {
+        bail!("Lane '{}' has no steps defined", lane_name);
+    }
+
+    validate_lane(lane_name, lane, &config.tasks)?;
+
+    if opts.dry_run {
+        return dry_run_lane(lane_name, lane);
+    }
+
+    execute_lane(lane_name, lane, &config.tasks, &project_dir)
+}
+
+fn list_lanes(lanes: &BTreeMap<String, LaneDef>, json: bool) -> Result<()> {
+    if json {
+        let entries: Vec<serde_json::Value> = lanes
+            .iter()
+            .map(|(name, lane)| {
+                serde_json::json!({
+                    "name": name,
+                    "description": lane.description,
+                    "steps": lane.steps.len(),
+                    "fail_fast": lane.fail_fast,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    println!("{}", style("Available lanes:").bold());
+    let max_name_len = lanes.keys().map(|k| k.len()).max().unwrap_or(0);
+    for (name, lane) in lanes {
+        let desc = lane.description.as_deref().unwrap_or("(no description)");
+        println!(
+            "  {:<width$}  {}",
+            style(name).green(),
+            style(desc).dim(),
+            width = max_name_len
+        );
+    }
+    Ok(())
+}
+
+fn validate_lane(lane_name: &str, lane: &LaneDef, tasks: &BTreeMap<String, TaskDef>) -> Result<()> {
+    for (i, step) in lane.steps.iter().enumerate() {
+        match step {
+            Step::TaskRef(name) => {
+                if !tasks.contains_key(name) {
+                    bail!(
+                        "Lane '{}' step {} references unknown task '{}'.\n  Define it in [tasks] first.",
+                        lane_name,
+                        i + 1,
+                        name
+                    );
+                }
+            }
+            Step::Inline { .. } => {}
+            Step::Parallel { parallel } => {
+                for name in parallel {
+                    if !tasks.contains_key(name) {
+                        bail!(
+                            "Lane '{}' step {} parallel group references unknown task '{}'.\n  Define it in [tasks] first.",
+                            lane_name,
+                            i + 1,
+                            name
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn dry_run_lane(lane_name: &str, lane: &LaneDef) -> Result<()> {
+    let desc = lane.description.as_deref().unwrap_or("(no description)");
+    println!(
+        "{} {} — {}",
+        style("Lane:").bold(),
+        style(lane_name).green(),
+        style(desc).dim()
+    );
+    if !lane.fail_fast {
+        println!("  {} fail_fast = false", style("⚙").dim());
+    }
+    for (i, step) in lane.steps.iter().enumerate() {
+        match step {
+            Step::TaskRef(name) => {
+                println!(
+                    "  {}. {} {}",
+                    i + 1,
+                    style(name).cyan(),
+                    style("(task)").dim()
+                );
+            }
+            Step::Inline { run: cmd } => {
+                println!(
+                    "  {}. {} {}",
+                    i + 1,
+                    style(cmd).cyan(),
+                    style("(inline)").dim()
+                );
+            }
+            Step::Parallel { parallel } => {
+                println!(
+                    "  {}. {} {}",
+                    i + 1,
+                    style(parallel.join(", ")).cyan(),
+                    style("(parallel)").dim()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn execute_lane(
+    lane_name: &str,
+    lane: &LaneDef,
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+) -> Result<()> {
+    let desc = lane.description.as_deref().unwrap_or("(no description)");
+    println!(
+        "{} {} — {}",
+        style("▸ Lane:").cyan().bold(),
+        style(lane_name).bold(),
+        style(desc).dim()
+    );
+
+    let total_steps = lane.steps.len();
+    let mut failures: Vec<String> = Vec::new();
+
+    for (i, step) in lane.steps.iter().enumerate() {
+        let result = match step {
+            Step::TaskRef(name) => execute_task_with_deps(name, tasks, project_dir),
+            Step::Inline { run: cmd } => execute_inline(cmd, project_dir),
+            Step::Parallel { parallel } => execute_parallel(parallel, tasks, project_dir),
+        };
+
+        if let Err(e) = result {
+            let step_desc = match step {
+                Step::TaskRef(name) => name.clone(),
+                Step::Inline { run: cmd } => cmd.clone(),
+                Step::Parallel { parallel } => format!("parallel({})", parallel.join(", ")),
+            };
+            if lane.fail_fast {
+                bail!(
+                    "Lane '{}' failed at step {} ({}): {}",
+                    lane_name,
+                    i + 1,
+                    step_desc,
+                    e
+                );
+            }
+            eprintln!(
+                "  {} Step {} ({}) failed: {}",
+                style("✗").red().bold(),
+                i + 1,
+                step_desc,
+                e
+            );
+            failures.push(step_desc);
+        }
+    }
+
+    if failures.is_empty() {
+        println!(
+            "{} Lane {} completed ({} steps)",
+            style("✓").green().bold(),
+            style(lane_name).green(),
+            total_steps
+        );
+    } else {
+        bail!(
+            "Lane '{}' completed with {} failure(s): {}",
+            lane_name,
+            failures.len(),
+            failures.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_task_with_deps(
+    name: &str,
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+) -> Result<()> {
+    let task = tasks
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("Task '{}' not found", name))?;
+
+    for dep in task.deps() {
+        execute_task_with_deps(dep, tasks, project_dir)?;
+    }
+
+    execute_single_task(name, task, project_dir)
+}
+
+fn execute_single_task(name: &str, task: &TaskDef, project_dir: &Path) -> Result<()> {
+    println!(
+        "  {} {}",
+        style("▸").cyan().bold(),
+        style(format!("Running task: {name}")).bold()
+    );
+
+    let cmd_str = task.cmd();
+    let work_dir = match task.dir() {
+        Some(d) => project_dir.join(d),
+        None => project_dir.to_path_buf(),
+    };
+
+    let shell = if cfg!(windows) { "cmd" } else { "sh" };
+    let flag = if cfg!(windows) { "/C" } else { "-c" };
+
+    let mut command = Command::new(shell);
+    command.arg(flag).arg(cmd_str).current_dir(&work_dir);
+
+    for (key, value) in task.env() {
+        command.env(key, value);
+    }
+
+    let status = command
+        .status()
+        .with_context(|| format!("running task '{name}'"))?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        bail!("Task '{}' failed with exit code {}", name, code);
+    }
+
+    Ok(())
+}
+
+fn execute_inline(cmd: &str, project_dir: &Path) -> Result<()> {
+    println!(
+        "  {} {}",
+        style("▸").cyan().bold(),
+        style(format!("Running: {cmd}")).bold()
+    );
+
+    let shell = if cfg!(windows) { "cmd" } else { "sh" };
+    let flag = if cfg!(windows) { "/C" } else { "-c" };
+
+    let status = Command::new(shell)
+        .arg(flag)
+        .arg(cmd)
+        .current_dir(project_dir)
+        .status()
+        .with_context(|| format!("running inline command: {cmd}"))?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        bail!("Inline command failed with exit code {}: {}", code, cmd);
+    }
+
+    Ok(())
+}
+
+fn execute_parallel(
+    task_names: &[String],
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+) -> Result<()> {
+    let names_display = task_names.join(", ");
+    println!(
+        "  {} {}",
+        style("▸").cyan().bold(),
+        style(format!("Running parallel: {names_display}")).bold()
+    );
+
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+    thread::scope(|s| {
+        let mut handles = Vec::new();
+
+        for name in task_names {
+            let errors = Arc::clone(&errors);
+            let handle = s.spawn(move || {
+                if let Err(e) = execute_task_with_deps(name, tasks, project_dir) {
+                    let mut errs = errors.lock().unwrap();
+                    errs.push(format!("{}: {}", name, e));
+                }
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    });
+
+    let errs = errors.lock().unwrap();
+    if !errs.is_empty() {
+        bail!("Parallel step failed:\n  {}", errs.join("\n  "));
+    }
+
+    Ok(())
+}
+
+fn lane_defaults(project_type: &str) -> &'static str {
+    match project_type {
+        "rust" => {
+            r#"
+[lanes.ci]
+description = "Run full CI pipeline"
+steps = ["fmt", "lint", "test", "build"]
+
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test"
+]
+"#
+        }
+        "node" => {
+            r#"
+[lanes.ci]
+description = "Run full CI pipeline"
+steps = ["lint", "test", "build"]
+
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["lint", "test"] },
+]
+"#
+        }
+        "go" => {
+            r#"
+[lanes.ci]
+description = "Run full CI pipeline"
+steps = ["fmt", "lint", "test", "build"]
+
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test"
+]
+"#
+        }
+        "python" => {
+            r#"
+[lanes.ci]
+description = "Run full CI pipeline"
+steps = ["fmt", "lint", "typecheck", "test"]
+
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test"
+]
+"#
+        }
+        _ => {
+            r#"
+[lanes.ci]
+description = "Run full CI pipeline"
+steps = ["lint", "test", "build"]
+"#
+        }
+    }
+}
+
+fn init_lanes() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let path = cwd.join("fledge.toml");
+
+    if !path.exists() {
+        bail!(
+            "No fledge.toml found. Run {} first, then add lanes.",
+            style("fledge run --init").cyan()
+        );
+    }
+
+    let content = std::fs::read_to_string(&path).context("reading fledge.toml")?;
+
+    if content.contains("[lanes") {
+        bail!("Lanes already defined in fledge.toml. Edit them manually.");
+    }
+
+    let project_type = detect_project_type(&cwd);
+    let defaults = lane_defaults(project_type);
+
+    let new_content = format!("{}{}", content.trim_end(), defaults);
+    std::fs::write(&path, new_content).context("writing fledge.toml")?;
+
+    println!(
+        "{} Added default lanes to {}",
+        style("✓").green().bold(),
+        style("fledge.toml").cyan()
+    );
+    println!("  Run {} to see them.", style("fledge lane").cyan());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_config(toml_str: &str) -> FledgeFileWithLanes {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn parse_sequential_lane() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+test = "cargo test"
+build = "cargo build"
+
+[lanes.ci]
+description = "CI pipeline"
+steps = ["lint", "test", "build"]
+"#,
+        );
+        assert_eq!(config.lanes.len(), 1);
+        assert_eq!(config.lanes["ci"].steps.len(), 3);
+        assert!(config.lanes["ci"].fail_fast);
+    }
+
+    #[test]
+    fn parse_inline_step() {
+        let config = parse_config(
+            r#"
+[tasks]
+test = "cargo test"
+
+[lanes.release]
+description = "Release"
+steps = [
+  "test",
+  { run = "cargo build --release" },
+]
+"#,
+        );
+        assert_eq!(config.lanes["release"].steps.len(), 2);
+        match &config.lanes["release"].steps[1] {
+            Step::Inline { run: cmd } => assert_eq!(cmd, "cargo build --release"),
+            _ => panic!("expected inline step"),
+        }
+    }
+
+    #[test]
+    fn parse_parallel_step() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+fmt = "cargo fmt --check"
+test = "cargo test"
+
+[lanes.check]
+description = "Quick check"
+steps = [
+  { parallel = ["lint", "fmt"] },
+  "test"
+]
+"#,
+        );
+        assert_eq!(config.lanes["check"].steps.len(), 2);
+        match &config.lanes["check"].steps[0] {
+            Step::Parallel { parallel } => {
+                assert_eq!(parallel, &["lint", "fmt"]);
+            }
+            _ => panic!("expected parallel step"),
+        }
+    }
+
+    #[test]
+    fn parse_fail_fast_false() {
+        let config = parse_config(
+            r#"
+[tasks]
+a = "echo a"
+b = "echo b"
+
+[lanes.audit]
+description = "Audit"
+fail_fast = false
+steps = ["a", "b"]
+"#,
+        );
+        assert!(!config.lanes["audit"].fail_fast);
+    }
+
+    #[test]
+    fn parse_fail_fast_default_true() {
+        let config = parse_config(
+            r#"
+[tasks]
+a = "echo a"
+
+[lanes.ci]
+steps = ["a"]
+"#,
+        );
+        assert!(config.lanes["ci"].fail_fast);
+    }
+
+    #[test]
+    fn validate_unknown_task_ref() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+
+[lanes.ci]
+steps = ["lint", "nonexistent"]
+"#,
+        );
+        let result = validate_lane("ci", &config.lanes["ci"], &config.tasks);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn validate_unknown_parallel_ref() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+
+[lanes.check]
+steps = [{ parallel = ["lint", "ghost"] }]
+"#,
+        );
+        let result = validate_lane("check", &config.lanes["check"], &config.tasks);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn validate_inline_always_ok() {
+        let config = parse_config(
+            r#"
+[tasks]
+
+[lanes.ci]
+steps = [{ run = "echo hello" }]
+"#,
+        );
+        let result = validate_lane("ci", &config.lanes["ci"], &config.tasks);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_all_valid_refs() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+test = "cargo test"
+build = "cargo build"
+
+[lanes.ci]
+steps = ["lint", "test", "build"]
+"#,
+        );
+        let result = validate_lane("ci", &config.lanes["ci"], &config.tasks);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_multiple_lanes() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+test = "cargo test"
+build = "cargo build"
+
+[lanes.ci]
+description = "CI"
+steps = ["lint", "test", "build"]
+
+[lanes.quick]
+description = "Quick"
+steps = ["lint"]
+"#,
+        );
+        assert_eq!(config.lanes.len(), 2);
+        assert!(config.lanes.contains_key("ci"));
+        assert!(config.lanes.contains_key("quick"));
+    }
+
+    #[test]
+    fn parse_no_lanes_section() {
+        let config = parse_config(
+            r#"
+[tasks]
+build = "cargo build"
+"#,
+        );
+        assert!(config.lanes.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_lanes_section() {
+        let config = parse_config(
+            r#"
+[tasks]
+build = "cargo build"
+
+[lanes]
+"#,
+        );
+        assert!(config.lanes.is_empty());
+    }
+
+    #[test]
+    fn parse_mixed_step_types() {
+        let config = parse_config(
+            r#"
+[tasks]
+test = "cargo test"
+lint = "cargo clippy"
+
+[lanes.full]
+steps = [
+  "test",
+  { run = "echo done" },
+  { parallel = ["test", "lint"] },
+]
+"#,
+        );
+        assert_eq!(config.lanes["full"].steps.len(), 3);
+        assert!(matches!(&config.lanes["full"].steps[0], Step::TaskRef(_)));
+        assert!(matches!(
+            &config.lanes["full"].steps[1],
+            Step::Inline { .. }
+        ));
+        assert!(matches!(
+            &config.lanes["full"].steps[2],
+            Step::Parallel { .. }
+        ));
+    }
+
+    #[test]
+    fn execute_sequential_lane_echo() {
+        let config = parse_config(
+            r#"
+[tasks]
+a = "echo step-a"
+b = "echo step-b"
+
+[lanes.seq]
+description = "Sequential"
+steps = ["a", "b"]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("seq", &config.lanes["seq"], &config.tasks, &project_dir);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_inline_step() {
+        let config = parse_config(
+            r#"
+[tasks]
+
+[lanes.inline]
+steps = [{ run = "echo inline-works" }]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane(
+            "inline",
+            &config.lanes["inline"],
+            &config.tasks,
+            &project_dir,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_parallel_step() {
+        let config = parse_config(
+            r#"
+[tasks]
+a = "echo parallel-a"
+b = "echo parallel-b"
+
+[lanes.par]
+steps = [{ parallel = ["a", "b"] }]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("par", &config.lanes["par"], &config.tasks, &project_dir);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_fail_fast_stops() {
+        let config = parse_config(
+            r#"
+[tasks]
+fail = "exit 1"
+ok = "echo ok"
+
+[lanes.ff]
+fail_fast = true
+steps = ["fail", "ok"]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("ff", &config.lanes["ff"], &config.tasks, &project_dir);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("failed at step 1"));
+    }
+
+    #[test]
+    fn execute_no_fail_fast_continues() {
+        let config = parse_config(
+            r#"
+[tasks]
+fail = "exit 1"
+ok = "echo ok"
+
+[lanes.noff]
+fail_fast = false
+steps = ["fail", "ok"]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("noff", &config.lanes["noff"], &config.tasks, &project_dir);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("1 failure"));
+    }
+
+    #[test]
+    fn execute_task_deps_in_lane() {
+        let config = parse_config(
+            r#"
+[tasks.build]
+cmd = "echo building"
+deps = ["prep"]
+
+[tasks.prep]
+cmd = "echo preparing"
+
+[lanes.ci]
+steps = ["build"]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("ci", &config.lanes["ci"], &config.tasks, &project_dir);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn lane_defaults_are_valid_toml() {
+        for project_type in &["rust", "node", "go", "python", "generic"] {
+            let tasks = match *project_type {
+                "rust" => {
+                    "[tasks]\nfmt = \"cargo fmt\"\nlint = \"cargo clippy\"\ntest = \"cargo test\"\nbuild = \"cargo build\"\ntypecheck = \"echo ok\"\n"
+                }
+                "node" => {
+                    "[tasks]\nlint = \"echo lint\"\ntest = \"echo test\"\nbuild = \"echo build\"\n"
+                }
+                "go" => {
+                    "[tasks]\nfmt = \"echo fmt\"\nlint = \"echo lint\"\ntest = \"echo test\"\nbuild = \"echo build\"\n"
+                }
+                "python" => {
+                    "[tasks]\nfmt = \"echo fmt\"\nlint = \"echo lint\"\ntypecheck = \"echo tc\"\ntest = \"echo test\"\n"
+                }
+                _ => {
+                    "[tasks]\nlint = \"echo lint\"\ntest = \"echo test\"\nbuild = \"echo build\"\n"
+                }
+            };
+            let defaults = lane_defaults(project_type);
+            let toml_str = format!("{}{}", tasks, defaults);
+            let result: Result<FledgeFileWithLanes, _> = toml::from_str(&toml_str);
+            assert!(
+                result.is_ok(),
+                "Invalid TOML for {}: {:?}",
+                project_type,
+                result.err()
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod doctor;
 mod github;
 mod init;
 mod issues;
+mod lanes;
 mod metrics;
 mod prompts;
 mod prs;
@@ -196,6 +197,23 @@ enum Commands {
         /// List available tasks
         #[arg(short, long)]
         list: bool,
+    },
+    /// Run a composable workflow pipeline
+    Lane {
+        /// Lane name to run (lists lanes if omitted)
+        lane: Option<String>,
+        /// List available lanes
+        #[arg(short, long)]
+        list: bool,
+        /// Add default lanes to fledge.toml
+        #[arg(long)]
+        init: bool,
+        /// Show execution plan without running
+        #[arg(long)]
+        dry_run: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Generate a changelog from git tags and commits
     Changelog {
@@ -502,6 +520,21 @@ fn run() -> Result<()> {
         }
         Commands::Review { base, file } => {
             review::run(review::ReviewOptions { base, file })?;
+        }
+        Commands::Lane {
+            lane,
+            list,
+            init,
+            dry_run,
+            json,
+        } => {
+            lanes::run(lanes::LaneOptions {
+                lane,
+                list,
+                init,
+                dry_run,
+                json,
+            })?;
         }
         Commands::Changelog {
             limit,


### PR DESCRIPTION
## Summary

Implements **Lanes** (#59) — the backbone of the v1.0 release. Lanes define composable, multi-step workflow pipelines in `fledge.toml`.

### What it does

- **`fledge lane`** — lists available lanes
- **`fledge lane <name>`** — runs a lane (sequential steps by default)
- **`fledge lane --init`** — adds language-aware default lanes to `fledge.toml`
- **`fledge lane --dry-run`** — prints the execution plan without running
- **`--json`** output for scripting

### Lane syntax in `fledge.toml`

```toml
[lanes.ci]
description = "Full CI pipeline"
steps = ["lint", "test", "build"]

[lanes.release]
steps = [
  "test",
  { run = "cargo build --release" },
  "publish"
]

[lanes.check]
description = "Parallel quality checks"
steps = [
  { parallel = ["lint", "fmt"] },
  "test"
]
```

### Step types

| Type | Format | Description |
|------|--------|-------------|
| Task reference | `"task_name"` | Runs a task from `[tasks]` |
| Inline command | `{ run = "command" }` | Runs a shell command directly |
| Parallel group | `{ parallel = ["a", "b"] }` | Runs tasks concurrently via threads |

### Key features

- **Validation before execution** — all task references checked before anything runs
- **fail_fast** (default true) — stops on first failure, or set to `false` to continue and report all failures
- **Task dependency resolution** — deps within tasks still respected inside lanes
- **Parallel execution** — `{ parallel = [...] }` groups run concurrently using `thread::scope`
- **Language-aware defaults** — `--init` generates `ci` and `check` lanes based on detected project type

### Files changed

- `src/lanes.rs` — new module (full implementation + 20 tests)
- `src/main.rs` — `Lane` subcommand + dispatch
- `specs/lanes/lanes.spec.md` — spec-sync spec

### Verification

- 279 unit tests + 10 integration tests pass
- 0 clippy warnings
- 0 spec errors
- `cargo fmt --check` clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)