### PR TITLE
feat: community flow registry + ROADMAP update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 Fledge is evolving from a project scaffolding tool into a full dev-lifecycle CLI — scaffold, spec, build, ship, monitor — all from one opinionated Rust binary.
 
-## Current State (v0.7.0)
+## Current State (v1.0.0)
 
-Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, `checks`, `run`, `changelog`, `flow`, `doctor`, TUI (feature-gated). 8 built-in templates (Rust CLI/lib, Node CLI/lib, Python CLI, Go CLI, monorepo, static site), hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A, CI/CD status, task runner with language-aware defaults, changelog generation from git history, composable workflow pipelines (flows), environment diagnostics. Distribution via Homebrew, install script, Nix flake, and shell completions auto-install.
+Shipped: `init`, `list`, `config`, `create-template`, `search`, `publish`, `update`, `spec`, `work`, `completions`, `issues`, `prs`, `review`, `ask`, `checks`, `run`, `changelog`, `flow`, `doctor`, `deps`, `metrics`, `plugin`, `validate-template`, TUI (feature-gated). 2 built-in templates (rust-cli, ts-bun), community templates via `CorvidLabs/fledge-templates`. Hook security, dry-run support, template versioning, version pinning with `@ref` syntax, project lifecycle commands, GitHub ops, AI-powered code review and Q&A, CI/CD status, task runner with language-aware defaults, changelog generation from git history, composable workflow pipelines (flows), environment diagnostics, dependency health (outdated/audit/licenses), project metrics (LOC/churn/test ratio), plugin architecture (install/remove/search/run). Distribution via Homebrew, install script, Nix flake, and shell completions auto-install.
 
 ---
 
@@ -58,8 +58,8 @@ Run tasks, check CI, and generate changelogs — fledge becomes your daily drive
 
 Dependency management, project metrics, and environment diagnostics.
 
-- [ ] `fledge deps` — dependency health check (outdated packages, audit, license scan)
-- [ ] `fledge metrics` — project stats (LOC, test coverage, complexity, churn)
+- [x] `fledge deps` — dependency health check (outdated packages, audit, license scan)
+- [x] `fledge metrics` — project stats (LOC, test coverage, complexity, churn)
 - [x] `fledge doctor` — environment diagnostics (toolchain versions, missing deps, config issues)
 
 ## 1.0 — Flows & Plugins
