### PR TITLE
feat: 1.0.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fledge validate-template` - validate templates for correctness with `--strict` and `--json` output
 - `fledge run` zero-config mode - auto-detects project type and runs tasks without `fledge.toml`
 - Community flow registry - search and import flows from GitHub
+- `fledge.toml` in the repo root - fledge now dogfoods its own CLI for development workflows
+- "Using Fledge with Existing Projects" documentation guide
+
+### Fixed
+
+- **Security**: path traversal in template rendering - malicious templates can no longer write outside the project directory
+- CLI reference examples now use correct built-in template names
 
 ### Changed
 
 - Full end-to-end dev lifecycle coverage from scaffold to ship
+- Homebrew formula updated to 1.0.0
 - Promoted to 1.0.0 - stable API
 
 ## [0.8.0] - 2026-04-19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,11 @@ cargo fmt --check
 - `src/github.rs` — Shared GitHub API helpers
 - `src/remote.rs` — Remote template fetching and caching
 - `src/flows.rs` — Composable workflow pipelines
+- `src/deps.rs` — Cross-language dependency health checker
+- `src/metrics.rs` — Code metrics (LOC, churn, test ratio)
+- `src/plugin.rs` — Plugin system for community extensions
+- `src/validate.rs` — Template validation
+- `src/tui.rs` — Interactive template browser (feature-gated)
 - `src/doctor.rs` — Environment diagnostics
 - `specs/` — spec-sync specifications (source of truth)
 - `templates/` — Built-in project templates

--- a/Formula/fledge.rb
+++ b/Formula/fledge.rb
@@ -2,7 +2,7 @@ class Fledge < Formula
   desc "Corvid-themed project scaffolding CLI — get your projects ready to fly"
   homepage "https://github.com/CorvidLabs/fledge"
   license "MIT"
-  version "0.6.0"
+  version "1.0.0"
 
   on_macos do
     on_arm do

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -28,10 +28,10 @@ fledge init <name> [OPTIONS]
 
 ```bash
 fledge init my-tool --template rust-cli
-fledge init my-app --template react-app --dry-run
-fledge init my-lib --template CorvidLabs/fledge-templates/rust-lib --yes
-fledge init my-project --template ts-bun -o ~/projects
-fledge init my-app --template CorvidLabs/templates/react-app@v2.0
+fledge init my-app --template ts-bun --dry-run
+fledge init my-lib --template go-cli --yes
+fledge init my-project --template python-cli -o ~/projects
+fledge init my-app --template CorvidLabs/fledge-templates/deno-cli@v2.0
 ```
 
 ---

--- a/fledge.toml
+++ b/fledge.toml
@@ -1,0 +1,43 @@
+# fledge.toml -- fledge uses its own CLI for development workflows
+# Detected project type: rust
+
+[tasks]
+build = "cargo build"
+test = "cargo test"
+lint = "cargo clippy -- -D warnings"
+fmt = "cargo fmt --check"
+fmt-fix = "cargo fmt"
+spec-check = "cargo run -- spec check"
+docs-build = "mdbook build docs"
+docs-serve = "mdbook serve docs --open"
+
+[tasks.validate-templates]
+cmd = "cargo run -- validate-template templates/"
+description = "Validate all built-in templates"
+
+[flows.ci]
+description = "Full CI pipeline"
+steps = ["fmt", "lint", "test", "build", "spec-check", "validate-templates"]
+
+[flows.check]
+description = "Quick quality check"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+]
+
+[flows.pre-commit]
+description = "Run before committing"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+  "spec-check",
+]
+
+[flows.docs]
+description = "Build and validate documentation"
+steps = ["docs-build"]
+
+[flows.release]
+description = "Pre-release validation"
+steps = ["fmt", "lint", "test", "build", "spec-check", "validate-templates", "docs-build"]


### PR DESCRIPTION
## Summary

- Homebrew formula bumped from 0.6.0 to 1.0.0 (SHA256 placeholders remain -- fill after building release binaries)
- `fledge.toml` committed -- fledge now dogfoods its own CLI with ci, check, pre-commit, docs, and release flows
- CHANGELOG updated with security fix (path traversal), dogfooding, and doc corrections
- CLAUDE.md architecture section updated with 5 missing modules
- CLI reference examples fixed to use actual built-in template names

## Verification

- 442 tests pass (362 unit + 80 integration)
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- `fledge spec check` -- 0 errors, 15 warnings (missing optional companion files)
- Path traversal regression test already exists (`safe_join_rejects_traversal` in templates.rs)

## What's left for the human team

1. Build release binaries for all targets (macOS ARM/x86, Linux x86)
2. Fill in SHA256 checksums in `Formula/fledge.rb`
3. Tag `v1.0.0` and create the GitHub release
4. Push the Homebrew tap
5. Verify `brew install CorvidLabs/tap/fledge` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)