### PR TITLE
feat: add project_name_kebab and project_name_camel built-in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # fledge
 
+[![CI](https://github.com/CorvidLabs/fledge/actions/workflows/ci.yml/badge.svg)](https://github.com/CorvidLabs/fledge/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/fledge)](https://crates.io/crates/fledge)
+[![Downloads](https://img.shields.io/crates/d/fledge)](https://crates.io/crates/fledge)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-brightgreen)](https://corvidlabs.github.io/fledge/)
+
 Dev-lifecycle CLI — get your projects ready to fly.
 
 A fast, opinionated CLI built in Rust. Scaffold projects, run tasks, compose workflow pipelines, manage plugins, check dependencies, review code, and ship — all from one binary.

--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -223,8 +223,10 @@ These variables are available in all rendered files:
 | Variable | Description |
 |----------|-------------|
 | `{{{{ project_name }}}}` | Project name as provided by the user |
-| `{{{{ project_name_snake }}}}` | Snake_case version |
+| `{{{{ project_name_snake }}}}` | snake_case version |
+| `{{{{ project_name_kebab }}}}` | kebab-case version |
 | `{{{{ project_name_pascal }}}}` | PascalCase version |
+| `{{{{ project_name_camel }}}}` | camelCase version |
 | `{{{{ author }}}}` | Author name |
 | `{{{{ github_org }}}}` | GitHub organization |
 | `{{{{ license }}}}` | License identifier |

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -30,7 +30,9 @@ pub fn prompt_variables(
     // Core variables
     ctx.insert("project_name", project_name);
     ctx.insert("project_name_snake", &to_snake_case(project_name));
+    ctx.insert("project_name_kebab", &to_kebab_case(project_name));
     ctx.insert("project_name_pascal", &to_pascal_case(project_name));
+    ctx.insert("project_name_camel", &to_camel_case(project_name));
 
     // Date variables
     let now = chrono::Local::now();
@@ -93,6 +95,31 @@ fn render_default(template: &str, ctx: &tera::Context) -> Result<String> {
     let mut tera = tera::Tera::default();
     tera.add_raw_template("__default__", template)?;
     Ok(tera.render("__default__", ctx)?)
+}
+
+fn to_kebab_case(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c == '_' {
+                '-'
+            } else {
+                c.to_ascii_lowercase()
+            }
+        })
+        .collect()
+}
+
+fn to_camel_case(s: &str) -> String {
+    let pascal = to_pascal_case(s);
+    let mut chars = pascal.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let mut s = first.to_lowercase().to_string();
+            s.extend(chars);
+            s
+        }
+    }
 }
 
 fn to_snake_case(s: &str) -> String {
@@ -174,6 +201,35 @@ mod tests {
     #[test]
     fn test_to_pascal_case_single_char() {
         assert_eq!(to_pascal_case("a"), "A");
+    }
+
+    #[test]
+    fn test_to_kebab_case() {
+        assert_eq!(to_kebab_case("my_project"), "my-project");
+        assert_eq!(to_kebab_case("my-project"), "my-project");
+        assert_eq!(to_kebab_case("MyProject"), "myproject");
+    }
+
+    #[test]
+    fn test_to_kebab_case_empty() {
+        assert_eq!(to_kebab_case(""), "");
+    }
+
+    #[test]
+    fn test_to_camel_case() {
+        assert_eq!(to_camel_case("my-project"), "myProject");
+        assert_eq!(to_camel_case("my_project"), "myProject");
+        assert_eq!(to_camel_case("single"), "single");
+    }
+
+    #[test]
+    fn test_to_camel_case_multiple_segments() {
+        assert_eq!(to_camel_case("my-cool-project"), "myCoolProject");
+    }
+
+    #[test]
+    fn test_to_camel_case_empty() {
+        assert_eq!(to_camel_case(""), "");
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -24,7 +24,9 @@ struct ValidationReport {
 const BUILTIN_VARS: &[&str] = &[
     "project_name",
     "project_name_snake",
+    "project_name_kebab",
     "project_name_pascal",
+    "project_name_camel",
     "year",
     "date",
     "author",


### PR DESCRIPTION
## Summary
- Adds `project_name_kebab` (kebab-case) and `project_name_camel` (camelCase) as built-in template variables
- Registers both in the `validate-template` BUILTIN_VARS so templates using them pass validation
- Updates `create-template` docs to list all 5 name variants
- Adds unit tests for both new case-conversion functions

## Context
The fledge-templates CI was failing because the `corvid-agent-skill` template uses `{{ project_name_kebab }}` and `{{ project_name_camel }}` which weren't recognized as built-in variables.

Root cause: the CI workflow was also installing a stale fledge binary (fixed separately in fledge-templates), but even with the correct binary these variables were genuinely missing.

## Test plan
- [x] 399 tests pass (329 unit + 70 integration)
- [x] Clippy clean
- [x] `cargo fmt` clean
- [ ] After merge, re-run fledge-templates CI to confirm validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)