### PR TITLE
docs: update all documentation for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # fledge
 
-Get your projects ready to fly.
+Dev-lifecycle CLI — get your projects ready to fly.
 
-A fast, opinionated dev-lifecycle CLI built in Rust. Scaffold projects from templates, manage specs, run tasks, check CI, review code, and ship — all from one binary.
+A fast, opinionated CLI built in Rust. Scaffold projects, run tasks, compose workflow pipelines, manage plugins, check dependencies, review code, and ship — all from one binary.
 
 ## Why fledge?
 
 - **Fast** — native Rust binary, no runtime dependencies
 - **Smart defaults** — pulls author/org from git config, renders dates, computes name variants automatically
 - **Remote templates** — use any GitHub repo as a template source with `owner/repo` syntax
-- **Full lifecycle** — scaffolding, specs, tasks, CI checks, changelogs, GitHub ops, AI review
+- **Full lifecycle** — scaffolding, tasks, lanes, specs, CI checks, changelogs, GitHub ops, AI review
+- **Composable lanes** — chain tasks into named pipelines with parallel execution
+- **Plugin system** — community extensions via external executables (git-style)
 - **Language-agnostic** — auto-detects Rust, Node, Go, Python, Ruby, Java and adapts defaults
-- **Extensible** — create your own templates with a simple `template.toml` manifest
+- **Extensible** — create templates, plugins, and custom lane steps
 - **Safe** — remote template hooks require explicit confirmation before running
 - **Optional TUI** — interactive template browser with `--features tui`
 
@@ -56,6 +58,20 @@ fledge init my-tool --template rust-cli --dry-run
 # Run project tasks
 fledge run build
 fledge run test
+
+# Compose workflow pipelines
+fledge lane --init       # add default lanes
+fledge lane ci           # run the CI lane
+fledge lane ci --dry-run # preview execution plan
+
+# Project health
+fledge doctor            # environment diagnostics
+fledge metrics           # LOC by language
+fledge deps --outdated   # check for outdated deps
+
+# Plugins
+fledge plugin search deploy
+fledge plugin install someone/fledge-deploy
 
 # Check CI status
 fledge checks
@@ -153,6 +169,51 @@ Options:
   -l, --list          List available tasks
 ```
 
+#### `fledge lane [name]`
+
+Run a composable workflow pipeline. Lanes chain tasks into named pipelines with parallel execution groups.
+
+```
+Options:
+  -l, --list          List available lanes
+      --init          Add default lanes to fledge.toml
+      --dry-run       Show execution plan without running
+      --json          Output as JSON
+```
+
+#### `fledge doctor`
+
+Diagnose project environment health (tools, config, issues).
+
+```
+Options:
+      --json          Output as JSON
+```
+
+#### `fledge metrics`
+
+Project code metrics — LOC by language, file churn, test ratio.
+
+```
+Options:
+      --churn         Show most-changed files from git history
+      --tests         Show test file detection and ratio
+  -l, --limit         Maximum entries for churn [default: 20]
+      --json          Output as JSON
+```
+
+#### `fledge deps`
+
+Check dependency health across ecosystems.
+
+```
+Options:
+      --outdated      Check for outdated dependencies
+      --audit         Run security audit
+      --licenses      Show dependency licenses
+      --json          Output as JSON
+```
+
 #### `fledge spec <action>`
 
 Manage spec-sync specifications (source of truth for modules).
@@ -238,6 +299,25 @@ Options:
 
 Ask a question about your codebase via Claude CLI.
 
+### Plugins
+
+#### `fledge plugin <action>`
+
+Manage community extensions — install, remove, list, and search.
+
+```
+Subcommands:
+  install <source>     Install a plugin from GitHub (owner/repo)
+  remove <name>        Remove an installed plugin
+  list                 List installed plugins
+  search [query]       Search for plugins on GitHub
+  run <name> [args]    Run a plugin command
+
+Options:
+      --json           Output as JSON
+      --force          Reinstall if already present (install only)
+```
+
 ### Configuration
 
 #### `fledge config <action>`
@@ -253,6 +333,7 @@ Subcommands:
   remove <key> <value> Remove a value from a list
   list                Show all config values
   path                Show config file path
+  init [--preset]     Initialize config (presets: corvidlabs)
 ```
 
 #### `fledge completions [shell]`

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -291,6 +291,175 @@ fledge changelog --tag v0.7.0
 
 ---
 
