### PR TITLE
docs: restore validate-template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Options:
   -o, --output        Parent directory for the template [default: .]
 ```
 
+#### `fledge validate-template [path]`
+
+Validate a template directory for correctness (manifest, Tera syntax, variable definitions, render globs).
+
+```
+Options:
+      --strict          Treat warnings as errors (non-zero exit)
+      --json            Output results as JSON
+```
+
 #### `fledge search [query]`
 
 Search for templates on GitHub by keyword.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -23,7 +23,7 @@ fledge is designed to be the one CLI you reach for throughout the dev lifecycle.
 
 | Category | Commands | Description |
 |----------|----------|-------------|
-| **Scaffolding** | `init`, `list`, `create-template`, `search`, `publish`, `update` | Create projects from templates, discover and share templates |
+| **Scaffolding** | `init`, `list`, `create-template`, `search`, `publish`, `update`, `validate-template` | Create projects from templates, discover, validate, and share templates |
 | **Project Lifecycle** | `run`, `lane`, `spec`, `work`, `changelog` | Task runner, workflow pipelines, spec management, git workflow |
 | **Project Health** | `doctor`, `metrics`, `deps` | Environment diagnostics, code metrics, dependency auditing |
 | **GitHub** | `issues`, `prs`, `checks` | View issues, PRs, and CI status from the terminal |

--- a/docs/src/templates.md
+++ b/docs/src/templates.md
@@ -119,14 +119,31 @@ fledge publish --org MyOrg
 
 Add the `fledge-template` topic to your GitHub repository. This makes it appear in `fledge search` results.
 
-### Validation
+### Validate Before Publishing
 
-When you run `fledge publish`, it automatically validates your template before publishing:
+```bash
+# Basic validation
+fledge validate-template .
+
+# Strict mode (warnings are errors)
+fledge validate-template . --strict
+
+# Validate all templates in a directory
+fledge validate-template ./templates
+
+# Machine-readable output
+fledge validate-template . --json
+```
+
+The validator checks:
 - `template.toml` exists and parses correctly
 - Required fields (`name`, `description`) are present
 - All `.tera` files have valid syntax
+- Variables used in templates are defined (built-in or via `[prompts]`)
+- `files.render` globs match actual files
+- `template.toml` is in the ignore list
 
-You can also test your template locally with a dry run before publishing:
+You can also test your template with a dry run:
 
 ```bash
 fledge init test-output --template ./my-template --dry-run


### PR DESCRIPTION
## Summary
- Restores `fledge validate-template` docs in templates.md (was incorrectly removed in PR #77)
- Adds `validate-template` to README CLI reference section
- Adds `validate-template` to introduction.md command table

## Verification
- All 24 CLI commands confirmed documented in both README and CLI reference
- 8 built-in templates match `fledge list` output across all pages
- 26 specs pass (0 errors), all tests pass, clippy clean, mdBook builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)