@@ -67,9 +67,9 @@ Dependency management, project metrics, and environment diagnostics.
 Extensible workflow automation — the workflow-as-code model, but in Rust.
 
 - [x] Flow system — composable, typed workflow pipelines (#36)
-- [ ] Plugin architecture (Rust or WASM)
-- [ ] Community flow registry
-- [ ] Full end-to-end dev lifecycle coverage
+- [x] Plugin architecture — install, remove, list, search, run plugins from GitHub
+- [x] Community flow registry — search and import flows from GitHub
+- [x] Full end-to-end dev lifecycle coverage — scaffold, spec, build, ship, monitor
 
 ---
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -177,6 +177,8 @@ fledge flow [name] [OPTIONS]
 - `--init` — Generate default flows
 - `--dry-run` — Preview the plan
 - `--json` — JSON output
+- `--search` — Search GitHub for community flows
+- `--import <source>` — Import flows from a GitHub repo (owner/repo or owner/repo@ref)
 
 **Flow config in fledge.toml:**
 
@@ -213,6 +215,9 @@ fledge flow
 fledge flow ci
 fledge flow ci --dry-run
 fledge flow --init
+fledge flow --search
+fledge flow rust --search
+fledge flow --import CorvidLabs/fledge-flows
 ```
 
 ---

--- a/docs/src/flows.md
+++ b/docs/src/flows.md
@@ -192,6 +192,34 @@ fledge flow ci           # run one
 fledge flow ci --dry-run # preview the plan
 fledge flow --init       # generate defaults
 fledge flow --list --json
+fledge flow --search              # find community flows
+fledge flow rust --search         # search with keyword
+fledge flow --import owner/repo   # import flows from GitHub
+fledge flow --import owner/repo@v1.0.0  # pin to a version
+```
+
+## Community Flow Registry
+
+Share and discover flows via GitHub. Repos with the `fledge-flow` topic are discoverable through `--search`.
+
+### Publishing Flows
+
+1. Create a repo with a `fledge.toml` containing your flows and tasks
+2. Add the `fledge-flow` topic to the repo on GitHub
+3. Others can find it with `fledge flow --search` and import it
+
+### Importing Flows
+
+```bash
+fledge flow --import CorvidLabs/fledge-flows
+```
+
+This fetches the remote repo's `fledge.toml`, extracts its flows and any required tasks, and merges them into your local `fledge.toml`. Existing flows with the same name are skipped (not overwritten).
+
+You can pin to a specific branch or tag:
+
+```bash
+fledge flow --import CorvidLabs/fledge-flows@v1.0.0
 ```
 
 ## Environment diagnostics with `fledge doctor`

--- a/specs/flows/flows.spec.md
+++ b/specs/flows/flows.spec.md
@@ -1,6 +1,6 @@
 ---
 module: flows
-version: 1
+version: 2
 status: active
 files:
   - src/flows.rs
@@ -8,6 +8,9 @@ files:
 db_tables: []
 depends_on:
   - run
+  - config
+  - github
+  - search
 ---
 
 # Flows
@@ -22,8 +25,8 @@ Composable workflow pipelines defined in `fledge.toml`. Flows chain multiple tas
 
 | Export | Description |
 |--------|-------------|
-| `run` | Entry point — lists or executes flows |
-| `FlowOptions` | Options: `flow`, `list`, `init`, `dry_run`, `json` |
+| `run` | Entry point — lists, executes, searches, or imports flows |
+| `FlowOptions` | Options: `flow`, `list`, `init`, `dry_run`, `json`, `search`, `import` |
 | `FlowDef` | Flow definition: description, steps, and fail_fast flag |
 
 ### Structs & Enums
@@ -128,6 +131,29 @@ $ fledge flow check
 # Init default flows
 $ fledge flow --init
 ✓ Added default flows to fledge.toml
+
+# Search community flows on GitHub
+$ fledge flow --search
+Community flows on GitHub:
+  CorvidLabs/fledge-flows  (★ 12)  Official community flow collection
+  user/rust-release-flow   (★ 3)   Rust release pipeline with cargo-dist
+
+# Search with keyword
+$ fledge flow rust --search
+Community flows on GitHub:
+  user/rust-release-flow   (★ 3)   Rust release pipeline with cargo-dist
+
+# Import flows from a remote repo
+$ fledge flow --import CorvidLabs/fledge-flows
+✓ Imported 3 flow(s) from CorvidLabs/fledge-flows
+  + release
+  + deploy
+  + audit
+  + Also added 2 task(s): package, upload
+  * Skipped (already exist): ci
+
+# Import with version pinning
+$ fledge flow --import CorvidLabs/fledge-flows@v1.0.0
 ```
 
 ## Error Cases
@@ -141,13 +167,20 @@ $ fledge flow --init
 | Step failed | Non-zero exit code | Stop flow (if fail_fast) or continue and report |
 | Already exists | `--init` when flows already exist | Error |
 | Empty steps | Flow has no steps | Error |
+| Remote no fledge.toml | Import target has no fledge.toml | Error with message |
+| Remote no flows | Import target's fledge.toml has no flows | Error with message |
+| All flows exist | All imported flows already defined locally | Skip with message |
 
 ## Dependencies
 
 - `run` module (reuses task execution, project detection)
+- `config` module (GitHub token for API auth)
+- `github` module (GitHub API requests)
+- `search` module (response parsing, URL encoding)
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-20 | Add community flow registry (search + import) |
 | 1 | 2026-04-20 | Initial spec |

--- a/src/flows.rs
+++ b/src/flows.rs
@@ -93,9 +93,19 @@ pub struct FlowOptions {
     pub init: bool,
     pub dry_run: bool,
     pub json: bool,
+    pub search: bool,
+    pub import: Option<String>,
 }
 
 pub fn run(opts: FlowOptions) -> Result<()> {
+    if opts.search {
+        return search_flows(opts.flow.as_deref(), opts.json);
+    }
+
+    if let Some(ref source) = opts.import {
+        return import_flows(source);
+    }
+
     if opts.init {
         return init_flows();
     }
@@ -536,6 +546,276 @@ fn init_flows() -> Result<()> {
     Ok(())
 }
 
+fn search_flows(keyword: Option<&str>, json: bool) -> Result<()> {
+    let config = crate::config::Config::load()?;
+    let token = config.github_token();
+
+    let query = match keyword {
+        Some(kw) => format!("{} topic:fledge-flow", kw),
+        None => "topic:fledge-flow".to_string(),
+    };
+
+    println!(
+        "  {} Searching GitHub for community flows...",
+        style("▸").cyan().bold()
+    );
+
+    let body = crate::github::github_api_get(
+        "/search/repositories",
+        token.as_deref(),
+        &[("q", &query), ("sort", "stars"), ("per_page", "30")],
+    )
+    .context("searching GitHub for flow repos")?;
+
+    let results = crate::search::parse_search_response(&body)?;
+
+    if results.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!(
+                "{} No community flows found{}.",
+                style("*").cyan().bold(),
+                keyword
+                    .map(|q| format!(" matching '{q}'"))
+                    .unwrap_or_default()
+            );
+        }
+        return Ok(());
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+        return Ok(());
+    }
+
+    println!("{}\n", style("Community flows on GitHub:").bold());
+    let max_name = results
+        .iter()
+        .map(|r| r.full_name().len())
+        .max()
+        .unwrap_or(0);
+    for r in &results {
+        let stars = crate::search::format_stars(r.stars);
+        let desc = if r.description.len() > 60 {
+            format!("{}...", &r.description[..57])
+        } else {
+            r.description.clone()
+        };
+        println!(
+            "  {:<width$}  {}  {}",
+            style(&r.full_name()).green(),
+            style(format!("(★ {})", stars)).dim(),
+            style(&desc).dim(),
+            width = max_name,
+        );
+    }
+    println!(
+        "\n{}",
+        style("Import with: fledge flow --import <owner/repo>").dim()
+    );
+
+    Ok(())
+}
+
+fn import_flows(source: &str) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let local_path = cwd.join("fledge.toml");
+
+    if !local_path.exists() {
+        bail!(
+            "No fledge.toml found. Run {} first.",
+            style("fledge run --init").cyan()
+        );
+    }
+
+    let config = crate::config::Config::load()?;
+    let token = config.github_token();
+
+    let (owner, repo, git_ref) = parse_import_source(source);
+
+    println!(
+        "  {} Fetching flows from {}/{}{}...",
+        style("▸").cyan().bold(),
+        owner,
+        repo,
+        git_ref
+            .as_ref()
+            .map(|r| format!("@{r}"))
+            .unwrap_or_default()
+    );
+
+    let ref_param = git_ref.as_deref().unwrap_or("HEAD");
+    let body = crate::github::github_api_get(
+        &format!("/repos/{owner}/{repo}/contents/fledge.toml"),
+        token.as_deref(),
+        &[("ref", ref_param)],
+    )
+    .context("fetching fledge.toml from remote repo")?;
+
+    let content_b64 = body
+        .get("content")
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Remote repo has no fledge.toml or it's not a file"))?;
+
+    let cleaned: String = content_b64.chars().filter(|c| !c.is_whitespace()).collect();
+    let decoded = base64_decode(&cleaned).context("decoding fledge.toml content")?;
+    let remote_content = String::from_utf8(decoded).context("fledge.toml is not valid UTF-8")?;
+
+    let remote_config: FledgeFileWithFlows =
+        toml::from_str(&remote_content).context("parsing remote fledge.toml")?;
+
+    if remote_config.flows.is_empty() {
+        bail!("Remote repo has no [flows] defined in fledge.toml.");
+    }
+
+    let local_content =
+        std::fs::read_to_string(&local_path).context("reading local fledge.toml")?;
+    let local_config: FledgeFileWithFlows =
+        toml::from_str(&local_content).context("parsing local fledge.toml")?;
+
+    let mut imported_flows = Vec::new();
+    let mut imported_tasks = Vec::new();
+    let mut skipped = Vec::new();
+    let mut append = String::new();
+
+    for (task_name, task_def) in &remote_config.tasks {
+        if local_config.tasks.contains_key(task_name) {
+            continue;
+        }
+        let cmd = task_def.cmd();
+        append.push_str(&format!("\n[tasks.{task_name}]\ncmd = \"{cmd}\"\n"));
+        imported_tasks.push(task_name.clone());
+    }
+
+    for (flow_name, flow) in &remote_config.flows {
+        if local_config.flows.contains_key(flow_name) {
+            skipped.push(flow_name.clone());
+            continue;
+        }
+        append.push_str(&format_flow_toml(flow_name, flow));
+        imported_flows.push(flow_name.clone());
+    }
+
+    if imported_flows.is_empty() {
+        println!(
+            "{} All flows from {}/{} already exist locally ({})",
+            style("*").cyan().bold(),
+            owner,
+            repo,
+            skipped.join(", ")
+        );
+        return Ok(());
+    }
+
+    let new_content = format!("{}{}", local_content.trim_end(), append);
+    std::fs::write(&local_path, new_content).context("writing fledge.toml")?;
+
+    println!(
+        "{} Imported {} flow(s) from {}/{}",
+        style("✓").green().bold(),
+        imported_flows.len(),
+        owner,
+        repo
+    );
+    for name in &imported_flows {
+        println!("  {} {}", style("+").green(), style(name).cyan());
+    }
+    if !imported_tasks.is_empty() {
+        println!(
+            "  {} Also added {} task(s): {}",
+            style("+").green(),
+            imported_tasks.len(),
+            imported_tasks.join(", ")
+        );
+    }
+    if !skipped.is_empty() {
+        println!(
+            "  {} Skipped (already exist): {}",
+            style("*").dim(),
+            skipped.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_import_source(source: &str) -> (String, String, Option<String>) {
+    let source = source
+        .strip_prefix("https://github.com/")
+        .unwrap_or(source)
+        .trim_end_matches(".git");
+
+    let (path, git_ref) = if let Some((p, r)) = source.split_once('@') {
+        (p, Some(r.to_string()))
+    } else {
+        (source, None)
+    };
+
+    let parts: Vec<&str> = path.splitn(2, '/').collect();
+    let owner = parts.first().unwrap_or(&"").to_string();
+    let repo = parts.get(1).unwrap_or(&"").to_string();
+
+    (owner, repo, git_ref)
+}
+
+fn format_flow_toml(name: &str, flow: &FlowDef) -> String {
+    let mut out = format!("\n[flows.{}]\n", name);
+    if let Some(ref desc) = flow.description {
+        out.push_str(&format!("description = \"{}\"\n", desc));
+    }
+    if !flow.fail_fast {
+        out.push_str("fail_fast = false\n");
+    }
+    out.push_str("steps = [");
+    for (i, step) in flow.steps.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        match step {
+            Step::TaskRef(name) => {
+                out.push_str(&format!("\"{}\"", name));
+            }
+            Step::Inline { run: cmd } => {
+                out.push_str(&format!("{{ run = \"{}\" }}", cmd));
+            }
+            Step::Parallel { parallel } => {
+                let names: Vec<String> = parallel.iter().map(|n| format!("\"{}\"", n)).collect();
+                out.push_str(&format!("{{ parallel = [{}] }}", names.join(", ")));
+            }
+        }
+    }
+    out.push_str("]\n");
+    out
+}
+
+fn base64_decode(input: &str) -> Result<Vec<u8>> {
+    let mut output = Vec::with_capacity(input.len() * 3 / 4);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+
+    for c in input.chars() {
+        let val = match c {
+            'A'..='Z' => c as u32 - b'A' as u32,
+            'a'..='z' => c as u32 - b'a' as u32 + 26,
+            '0'..='9' => c as u32 - b'0' as u32 + 52,
+            '+' => 62,
+            '/' => 63,
+            '=' => break,
+            _ => continue,
+        };
+        buf = (buf << 6) | val;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            output.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -923,5 +1203,144 @@ steps = ["build"]
                 result.err()
             );
         }
+    }
+
+    #[test]
+    fn parse_import_source_basic() {
+        let (owner, repo, git_ref) = parse_import_source("CorvidLabs/fledge-flows");
+        assert_eq!(owner, "CorvidLabs");
+        assert_eq!(repo, "fledge-flows");
+        assert!(git_ref.is_none());
+    }
+
+    #[test]
+    fn parse_import_source_with_ref() {
+        let (owner, repo, git_ref) = parse_import_source("CorvidLabs/fledge-flows@v1.0.0");
+        assert_eq!(owner, "CorvidLabs");
+        assert_eq!(repo, "fledge-flows");
+        assert_eq!(git_ref.unwrap(), "v1.0.0");
+    }
+
+    #[test]
+    fn parse_import_source_full_url() {
+        let (owner, repo, git_ref) =
+            parse_import_source("https://github.com/CorvidLabs/fledge-flows.git");
+        assert_eq!(owner, "CorvidLabs");
+        assert_eq!(repo, "fledge-flows");
+        assert!(git_ref.is_none());
+    }
+
+    #[test]
+    fn parse_import_source_url_with_ref() {
+        let (owner, repo, git_ref) =
+            parse_import_source("https://github.com/CorvidLabs/fledge-flows@main");
+        assert_eq!(owner, "CorvidLabs");
+        assert_eq!(repo, "fledge-flows");
+        assert_eq!(git_ref.unwrap(), "main");
+    }
+
+    #[test]
+    fn format_flow_toml_sequential() {
+        let flow = FlowDef {
+            description: Some("CI pipeline".to_string()),
+            steps: vec![
+                Step::TaskRef("lint".to_string()),
+                Step::TaskRef("test".to_string()),
+            ],
+            fail_fast: true,
+        };
+        let toml = format_flow_toml("ci", &flow);
+        assert!(toml.contains("[flows.ci]"));
+        assert!(toml.contains("description = \"CI pipeline\""));
+        assert!(toml.contains("\"lint\""));
+        assert!(toml.contains("\"test\""));
+        assert!(!toml.contains("fail_fast"));
+    }
+
+    #[test]
+    fn format_flow_toml_with_fail_fast_false() {
+        let flow = FlowDef {
+            description: None,
+            steps: vec![Step::TaskRef("audit".to_string())],
+            fail_fast: false,
+        };
+        let toml = format_flow_toml("audit", &flow);
+        assert!(toml.contains("fail_fast = false"));
+    }
+
+    #[test]
+    fn format_flow_toml_with_inline() {
+        let flow = FlowDef {
+            description: None,
+            steps: vec![Step::Inline {
+                run: "echo hello".to_string(),
+            }],
+            fail_fast: true,
+        };
+        let toml = format_flow_toml("test", &flow);
+        assert!(toml.contains("{ run = \"echo hello\" }"));
+    }
+
+    #[test]
+    fn format_flow_toml_with_parallel() {
+        let flow = FlowDef {
+            description: None,
+            steps: vec![Step::Parallel {
+                parallel: vec!["lint".to_string(), "fmt".to_string()],
+            }],
+            fail_fast: true,
+        };
+        let toml = format_flow_toml("check", &flow);
+        assert!(toml.contains("parallel"));
+        assert!(toml.contains("\"lint\""));
+        assert!(toml.contains("\"fmt\""));
+    }
+
+    #[test]
+    fn format_flow_toml_roundtrips() {
+        let flow = FlowDef {
+            description: Some("Full CI".to_string()),
+            steps: vec![
+                Step::TaskRef("lint".to_string()),
+                Step::TaskRef("test".to_string()),
+                Step::TaskRef("build".to_string()),
+            ],
+            fail_fast: true,
+        };
+        let toml_str = format!(
+            "[tasks]\nlint = \"echo lint\"\ntest = \"echo test\"\nbuild = \"echo build\"\n{}",
+            format_flow_toml("ci", &flow)
+        );
+        let parsed: FledgeFileWithFlows = toml::from_str(&toml_str).unwrap();
+        assert!(parsed.flows.contains_key("ci"));
+        assert_eq!(parsed.flows["ci"].steps.len(), 3);
+    }
+
+    #[test]
+    fn base64_decode_basic() {
+        let encoded = "SGVsbG8gV29ybGQ=";
+        let decoded = base64_decode(encoded).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn base64_decode_no_padding() {
+        let encoded = "Zm9v";
+        let decoded = base64_decode(encoded).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "foo");
+    }
+
+    #[test]
+    fn base64_decode_empty() {
+        let decoded = base64_decode("").unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn base64_decode_with_newlines() {
+        let encoded = "SGVs\nbG8=";
+        let cleaned: String = encoded.chars().filter(|c| !c.is_whitespace()).collect();
+        let decoded = base64_decode(&cleaned).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "Hello");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,12 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Search GitHub for community flows
+        #[arg(long)]
+        search: bool,
+        /// Import flows from a GitHub repo (owner/repo)
+        #[arg(long, value_name = "SOURCE")]
+        import: Option<String>,
     },
     /// Generate a changelog from git tags and commits
     Changelog {
@@ -595,6 +601,8 @@ fn run() -> Result<()> {
             init,
             dry_run,
             json,
+            search,
+            import,
         } => {
             flows::run(flows::FlowOptions {
                 flow,
@@ -602,6 +610,8 @@ fn run() -> Result<()> {
                 init,
                 dry_run,
                 json,
+                search,
+                import,
             })?;
         }
         Commands::Changelog {


### PR DESCRIPTION
## Summary

- **Community flow registry** — adds `--search` and `--import` flags to `fledge flow`:
  - `fledge flow --search [keyword]` — discovers flows on GitHub via `fledge-flow` topic
  - `fledge flow --import owner/repo[@ref]` — fetches remote fledge.toml and merges flows + required tasks into local project
  - Skips existing flows (no overwrites), supports version pinning with `@ref`
- **ROADMAP update** — marks deps, metrics, plugin, flow registry, and lifecycle coverage as completed. Updates current state to v1.0.0.
- **Docs & specs** — updated flows spec (v1→v2), CLI reference, and flows docs page with registry section

## Verification

| Check | Status |
|-------|--------|
| `cargo fmt --check` | Clean |
| `cargo clippy -- -D warnings` | Clean |
| `cargo test` (70 integration + 33 flow unit) | All pass |
| `cargo run -- spec check` | 0 errors |

## Test plan

- [ ] `fledge flow --search` returns results (requires GitHub API access)
- [ ] `fledge flow --import CorvidLabs/fledge-flows` imports flows into local fledge.toml
- [ ] Import skips flows that already exist locally
- [ ] Import with `@ref` pins to specific version
- [ ] Existing flow commands (`fledge flow ci`, `--init`, `--dry-run`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)