+### fledge lane `[name]`
+
+Run a composable workflow pipeline defined in `fledge.toml`. Lanes chain multiple tasks into named pipelines with parallel execution and configurable failure behavior.
+
+#### Usage
+
+```
+fledge lane [name] [OPTIONS]
+```
+
+#### Arguments
+
+- `[name]` — Lane name to run (lists lanes if omitted)
+
+#### Options
+
+- `-l, --list` — List available lanes
+- `--init` — Add default lanes to `fledge.toml` (language-aware)
+- `--dry-run` — Show execution plan without running
+- `--json` — Output as JSON
+
+#### Lane Configuration
+
+Lanes are defined in `fledge.toml` alongside tasks:
+
+```toml
+[lanes.ci]
+description = "Full CI pipeline"
+steps = ["lint", "test", "build"]
+
+[lanes.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["lint", "fmt"] },
+  "test"
+]
+
+[lanes.release]
+description = "Build and publish"
+fail_fast = false
+steps = [
+  "test",
+  { run = "cargo build --release" },
+  "publish"
+]
+```
+
+#### Step Types
+
+| Type | Syntax | Description |
+|------|--------|-------------|
+| Task reference | `"task_name"` | Runs a task from `[tasks]` |
+| Inline command | `{ run = "command" }` | Runs a shell command |
+| Parallel group | `{ parallel = ["a", "b"] }` | Runs tasks concurrently |
+
+#### Examples
+
+```bash
+# List lanes
+fledge lane
+
+# Run the CI lane
+fledge lane ci
+
+# Preview without running
+fledge lane ci --dry-run
+
+# Add default lanes for your project type
+fledge lane --init
+```
+
+---
+
+### fledge doctor
+
+Diagnose project environment health. Checks for required tools, validates configuration, and reports issues.
+
+#### Usage
+
+```
+fledge doctor [OPTIONS]
+```
+
+#### Options
+
+- `--json` — Output as JSON
+
+---
+
+### fledge metrics
+
+Project code metrics — lines of code by language, file churn, and test coverage ratio.
+
+#### Usage
+
+```
+fledge metrics [OPTIONS]
+```
+
+#### Options
+
+- `--churn` — Show most-changed files from git history
+- `--tests` — Show test file detection and test-to-code ratio
+- `-l, --limit <N>` — Maximum entries for churn output [default: `20`]
+- `--json` — Output as JSON
+
+#### Examples
+
+```bash
+# LOC breakdown by language
+fledge metrics
+
+# Most frequently changed files
+fledge metrics --churn
+
+# Test coverage ratio
+fledge metrics --tests
+
+# All metrics as JSON
+fledge metrics --churn --tests --json
+```
+
+---
+
+### fledge deps
+
+Check dependency health — list dependencies, find outdated packages, run security audits, and scan licenses.
+
+#### Usage
+
+```
+fledge deps [OPTIONS]
+```
+
+#### Options
+
+- `--outdated` — Check for outdated dependencies
+- `--audit` — Run security audit via ecosystem tools
+- `--licenses` — Show dependency licenses
+- `--json` — Output as JSON
+
+#### Supported Ecosystems
+
+| Ecosystem | Detection | Outdated | Audit | Licenses |
+|-----------|-----------|----------|-------|----------|
+| Rust | `Cargo.lock` | `cargo outdated` | `cargo audit` | `cargo license` |
+| Node.js | `package-lock.json` / `yarn.lock` | `npm outdated` / `yarn outdated` | `npm audit` / `yarn audit` | `license-checker` |
+| Go | `go.sum` | `go list` | `govulncheck` | — |
+| Python | `requirements.txt` / `Pipfile.lock` / `poetry.lock` | `pip list --outdated` | `pip-audit` | — |
+| Ruby | `Gemfile.lock` | `bundle outdated` | `bundle audit` | — |
+
+#### Examples
+
+```bash
+# List all dependencies
+fledge deps
+
+# Check for outdated packages
+fledge deps --outdated
+
+# Run security audit
+fledge deps --audit
+
+# Full health check as JSON
+fledge deps --outdated --audit --licenses --json
+```
+
+---
+
 ## GitHub Integration Commands
 
 ### fledge issues `[view <number>]`
@@ -387,6 +556,88 @@ fledge ask "what tests cover the config module?"
 
 ---
 
