### PR TITLE
feat: add `requires` field for template tool dependencies

### DIFF
--- a/specs/templates/templates.spec.md
+++ b/specs/templates/templates.spec.md
@@ -1,6 +1,6 @@
 ---
 module: templates
-version: 3
+version: 4
 status: active
 files:
   - src/templates.rs
@@ -32,6 +32,7 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | `render_template` | Renders a template's files into a target directory using Tera variable substitution |
 | `load_templates_from_dir_pub` | Loads templates from a specific directory into a mutable vector |
 | `matches_glob_pub` | Tests whether a file path matches a glob pattern |
+| `check_requirements` | Checks which required tools from `template.toml` are available on PATH |
 
 ### Structs & Enums
 
@@ -58,6 +59,7 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | `render_template` | `(&Template, &Path, &tera::Context) -> Result<Vec<PathBuf>>` | Render template files into target directory |
 | `load_templates_from_dir_pub` | `(&Path, &mut Vec<Template>) -> Result<()>` | Load templates from a directory into a vector |
 | `matches_glob_pub` | `(&str, &str) -> bool` | Test if a path matches a glob pattern |
+| `check_requirements` | `(&[String]) -> (Vec<String>, Vec<String>)` | Returns (found, missing) tools from PATH |
 
 ## Invariants
 
@@ -152,3 +154,4 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | 2026-04-18 | CorvidAgent | Initial spec |
 | 2026-04-18 | CorvidAgent | v2: Fill in export descriptions, add invariants for sort order and directory resolution, expand behavioral examples and error cases |
 | 2026-04-18 | CorvidAgent | v3: Add discover_templates_with_repos for remote GitHub template support |
+| 2026-04-20 | CorvidAgent | v4: Add check_requirements for template tool dependency checking |

--- a/src/init.rs
+++ b/src/init.rs
@@ -51,6 +51,7 @@ pub fn run(opts: InitOptions) -> Result<()> {
     );
 
     check_template_version(&template.manifest)?;
+    check_template_requirements(&template.manifest, opts.yes)?;
 
     // Target directory
     let target_dir = opts.output.join(&opts.name);
@@ -175,6 +176,7 @@ fn run_remote(
     );
 
     check_template_version(&template.manifest)?;
+    check_template_requirements(&template.manifest, opts.yes)?;
 
     let target_dir = opts.output.join(&opts.name);
     if target_dir.exists() {
@@ -328,6 +330,21 @@ fn print_dry_run(
     println!("  Location:  {}", style(target_dir.display()).dim());
     println!("  Git init:  {}", if no_git { "no" } else { "yes" });
 
+    if !template.manifest.template.requires.is_empty() {
+        let (found, missing) = templates::check_requirements(&template.manifest.template.requires);
+        print!("  Requires:  ");
+        let parts: Vec<String> = found
+            .iter()
+            .map(|t| format!("{}", style(t).green()))
+            .chain(
+                missing
+                    .iter()
+                    .map(|t| format!("{}", style(format!("{t} (missing)")).red())),
+            )
+            .collect();
+        println!("{}", parts.join(", "));
+    }
+
     // List template files
     let files: Vec<_> = walkdir::WalkDir::new(&template.path)
         .into_iter()
@@ -366,6 +383,51 @@ fn check_template_version(manifest: &templates::TemplateManifest) -> Result<()> 
     if let Some(ref min_ver) = manifest.template.min_fledge_version {
         crate::versioning::check_fledge_version(min_ver)?;
     }
+    Ok(())
+}
+
+fn check_template_requirements(
+    manifest: &templates::TemplateManifest,
+    auto_yes: bool,
+) -> Result<()> {
+    if manifest.template.requires.is_empty() {
+        return Ok(());
+    }
+
+    let (_, missing) = templates::check_requirements(&manifest.template.requires);
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    println!(
+        "\n{} This template requires tools not found on your PATH:",
+        style("!").yellow().bold()
+    );
+    for tool in &missing {
+        println!("  {} {}", style("missing:").yellow().bold(), tool);
+    }
+    println!();
+
+    if auto_yes {
+        println!(
+            "{} Continuing anyway (--yes). Post-create hooks may fail.",
+            style("*").cyan().bold()
+        );
+        return Ok(());
+    }
+
+    let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+        .with_prompt("Continue without these tools? (post-create hooks may fail)")
+        .default(false)
+        .interact()?;
+
+    if !confirm {
+        bail!(
+            "Missing required tools: {}. Install them and try again.",
+            missing.join(", ")
+        );
+    }
+
     Ok(())
 }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -34,6 +34,28 @@ pub struct TemplateInfo {
     #[serde(default)]
     #[allow(dead_code)]
     pub version: Option<String>,
+    #[serde(default)]
+    pub requires: Vec<String>,
+}
+
+pub fn check_requirements(requires: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut found = Vec::new();
+    let mut missing = Vec::new();
+    for tool in requires {
+        let ok = std::process::Command::new("sh")
+            .args(["-c", &format!("command -v {}", tool)])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            found.push(tool.clone());
+        } else {
+            missing.push(tool.clone());
+        }
+    }
+    (found, missing)
 }
 
 #[derive(Debug, Deserialize)]
