### PR TITLE
fix: skip hooks when required tools are missing

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -60,7 +60,7 @@ pub fn run(opts: InitOptions) -> Result<()> {
     );
 
     check_template_version(&template.manifest)?;
-    check_template_requirements(&template.manifest, opts.yes)?;
+    let reqs_ok = check_template_requirements(&template.manifest, opts.yes)?;
 
     // Target directory
     let target_dir = opts.output.join(&opts.name);
@@ -108,8 +108,8 @@ pub fn run(opts: InitOptions) -> Result<()> {
         init_git(&target_dir)?;
     }
 
-    // Post-create hooks (local templates are trusted)
-    if !opts.no_install {
+    // Post-create hooks (local templates are trusted); skip if required tools missing
+    if !opts.no_install && reqs_ok {
         run_post_create_hooks(
             &template.manifest.hooks.post_create,
             &target_dir,
@@ -185,7 +185,7 @@ fn run_remote(
     );
 
     check_template_version(&template.manifest)?;
-    check_template_requirements(&template.manifest, opts.yes)?;
+    let reqs_ok = check_template_requirements(&template.manifest, opts.yes)?;
 
     let target_dir = opts.output.join(&opts.name);
     if target_dir.exists() {
@@ -228,8 +228,8 @@ fn run_remote(
         init_git(&target_dir)?;
     }
 
-    // Remote templates require confirmation before running hooks
-    if !opts.no_install {
+    // Remote templates require confirmation before running hooks; skip if required tools missing
+    if !opts.no_install && reqs_ok {
         run_post_create_hooks(
             &template.manifest.hooks.post_create,
             &target_dir,
@@ -395,17 +395,18 @@ fn check_template_version(manifest: &templates::TemplateManifest) -> Result<()> 
     Ok(())
 }
 
+/// Returns true if all requirements are met (hooks safe to run).
 fn check_template_requirements(
     manifest: &templates::TemplateManifest,
     auto_yes: bool,
-) -> Result<()> {
+) -> Result<bool> {
     if manifest.template.requires.is_empty() {
-        return Ok(());
+        return Ok(true);
     }
 
     let (_, missing) = templates::check_requirements(&manifest.template.requires);
     if missing.is_empty() {
-        return Ok(());
+        return Ok(true);
     }
 
     println!(
@@ -419,14 +420,14 @@ fn check_template_requirements(
 
     if auto_yes {
         println!(
-            "{} Continuing anyway (--yes). Post-create hooks may fail.",
+            "{} Continuing anyway (--yes). Skipping post-create hooks.",
             style("*").cyan().bold()
         );
-        return Ok(());
+        return Ok(false);
     }
 
     let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
-        .with_prompt("Continue without these tools? (post-create hooks may fail)")
+        .with_prompt("Continue without these tools? (post-create hooks will be skipped)")
         .default(false)
         .interact()?;
 
@@ -437,7 +438,7 @@ fn check_template_requirements(
         );
     }
 
-    Ok(())
+    Ok(false)
 }
 
 fn resolve_template<'a>(

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -184,13 +184,26 @@ fn extract_embedded_templates() -> PathBuf {
         .join("fledge")
         .join(format!("templates-v{}", version));
 
-    // If already extracted for this version, reuse it
-    if cache_dir.exists() {
-        return cache_dir;
-    }
+    let should_extract = if cache_dir.exists() {
+        // Re-extract if the binary is newer than the cache
+        let binary_mtime = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.metadata().ok())
+            .and_then(|m| m.modified().ok());
+        let cache_mtime = cache_dir.metadata().ok().and_then(|m| m.modified().ok());
+        match (binary_mtime, cache_mtime) {
+            (Some(bin), Some(cache)) => bin > cache,
+            _ => false,
+        }
+    } else {
+        true
+    };
 
-    if let Err(e) = extract_dir_recursive(&EMBEDDED_TEMPLATES, &cache_dir) {
-        eprintln!("Warning: failed to extract embedded templates: {}", e);
+    if should_extract {
+        let _ = std::fs::remove_dir_all(&cache_dir);
+        if let Err(e) = extract_dir_recursive(&EMBEDDED_TEMPLATES, &cache_dir) {
+            eprintln!("Warning: failed to extract embedded templates: {}", e);
+        }
     }
 
     cache_dir


### PR DESCRIPTION
## Summary
- **Skip post-create hooks** when `requires` tools are missing — previously hooks still ran and hard-failed (e.g., `npm install` with no npm)
- **Fix stale template cache** — embedded templates are now re-extracted when the binary is newer than the cache directory, preventing old cached templates from shadowing updated ones

## E2E test results
All 8 built-in templates scaffold successfully. Compilable templates (rust-cli, rust-lib, swift-pkg, ts-bun) all build clean. angular-app gracefully skips `npm install` when npm is missing instead of crashing.

## Test plan
- [x] All 348 tests pass (338 unit + 10 integration)
- [x] Clippy clean
- [x] Pre-commit hooks pass
- [x] E2E: all 8 templates scaffold correctly
- [x] E2E: angular-app skips hooks when npm missing (was a hard crash)
- [x] Cache invalidation works when binary is rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)