### PR TITLE
fix: --yes flag now skips all interactive prompts

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -72,7 +72,7 @@ pub fn run(opts: InitOptions) -> Result<()> {
     }
 
     // Prompt for template variables
-    let variables = prompts::prompt_variables(template, &opts.name, &config)?;
+    let variables = prompts::prompt_variables(template, &opts.name, &config, opts.yes)?;
 
     // Create project directory
     std::fs::create_dir_all(&target_dir)
@@ -194,7 +194,7 @@ fn run_remote(
         );
     }
 
-    let variables = prompts::prompt_variables(template, &opts.name, config)?;
+    let variables = prompts::prompt_variables(template, &opts.name, config, opts.yes)?;
 
     std::fs::create_dir_all(&target_dir)
         .with_context(|| format!("creating directory {}", target_dir.display()))?;

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -23,6 +23,7 @@ pub fn prompt_variables(
     template: &Template,
     project_name: &str,
     config: &Config,
+    yes: bool,
 ) -> Result<tera::Context> {
     let mut ctx = tera::Context::new();
 
@@ -36,18 +37,18 @@ pub fn prompt_variables(
     ctx.insert("year", &now.format("%Y").to_string());
     ctx.insert("date", &now.format("%Y-%m-%d").to_string());
 
-    // Author — from config, git, or prompt
     let author = match config.author_or_git() {
         Some(a) => a,
+        None if yes => project_name.to_string(),
         None => Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Author name")
             .interact_text()?,
     };
     ctx.insert("author", &author);
 
-    // GitHub org — from config or prompt
     let github_org = match config.github_org() {
         Some(org) => org,
+        None if yes => project_name.to_string(),
         None => Input::with_theme(&ColorfulTheme::default())
             .with_prompt("GitHub organization")
             .default("CorvidLabs".to_string())
@@ -58,19 +59,26 @@ pub fn prompt_variables(
     // License
     ctx.insert("license", &config.license());
 
-    // Template-specific prompts
     for (key, prompt_def) in &template.manifest.prompts {
-        let theme = ColorfulTheme::default();
-        let value: String = if let Some(ref default) = prompt_def.default {
-            let rendered = render_default(default, &ctx).unwrap_or_else(|_| default.clone());
-            Input::with_theme(&theme)
-                .with_prompt(&prompt_def.message)
-                .default(rendered)
-                .interact_text()?
+        let value: String = if yes {
+            if let Some(ref default) = prompt_def.default {
+                render_default(default, &ctx).unwrap_or_else(|_| default.clone())
+            } else {
+                String::new()
+            }
         } else {
-            Input::with_theme(&theme)
-                .with_prompt(&prompt_def.message)
-                .interact_text()?
+            let theme = ColorfulTheme::default();
+            if let Some(ref default) = prompt_def.default {
+                let rendered = render_default(default, &ctx).unwrap_or_else(|_| default.clone());
+                Input::with_theme(&theme)
+                    .with_prompt(&prompt_def.message)
+                    .default(rendered)
+                    .interact_text()?
+            } else {
+                Input::with_theme(&theme)
+                    .with_prompt(&prompt_def.message)
+                    .interact_text()?
+            }
         };
         ctx.insert(key, &value);
     }


### PR DESCRIPTION
## Summary

- **1.0 blocker fix**: `prompt_variables()` ignored the `--yes` flag and always opened interactive prompts for `author`, `github_org`, and template-specific variables
- This broke `fledge init` in non-TTY environments (CI, scripts, piped input)
- Now falls back to config → git → project name for author/org, and rendered defaults (or empty string) for template prompts when `--yes` is passed

## Changes
- `src/prompts.rs`: Added `yes: bool` parameter to `prompt_variables()`
- `src/init.rs`: Updated both call sites (local and remote paths) to pass `opts.yes`

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — all 334 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)