@@ -864,5 +886,34 @@ ignore = ["template.toml"]
         let ctx = tera::Context::new();
         let result = render_template(&template, &target, &ctx);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn check_requirements_finds_sh() {
+        let (found, missing) = check_requirements(&["sh".to_string()]);
+        assert_eq!(found, vec!["sh"]);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn check_requirements_reports_missing() {
+        let (found, missing) = check_requirements(&["fledge_nonexistent_xyz".to_string()]);
+        assert!(found.is_empty());
+        assert_eq!(missing, vec!["fledge_nonexistent_xyz"]);
+    }
+
+    #[test]
+    fn check_requirements_mixed() {
+        let (found, missing) =
+            check_requirements(&["sh".to_string(), "fledge_nonexistent_xyz".to_string()]);
+        assert_eq!(found, vec!["sh"]);
+        assert_eq!(missing, vec!["fledge_nonexistent_xyz"]);
+    }
+
+    #[test]
+    fn check_requirements_empty_input() {
+        let (found, missing) = check_requirements(&[]);
+        assert!(found.is_empty());
+        assert!(missing.is_empty());
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -19,6 +19,8 @@ struct ValidationReport {
     path: String,
     errors: Vec<String>,
     warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    missing_requirements: Vec<String>,
 }
 
 const BUILTIN_VARS: &[&str] = &[
@@ -100,6 +102,18 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
         report
             .errors
             .push("template.description is empty".to_string());
+    }
+
+    if !manifest.template.requires.is_empty() {
+        let (_, missing) = crate::templates::check_requirements(&manifest.template.requires);
+        if !missing.is_empty() {
+            for tool in &missing {
+                report
+                    .warnings
+                    .push(format!("required tool '{tool}' not found on PATH"));
+            }
+            report.missing_requirements = missing;
+        }
     }
 
     let known_vars: HashSet<String> = BUILTIN_VARS
@@ -627,5 +641,88 @@ ignore = ["template.toml"]
             json: false,
         });
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn missing_requirement_is_warning() {
+        let tmp = TempDir::new().unwrap();
+        let tpl = tmp.path().join("needs-tool");
+        make_template(
+            &tpl,
+            r#"
+[template]
+name = "needs-tool"
+description = "Needs a nonexistent tool"
+requires = ["fledge_nonexistent_tool_xyz"]
+
+[files]
+ignore = ["template.toml"]
+"#,
+            &[("file.txt", "hello")],
+        );
+
+        let report = validate_single(&tpl).unwrap();
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("fledge_nonexistent_tool_xyz")),
+            "should warn about missing tool"
+        );
+        assert_eq!(
+            report.missing_requirements,
+            vec!["fledge_nonexistent_tool_xyz"]
+        );
+    }
+
+    #[test]
+    fn present_requirement_no_warning() {
+        let tmp = TempDir::new().unwrap();
+        let tpl = tmp.path().join("needs-sh");
+        make_template(
+            &tpl,
+            r#"
+[template]
+name = "needs-sh"
+description = "Needs sh which always exists"
+requires = ["sh"]
+
+[files]
+ignore = ["template.toml"]
+"#,
+            &[("file.txt", "hello")],
+        );
+
+        let report = validate_single(&tpl).unwrap();
+        assert!(report.errors.is_empty());
+        assert!(
+            !report.warnings.iter().any(|w| w.contains("not found")),
+            "should not warn about sh: {:?}",
+            report.warnings
+        );
+        assert!(report.missing_requirements.is_empty());
+    }
+
+    #[test]
+    fn requires_field_is_optional() {
+        let tmp = TempDir::new().unwrap();
+        let tpl = tmp.path().join("no-requires");
+        make_template(
+            &tpl,
+            r#"
+[template]
+name = "no-requires"
+description = "No requires field at all"
+
+[files]
+ignore = ["template.toml"]
+"#,
+            &[("file.txt", "hello")],
+        );
+
+        let report = validate_single(&tpl).unwrap();
+        assert!(report.errors.is_empty());
+        assert!(report.missing_requirements.is_empty());
     }
 }

--- a/templates/angular-app/template.toml
+++ b/templates/angular-app/template.toml
@@ -2,6 +2,7 @@
 name = "angular-app"
 description = "Angular application with mobile-first setup"
 min_fledge_version = "0.1.0"
+requires = ["npm", "node"]
 
 [prompts]
 description = { message = "Project description", default = "A new Angular application" }


### PR DESCRIPTION
## Summary
- Adds `requires` field to `template.toml` `[template]` section — templates can declare tool dependencies (e.g. `requires = ["npm", "node"]`)
- `fledge validate-template` reports missing tools as warnings (not errors), so CI doesn't hard-fail on environments without optional runtimes
- `fledge init` warns about missing requirements before scaffolding and prompts the user to continue or abort
- `--dry-run` output shows requirement status (green for found, red for missing)
- Updated `angular-app` template to declare `requires = ["npm", "node"]`
- Added 7 new tests covering requirement checking and validation

## Test plan
- [x] All 346 tests pass (336 unit + 10 integration)
- [x] Clippy clean, fmt clean
- [x] Manual test: `validate-template` shows missing npm as warning
- [x] Manual test: `init --template angular-app --yes` warns about missing npm before continuing
- [x] Manual test: `init --template angular-app --dry-run` shows requirement status
- [x] Templates without `requires` field work unchanged (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)