### PR TITLE
feat: v1.0.0 — config init preset, version bump, branding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fledge"
-version = "0.7.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
-description = "Corvid-themed project scaffolding CLI — get your projects ready to fly."
+description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."
 readme = "README.md"
 license = "MIT"
 homepage = "https://github.com/CorvidLabs/fledge"
 repository = "https://github.com/CorvidLabs/fledge"
 rust-version = "1.85"
-keywords = ["cli", "scaffold", "template", "project-init"]
+keywords = ["cli", "scaffold", "template", "task-runner", "dev-tools"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,6 +230,63 @@ impl Config {
     }
 }
 
+pub fn init_config(preset: Option<&str>) -> Result<()> {
+    use console::style;
+
+    let path = Config::config_path();
+    if path.exists() {
+        anyhow::bail!(
+            "Config already exists at {}.\n  Use {} to modify it.",
+            style(path.display()).dim(),
+            style("fledge config set").cyan()
+        );
+    }
+
+    let mut config = Config::default();
+
+    if let Some(preset_name) = preset {
+        match preset_name {
+            "corvidlabs" => {
+                config.defaults.author = Some("CorvidLabs".to_string());
+                config.defaults.github_org = Some("CorvidLabs".to_string());
+                config.defaults.license = Some("MIT".to_string());
+                config
+                    .templates
+                    .repos
+                    .push("CorvidLabs/fledge-templates".to_string());
+            }
+            _ => {
+                anyhow::bail!(
+                    "Unknown preset '{}'. Available presets: {}",
+                    preset_name,
+                    style("corvidlabs").cyan()
+                );
+            }
+        }
+        config.save()?;
+        println!(
+            "{} Created config with {} preset at {}",
+            style("✓").green().bold(),
+            style(preset_name).cyan(),
+            style(path.display()).dim()
+        );
+    } else {
+        config.save()?;
+        println!(
+            "{} Created default config at {}",
+            style("✓").green().bold(),
+            style(path.display()).dim()
+        );
+    }
+
+    println!(
+        "  Edit with: {}",
+        style("fledge config set <key> <value>").cyan()
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -568,6 +625,23 @@ repos = ["CorvidLabs/fledge-templates", "user/my-templates"]
     fn remove_from_list_scalar_key_errors() {
         let mut config = Config::default();
         assert!(config.remove_from_list("defaults.author", "val").is_err());
+    }
+
+    #[test]
+    fn corvidlabs_preset_sets_expected_values() {
+        let mut config = Config::default();
+        config.defaults.author = Some("CorvidLabs".to_string());
+        config.defaults.github_org = Some("CorvidLabs".to_string());
+        config.defaults.license = Some("MIT".to_string());
+        config
+            .templates
+            .repos
+            .push("CorvidLabs/fledge-templates".to_string());
+
+        assert_eq!(config.defaults.author.as_deref(), Some("CorvidLabs"));
+        assert_eq!(config.github_org().as_deref(), Some("CorvidLabs"));
+        assert_eq!(config.license(), "MIT");
+        assert_eq!(config.template_repos(), &["CorvidLabs/fledge-templates"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@ mod versioning;
 mod work;
 
 #[derive(Parser)]
-#[command(name = "fledge", version, about = "Get your projects ready to fly.")]
+#[command(
+    name = "fledge",
+    version,
+    about = "Dev-lifecycle CLI — get your projects ready to fly."
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -393,6 +397,12 @@ enum ConfigAction {
     List,
     /// Show config file path
     Path,
+    /// Initialize config with a preset (e.g. corvidlabs)
+    Init {
+        /// Preset name (available: corvidlabs)
+        #[arg(long)]
+        preset: Option<String>,
+    },
 }
 
 #[derive(clap::Subcommand)]
@@ -781,6 +791,9 @@ fn handle_config(action: ConfigAction) -> Result<()> {
         }
         ConfigAction::Path => {
             println!("{}", config::Config::config_path().display());
+        }
+        ConfigAction::Init { preset } => {
+            config::init_config(preset.as_deref())?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

- Adds `fledge config init [--preset corvidlabs]` for quick onboarding (#8 partial)
- Bumps version to **1.0.0**
- Updates CLI about text to "Dev-lifecycle CLI" 
- Updates Cargo.toml description and keywords to reflect expanded scope

## What's in 1.0.0

| Feature | PR |
|---------|------|
| Lanes — composable workflows | #69 |
| Plugins — community extensions | #70 |
| Config init presets | this PR |
| Deps, doctor, metrics | #62, #66, #68 |
| All v0.1-v0.7 features | scaffolding, tasks, specs, issues, PRs, review, search, publish, etc. |

## Test plan

- [x] `fledge --version` shows `1.0.0`
- [x] `fledge config init --help` shows preset option
- [x] `fledge config init --preset corvidlabs` sets CorvidLabs defaults
- [x] Unknown preset errors gracefully
- [x] All 315 unit + 10 integration tests pass
- [x] 0 clippy warnings, fmt clean, 25 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)