+## Plugin Commands
+
+### fledge plugin `<action>`
+
+Manage plugins — install, remove, list, and search community extensions.
+
+#### Usage
+
+```
+fledge plugin <install|remove|list|search|run> [OPTIONS]
+```
+
+#### Subcommands
+
+##### `fledge plugin install <source>`
+
+Install a plugin from GitHub. Clones the repo, reads `plugin.toml`, and symlinks binaries.
+
+- `<source>` — GitHub repo (`owner/repo`) or full URL
+- `--force` — Reinstall if already present
+
+##### `fledge plugin remove <name>`
+
+Remove an installed plugin and clean up symlinks.
+
+##### `fledge plugin list`
+
+List installed plugins with name, version, source, and commands.
+
+##### `fledge plugin search [query]`
+
+Search for plugins on GitHub using the `fledge-plugin` topic.
+
+- `-l, --limit <N>` — Maximum results [default: `20`]
+
+##### `fledge plugin run <name> [args...]`
+
+Run a plugin command with additional arguments.
+
+#### Global Options
+
+- `--json` — Output as JSON (for `list` and `search`)
+
+#### Plugin Format
+
+Plugins are repositories containing a `plugin.toml` manifest:
+
+```toml
+[plugin]
+name = "fledge-deploy"
+version = "0.1.0"
+description = "Deploy to cloud providers"
+author = "someone"
+
+[[commands]]
+name = "deploy"
+description = "Deploy the project"
+binary = "fledge-deploy"
+
+[[hooks]]
+event = "lane:post"
+binary = "fledge-deploy-notify"
+```
+
+#### Examples
+
+```bash
+# Install a plugin
+fledge plugin install someone/fledge-deploy
+
+# List installed plugins
+fledge plugin list
+
+# Search for plugins
+fledge plugin search deploy
+
+# Remove a plugin
+fledge plugin remove fledge-deploy
+```
+
+---
+
 ## Configuration Commands
 
 ### fledge config `<action>`
@@ -396,7 +647,7 @@ Manage global configuration stored in `~/.config/fledge/config.toml`.
 #### Usage
 
 ```
-fledge config <get|set|unset|add|remove|list|path>
+fledge config <get|set|unset|add|remove|list|path|init>
 ```
 
 #### Subcommands
@@ -410,6 +661,7 @@ fledge config <get|set|unset|add|remove|list|path>
 | `remove <key> <value>` | Remove a value from a list key |
 | `list` | Show all config values |
 | `path` | Show config file path |
+| `init [--preset <name>]` | Initialize config (presets: `corvidlabs`) |
 
 #### Valid Keys
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,6 +2,18 @@
 
 Configure fledge to customize defaults and add custom template repositories.
 
