### PR TITLE
fix: cross-platform plugin support (Windows CI)

### DIFF
--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -40,6 +40,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `extra_template_paths` | Resolves and returns additional template directory paths |
 | `github_token` | Returns GitHub token from `FLEDGE_GITHUB_TOKEN`, `GITHUB_TOKEN` env var, or config |
 | `template_repos` | Returns configured remote template repository references |
+| `init_config` | Creates a new config file at the default path, optionally with a named preset |
 
 ### Structs & Enums
 
@@ -74,6 +75,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `Config::extra_template_paths` | `(&self) -> Vec<PathBuf>` | Resolves extra template directory paths |
 | `Config::github_token` | `(&self) -> Option<String>` | GitHub token from env vars or config |
 | `Config::template_repos` | `(&self) -> &[String]` | Remote template repo references |
+| `init_config` | `(Option<&str>) -> Result<()>` | Create config file, optionally applying a named preset |
 
 ## Invariants
 

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -24,6 +24,7 @@ Composable workflow pipelines defined in `fledge.toml`. Lanes chain multiple tas
 |--------|-------------|
 | `run` | Entry point — lists or executes lanes |
 | `LaneOptions` | Options: `lane`, `list`, `init`, `dry_run`, `json` |
+| `LaneDef` | Lane definition: description, steps, and fail_fast flag |
 
 ### Structs & Enums
 

--- a/specs/lanes/requirements.md
+++ b/specs/lanes/requirements.md
@@ -1,0 +1,18 @@
+# Lanes — Requirements
+
+## Functional Requirements
+
+1. Define named workflow pipelines in `fledge.toml` under `[lanes]`
+2. Execute lanes as ordered sequences of steps
+3. Support three step types: task references, inline commands, parallel groups
+4. Validate task references before execution
+5. Support `fail_fast` flag to control failure behavior
+6. Support `--dry-run` to preview execution plan
+7. Support `--init` to scaffold default lanes for the detected language
+8. List available lanes with descriptions
+
+## Non-Functional Requirements
+
+1. Parallel groups must execute steps concurrently using threads
+2. Lane execution must respect task dependency ordering within each step
+3. `--json` flag must produce machine-parseable output for list operations

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -25,15 +25,19 @@ Plugin system for community extensions. Plugins are external executables that re
 |--------|-------------|
 | `run` | Entry point — install, list, remove, or run plugins |
 | `PluginOptions` | Options for the plugin subcommand |
+| `PluginEntry` | Installed plugin metadata: name, source, version, install date, commands |
+| `PluginAction` | Enum of plugin operations: Install, Remove, List, Search, Run |
 | `resolve_plugin_command` | Check if a command name matches an installed plugin |
+| `list_installed` | List all installed plugins with metadata |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `PluginOptions` | CLI options: `action`, `name`, `json` |
+| `PluginOptions` | CLI options: `action`, `json` |
+| `PluginAction` | Enum: Install, Remove, List, Search, Run |
+| `PluginEntry` | Installed plugin record: name, source, version, installed date, commands |
 | `PluginManifest` | Parsed `plugin.toml`: name, version, description, commands, hooks |
-| `PluginInfo` | Installed plugin metadata for listing |
 
 ### Functions
 

--- a/specs/plugin/requirements.md
+++ b/specs/plugin/requirements.md
@@ -1,0 +1,18 @@
+# Plugin — Requirements
+
+## Functional Requirements
+
+1. Install plugins from GitHub repositories via `fledge plugin install <repo>`
+2. Remove installed plugins via `fledge plugin remove <name>`
+3. List installed plugins with metadata via `fledge plugin list`
+4. Search for plugins on GitHub via `fledge plugin search <query>`
+5. Run plugin commands as fledge subcommands
+6. Resolve plugin executables by name for CLI dispatch
+7. Support cross-platform symlink creation (Unix symlinks, Windows symlinks)
+8. Set executable permissions on plugin binaries (Unix only)
+
+## Non-Functional Requirements
+
+1. Plugin installation must be idempotent with `--force` flag
+2. Plugin binaries must be discoverable via PATH or `plugins/bin/`
+3. `--json` flag must produce machine-parseable output for all list/search operations

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, bail};
 use console::style;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -232,7 +231,7 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
         if link_path.exists() || link_path.is_symlink() {
             fs::remove_file(&link_path).ok();
         }
-        symlink(&binary_path, &link_path).with_context(|| {
+        create_symlink(&binary_path, &link_path).with_context(|| {
             format!(
                 "creating symlink {} -> {}",
                 link_path.display(),
@@ -509,13 +508,32 @@ fn which_fledge_plugin(name: &str) -> Option<PathBuf> {
 }
 
 fn make_executable(path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let metadata = fs::metadata(path)?;
-    let mut perms = metadata.permissions();
-    let mode = perms.mode();
-    if mode & 0o111 == 0 {
-        perms.set_mode(mode | 0o755);
-        fs::set_permissions(path, perms)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = fs::metadata(path)?;
+        let mut perms = metadata.permissions();
+        let mode = perms.mode();
+        if mode & 0o111 == 0 {
+            perms.set_mode(mode | 0o755);
+            fs::set_permissions(path, perms)?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn create_symlink(original: &Path, link: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)?;
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(original, link)?;
     }
     Ok(())
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -593,7 +593,7 @@ mod tests {
     #[test]
     fn bin_dir_is_under_plugins() {
         let dir = plugin_bin_dir();
-        assert!(dir.to_string_lossy().ends_with("plugins/bin"));
+        assert!(dir.ends_with("plugins/bin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Wrap `std::os::unix::fs::symlink` and `PermissionsExt` in `#[cfg(unix)]` guards
- Add `#[cfg(windows)]` alternative using `std::os::windows::fs::symlink_file`
- Fixes Windows CI build failure that's been red since the plugin command landed

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all 323 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Windows CI should pass once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)