+## Quick Setup with Presets
+
+Initialize config with a preset for fast onboarding:
+
+```bash
+# CorvidLabs preset — sets author, org, license, and template repo
+fledge config init --preset corvidlabs
+
+# Default config with MIT license
+fledge config init
+```
+
 ## Config File Location
 
 fledge reads configuration from:

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -47,6 +47,40 @@ fledge run build     # run the build task
 fledge run test      # run tests
 ```
 
+## Compose Workflow Pipelines
+
+Lanes chain tasks into named pipelines — think `fledge lane ci` to run lint, test, and build in sequence:
+
+```bash
+fledge lane --init       # add default lanes for your project type
+fledge lane              # list available lanes
+fledge lane ci           # run the CI lane
+fledge lane ci --dry-run # preview the execution plan
+```
+
+Lanes support parallel execution groups and inline commands. See the [CLI Reference](../cli-reference.md) for full configuration.
+
+## Check Project Health
+
+```bash
+fledge doctor            # diagnose environment issues
+fledge metrics           # LOC breakdown by language
+fledge metrics --churn   # most frequently changed files
+fledge deps              # list all dependencies
+fledge deps --outdated   # find outdated packages
+fledge deps --audit      # run security audit
+```
+
+## Install Plugins
+
+Extend fledge with community plugins:
+
+```bash
+fledge plugin search deploy   # find plugins on GitHub
+fledge plugin install someone/fledge-deploy
+fledge plugin list            # see installed plugins
+```
+
 ## Start a Feature Branch
 
 Use the workflow commands to manage branches and PRs:

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,28 +1,31 @@
 # Introduction
 
-Get your projects ready to fly.
+Dev-lifecycle CLI — get your projects ready to fly.
 
-**fledge** is a fast, opinionated dev-lifecycle CLI built in Rust. Scaffold projects from templates, manage specs, run tasks, check CI, review code, and ship — all from one binary.
+**fledge** is a fast, opinionated CLI built in Rust. Scaffold projects, run tasks, compose workflow pipelines, manage plugins, check dependencies, review code, and ship — all from one binary.
 
 ## Why fledge?
 
 - **Fast** — native Rust binary, no runtime dependencies
 - **Smart defaults** — pulls author/org from git config, renders dates, computes name variants automatically
 - **Remote templates** — use any GitHub repo as a template source with `owner/repo` syntax
-- **Full lifecycle** — scaffolding, specs, tasks, CI checks, changelogs, GitHub ops, AI review
+- **Full lifecycle** — scaffolding, tasks, lanes, specs, CI checks, changelogs, GitHub ops, AI review
+- **Composable lanes** — chain tasks into named pipelines with parallel execution
+- **Plugin system** — community extensions via external executables (git-style)
 - **Language-agnostic** — auto-detects Rust, Node, Go, Python, Ruby, Java and adapts defaults
-- **Extensible** — create your own templates with a simple `template.toml` manifest
+- **Extensible** — create templates, plugins, and custom lane steps
 - **Safe** — remote template hooks require explicit confirmation before running
 - **Optional TUI** — interactive template browser with `--features tui`
 
-fledge is designed to be the one CLI you reach for throughout the dev lifecycle. Start a project with `init`, manage specs with `spec`, run tasks with `run`, check CI with `checks`, review code with `review`, and generate changelogs with `changelog`. Whether you're scaffolding a Rust CLI, a Go service, or a TypeScript project, fledge provides a consistent, powerful toolset with sensible defaults that just work.
+fledge is designed to be the one CLI you reach for throughout the dev lifecycle. Start a project with `init`, define tasks in `fledge.toml` and compose them into lanes with `lane`, manage specs with `spec`, check dependencies with `deps`, review code with `review`, and extend with community plugins via `plugin`. Whether you're scaffolding a Rust CLI, a Go service, or a TypeScript project, fledge provides a consistent, powerful toolset with sensible defaults that just work.
 
 ## What can fledge do?
 
 | Category | Commands | Description |
 |----------|----------|-------------|
 | **Scaffolding** | `init`, `list`, `create-template`, `search`, `publish`, `update` | Create projects from templates, discover and share templates |
-| **Project Lifecycle** | `run`, `spec`, `work`, `changelog` | Task runner, spec management, git workflow, changelog generation |
+| **Project Lifecycle** | `run`, `lane`, `spec`, `work`, `changelog` | Task runner, workflow pipelines, spec management, git workflow |
+| **Project Health** | `doctor`, `metrics`, `deps` | Environment diagnostics, code metrics, dependency auditing |
 | **GitHub** | `issues`, `prs`, `checks` | View issues, PRs, and CI status from the terminal |
 | **AI-Powered** | `review`, `ask` | Code review and codebase Q&A via Claude |
-| **Configuration** | `config`, `completions`, `tui` | Global settings, shell completions, interactive UI |
+| **Extensibility** | `plugin`, `config`, `completions`, `tui` | Plugins, global settings, shell completions, interactive UI |


### PR DESCRIPTION
## Summary

- Updates README, CLI reference, introduction, quick start, and configuration docs for 1.0.0
- Adds documentation for 5 new commands: `lane`, `plugin`, `doctor`, `metrics`, `deps`
- Updates `config` docs to include `init --preset` subcommand
- Refreshes branding from "scaffolding CLI" to "dev-lifecycle CLI"

## Files changed

| File | Changes |
|------|---------|
| `README.md` | Added lane, plugin, doctor, metrics, deps sections; updated Quick Start |
| `docs/src/cli-reference.md` | Added 5 missing command reference sections + plugin format docs |
| `docs/src/introduction.md` | Updated feature list and command table |
| `docs/src/getting-started/quick-start.md` | Added lanes, health, plugins workflow guides |
| `docs/src/configuration.md` | Added config init --preset section |

## Test plan

- [x] All 313 unit + 10 integration tests pass
- [x] 0 clippy warnings, fmt clean
- [x] 25 specs pass, 0 errors
- [x] Documentation content reviewed for accuracy against CLI --help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)