### PR TITLE
feat: full TUI command dashboard

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -559,7 +559,7 @@ fledge completions fish > ~/.config/fish/completions/fledge.fish
 
 ### fledge tui *(requires `--features tui`)*
 
-Interactive template browser. Browse, preview, and scaffold templates without memorizing command flags.
+Interactive dashboard for the entire fledge dev lifecycle. Browse and run all fledge commands from a two-panel TUI with keyboard navigation.
 
 ```
 fledge tui [OPTIONS]
@@ -567,6 +567,19 @@ fledge tui [OPTIONS]
 
 **Options:**
 - `-o, --output <OUTPUT>` - Where to put the project [default: `.`]
-- `--no-git` - Skip git init
+- `--no-git` - Skip git init for template scaffolding
 
-**Navigation:** Arrow keys to browse, Tab to fill in variables, Enter to create.
+**Categories:**
+- **Work** — start branches, create PRs, view status
+- **GitHub** — browse issues, PRs, CI checks
+- **Run** — execute tasks and workflow pipelines
+- **Specs** — check, init, create new spec modules
+- **Metrics** — LOC, file churn, test ratio, dependency health
+- **Config** — view and edit settings
+- **Templates** — browse, scaffold, search, create, publish, validate, update
+- **AI** — code review, codebase Q&A
+- **Doctor** — environment diagnostics
+- **Changelog** — generate from tags, view unreleased changes
+- **Plugins** — list, search, install, remove, run community extensions
+
+**Navigation:** `↑↓`/`j`/`k` to navigate, `Enter` to run, `Tab`/`→` to open category, `Esc`/`←` to go back, `q` to quit. Actions that need input show an inline form. Output is displayed in a scrollable panel (`PgUp`/`PgDn`, `g`/`G` for top/bottom).

--- a/specs/tui/context.md
+++ b/specs/tui/context.md
@@ -1,0 +1,20 @@
+---
+spec: tui.spec.md
+---
+
+## Context
+
+`fledge tui` is the interactive companion to the CLI. Instead of memorizing flags and subcommands, users navigate a categorized menu and run any fledge command inline. Originally a template-only browser, it was expanded to a full dev-lifecycle dashboard covering all 11 command categories.
+
+## Related Modules
+
+- `templates` — provides `discover_templates_with_repos` and `render_template` for the nested template browser
+- `init` — provides `init_git_for_tui` for git init after scaffolding
+- `config` — provides `Config` for detecting project configuration
+
+## Design Decisions
+
+- Commands run as subprocesses (`std::env::current_exe()`) rather than calling module functions directly — this avoids coupling TUI to every module's internal API and ensures identical behavior to CLI usage
+- ANSI codes are stripped from subprocess output since ratatui handles its own styling
+- The template browser is a separate nested TUI that takes over the full screen, rather than being embedded in the dashboard — this preserves the original template browser experience
+- Feature-gated behind `tui` to keep the binary small for users who don't need it

--- a/specs/tui/requirements.md
+++ b/specs/tui/requirements.md
@@ -1,0 +1,31 @@
+---
+spec: tui.spec.md
+---
+
+## User Stories
+
+- As a developer, I want to run `fledge tui` and browse all available commands without memorizing CLI flags
+- As a new user, I want to discover fledge's capabilities through an interactive menu
+- As a developer, I want to run commands and see output inline without leaving the TUI
+
+## Acceptance Criteria
+
+- `fledge tui` launches a two-panel dashboard with categories on the left and actions on the right
+- All 11 categories are present: Work, GitHub, Run, Specs, Metrics, Config, Templates, AI, Doctor, Changelog, Plugins
+- Direct actions run immediately and show output in a scrollable panel
+- Input-requiring actions show an inline form with labeled fields, defaults, and required field validation
+- Template browser launches as a nested TUI and returns to the dashboard on exit
+- Keyboard navigation works: arrows/j/k, Tab, Enter, Esc, q
+- Terminal state is always restored on exit (raw mode disabled, alternate screen left)
+
+## Constraints
+
+- Requires `--features tui` at compile time (ratatui + crossterm are optional dependencies)
+- Commands run as subprocesses — requires the fledge binary to be available via `current_exe()`
+
+## Out of Scope
+
+- Concurrent command execution
+- Command history / recent commands
+- Custom keybindings
+- Mouse support

--- a/specs/tui/tasks.md
+++ b/specs/tui/tasks.md
@@ -1,0 +1,15 @@
+---
+spec: tui.spec.md
+---
+
+## Tasks
+
+- [x] Write spec files for TUI module
+- [x] Implement dashboard with 11 categories and all actions
+- [x] Implement input form for actions requiring user input
+- [x] Implement scrollable output panel
+- [x] Integrate nested template browser
+- [x] Add publish action to Templates category
+- [x] Update CLI reference documentation
+- [x] Wire up CLI subcommand in main.rs
+- [x] Run verification suite

--- a/specs/tui/testing.md
+++ b/specs/tui/testing.md
@@ -1,0 +1,17 @@
+---
+spec: tui.spec.md
+---
+
+## Test Plan
+
+### Unit Tests
+
+- `build_categories` returns 11 categories
+- `build_command` produces correct args for each `ActionId` variant
+- `strip_ansi` removes ANSI escape sequences from strings
+- All `ActionId` variants are handled in `build_command` (no missing match arms)
+
+### Integration Tests
+
+- `fledge tui` compiles only with `--features tui`
+- TUI code is absent from non-TUI builds (feature gate works)

--- a/specs/tui/tui.spec.md
+++ b/specs/tui/tui.spec.md
@@ -1,0 +1,105 @@
+---
+module: tui
+version: 1
+status: active
+files:
+  - src/tui.rs
+
+db_tables: []
+depends_on:
+  - config
+  - templates
+  - init
+---
+
+# TUI
+
+## Purpose
+
+Interactive dashboard for the entire fledge dev lifecycle. Provides a two-panel menu interface to browse and run all fledge commands without memorizing flags or subcommands. Feature-gated behind `--features tui`.
+
+## Public API
+
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `run` | Entry point — launch the dashboard TUI |
+
+### Structs & Enums
+
+| Type | Description |
+|------|-------------|
+| `DashboardApp` | Main dashboard state: categories, focus, screen, input fields, output |
+| `DashFocus` | Enum: `Categories`, `Actions` — which panel has focus |
+| `DashScreen` | Enum: `Browse`, `Input`, `Output` — current screen mode |
+| `ActionKind` | Enum: `Direct` (run immediately), `WithInput` (show form), `TemplateBrowser` (launch nested TUI) |
+| `ActionId` | Enum: identifies each input-requiring action for command building |
+| `CategoryDef` | Definition of a menu category: name, icon, description, actions |
+| `ActionDef` | Definition of a menu action: name, description, kind |
+
+### Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `run` | `(PathBuf, bool) -> Result<()>` | Main entry — launch dashboard |
+| `run_template_browser` | `(PathBuf, bool) -> Result<()>` | Launch the nested template browser |
+| `build_categories` | `() -> Vec<CategoryDef>` | Build all 11 menu categories with actions |
+| `build_command` | `(ActionId, &[String]) -> Vec<String>` | Convert form input to CLI args |
+
+## Invariants
+
+1. Dashboard has 11 categories: Work, GitHub, Run, Specs, Metrics, Config, Templates, AI, Doctor, Changelog, Plugins
+2. Every fledge CLI command is represented except `completions` (not useful in TUI) and `tui` (recursive)
+3. Commands run as subprocesses via `std::env::current_exe()` — no internal module coupling
+4. `NO_COLOR=1` is set on subprocesses; ANSI escape codes are stripped from output
+5. Input forms validate required fields before submission; empty optional fields use defaults
+6. Template Browser launches as a nested full-screen TUI, restoring the dashboard on exit
+7. Output panel is scrollable with `↑↓`, `PgUp`/`PgDn`, `g`/`G`
+8. `Ctrl+C` always exits cleanly, restoring terminal state
+9. Terminal raw mode and alternate screen are properly entered/exited, including on error paths
+10. The `tui` feature gate controls all TUI code via `#[cfg(feature = "tui")]`
+
+## Behavioral Examples
+
+```
+$ fledge tui
+
+  ┌─ Categories ──────┬─ Work ──────────────────────────┐
+  │ ▶ ⎇ Work          │ ▶ Start Branch     Create a new │
+  │   ⊙ GitHub        │   Create PR        Open a pull  │
+  │   ▶ Run           │   Status           Show current │
+  │   📋 Specs         │                                  │
+  │   📊 Metrics       │                                  │
+  │   ⚙ Config        │                                  │
+  │   📦 Templates     │                                  │
+  │   ✦ AI            │                                  │
+  │   🩺 Doctor        │                                  │
+  │   📝 Changelog     │                                  │
+  │   🔌 Plugins       │                                  │
+  └───────────────────┴──────────────────────────────────┘
+  ↑↓ navigate  ⏎/→ open category  q quit
+```
+
+## Error Cases
+
+| Error | When | Behavior |
+|-------|------|----------|
+| Terminal setup fails | Cannot enter raw mode | anyhow error |
+| Command not found | `current_exe()` fails | Error shown in output panel |
+| Subprocess fails | Command returns non-zero | Exit code shown in output panel |
+| Required field empty | User submits form without filling required field | Error popup shown |
+
+## Dependencies
+
+- `ratatui` for TUI rendering (optional, feature-gated)
+- `crossterm` for terminal control (optional, feature-gated)
+- `crate::config::Config` for detecting project config
+- `crate::templates` for template browser integration
+- `crate::init` for git init in template scaffolding
+
+## Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1 | 2026-04-20 | Initial spec — full dashboard with 11 categories, 40+ actions |

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,13 +304,13 @@ enum Commands {
         /// The question to ask
         question: Vec<String>,
     },
-    /// Interactive TUI for browsing and scaffolding templates (requires --features tui)
+    /// Interactive TUI dashboard — browse and run all fledge commands (requires --features tui)
     #[cfg(feature = "tui")]
     Tui {
-        /// Parent directory for the project
+        /// Parent directory for template scaffolding
         #[arg(short, long, default_value = ".")]
         output: PathBuf,
-        /// Skip git init and initial commit
+        /// Skip git init for template scaffolding
         #[arg(long)]
         no_git: bool,
     },

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,6 +13,7 @@ use ratatui::{
 };
 use std::io;
 use std::path::PathBuf;
+use std::process::Command;
 
 use crate::config::Config;
 use crate::templates::Template;
@@ -22,14 +23,1272 @@ const DIM: Color = Color::DarkGray;
 const GREEN: Color = Color::Green;
 const WHITE: Color = Color::White;
 const YELLOW: Color = Color::Yellow;
+const RED: Color = Color::Red;
 
-#[derive(PartialEq)]
-enum Screen {
-    SelectTemplate,
-    InputVariables,
-    Confirm,
-    Done,
+// ─── Action Definitions ─────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct ActionDef {
+    name: &'static str,
+    description: &'static str,
+    kind: ActionKind,
 }
+
+#[derive(Clone)]
+enum ActionKind {
+    Direct(Vec<&'static str>),
+    WithInput {
+        fields: Vec<FieldDef>,
+        action_id: ActionId,
+    },
+    TemplateBrowser,
+}
+
+#[derive(Clone, Copy)]
+enum ActionId {
+    WorkStart,
+    WorkPr,
+    SpecNew,
+    RunTask,
+    RunFlow,
+    SearchTemplates,
+    CreateTemplate,
+    ConfigGet,
+    ConfigSet,
+    AskQuestion,
+    IssueView,
+    PrView,
+    PluginInstall,
+    PluginRemove,
+    PluginSearch,
+    PluginRun,
+}
+
+#[derive(Clone)]
+struct FieldDef {
+    label: &'static str,
+    default: &'static str,
+    required: bool,
+}
+
+struct CategoryDef {
+    name: &'static str,
+    icon: &'static str,
+    description: &'static str,
+    actions: Vec<ActionDef>,
+}
+
+fn build_categories() -> Vec<CategoryDef> {
+    vec![
+        CategoryDef {
+            name: "Work",
+            icon: "⎇",
+            description: "Branch workflow",
+            actions: vec![
+                ActionDef {
+                    name: "Start Branch",
+                    description: "Create a new work branch",
+                    kind: ActionKind::WithInput {
+                        fields: vec![
+                            FieldDef {
+                                label: "Branch name",
+                                default: "",
+                                required: true,
+                            },
+                            FieldDef {
+                                label: "Type (feat/fix/chore/docs/hotfix/refactor)",
+                                default: "feat",
+                                required: false,
+                            },
+                            FieldDef {
+                                label: "Issue number",
+                                default: "",
+                                required: false,
+                            },
+                            FieldDef {
+                                label: "Base branch",
+                                default: "main",
+                                required: false,
+                            },
+                        ],
+                        action_id: ActionId::WorkStart,
+                    },
+                },
+                ActionDef {
+                    name: "Create PR",
+                    description: "Open a pull request from current branch",
+                    kind: ActionKind::WithInput {
+                        fields: vec![
+                            FieldDef {
+                                label: "Title (auto if empty)",
+                                default: "",
+                                required: false,
+                            },
+                            FieldDef {
+                                label: "Body",
+                                default: "",
+                                required: false,
+                            },
+                        ],
+                        action_id: ActionId::WorkPr,
+                    },
+                },
+                ActionDef {
+                    name: "Status",
+                    description: "Show current branch and PR status",
+                    kind: ActionKind::Direct(vec!["work", "status"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "GitHub",
+            icon: "⊙",
+            description: "Issues, PRs, CI checks",
+            actions: vec![
+                ActionDef {
+                    name: "List Issues",
+                    description: "Show open GitHub issues",
+                    kind: ActionKind::Direct(vec!["issues"]),
+                },
+                ActionDef {
+                    name: "View Issue",
+                    description: "View a specific issue by number",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Issue number",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::IssueView,
+                    },
+                },
+                ActionDef {
+                    name: "List PRs",
+                    description: "Show open pull requests",
+                    kind: ActionKind::Direct(vec!["prs"]),
+                },
+                ActionDef {
+                    name: "View PR",
+                    description: "View a specific PR by number",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "PR number",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::PrView,
+                    },
+                },
+                ActionDef {
+                    name: "CI Checks",
+                    description: "View CI/CD status for current branch",
+                    kind: ActionKind::Direct(vec!["checks"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Run",
+            icon: "▶",
+            description: "Tasks and flows",
+            actions: vec![
+                ActionDef {
+                    name: "List Tasks",
+                    description: "Show available tasks from fledge.toml",
+                    kind: ActionKind::Direct(vec!["run", "--list"]),
+                },
+                ActionDef {
+                    name: "Run Task",
+                    description: "Execute a named task",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Task name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::RunTask,
+                    },
+                },
+                ActionDef {
+                    name: "List Flows",
+                    description: "Show available workflow pipelines",
+                    kind: ActionKind::Direct(vec!["flow", "--list"]),
+                },
+                ActionDef {
+                    name: "Run Flow",
+                    description: "Execute a workflow pipeline",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Flow name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::RunFlow,
+                    },
+                },
+                ActionDef {
+                    name: "Init Tasks",
+                    description: "Create a starter fledge.toml",
+                    kind: ActionKind::Direct(vec!["run", "--init"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Specs",
+            icon: "📋",
+            description: "Spec-sync management",
+            actions: vec![
+                ActionDef {
+                    name: "Check",
+                    description: "Validate specs against source code",
+                    kind: ActionKind::Direct(vec!["spec", "check"]),
+                },
+                ActionDef {
+                    name: "Init",
+                    description: "Initialize spec-sync configuration",
+                    kind: ActionKind::Direct(vec!["spec", "init"]),
+                },
+                ActionDef {
+                    name: "New Module",
+                    description: "Scaffold a new spec module",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Module name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::SpecNew,
+                    },
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Metrics",
+            icon: "📊",
+            description: "Code metrics and deps",
+            actions: vec![
+                ActionDef {
+                    name: "Overview",
+                    description: "Lines of code by language",
+                    kind: ActionKind::Direct(vec!["metrics"]),
+                },
+                ActionDef {
+                    name: "File Churn",
+                    description: "Most-changed files from git history",
+                    kind: ActionKind::Direct(vec!["metrics", "--churn"]),
+                },
+                ActionDef {
+                    name: "Test Ratio",
+                    description: "Test file detection and coverage ratio",
+                    kind: ActionKind::Direct(vec!["metrics", "--tests"]),
+                },
+                ActionDef {
+                    name: "Outdated Deps",
+                    description: "Check for outdated dependencies",
+                    kind: ActionKind::Direct(vec!["deps", "--outdated"]),
+                },
+                ActionDef {
+                    name: "Security Audit",
+                    description: "Run security audit on dependencies",
+                    kind: ActionKind::Direct(vec!["deps", "--audit"]),
+                },
+                ActionDef {
+                    name: "Licenses",
+                    description: "Show dependency licenses",
+                    kind: ActionKind::Direct(vec!["deps", "--licenses"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Config",
+            icon: "⚙",
+            description: "Settings management",
+            actions: vec![
+                ActionDef {
+                    name: "List All",
+                    description: "Show all config values",
+                    kind: ActionKind::Direct(vec!["config", "list"]),
+                },
+                ActionDef {
+                    name: "Get Value",
+                    description: "Read a config key",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Key (e.g. defaults.author)",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::ConfigGet,
+                    },
+                },
+                ActionDef {
+                    name: "Set Value",
+                    description: "Write a config key",
+                    kind: ActionKind::WithInput {
+                        fields: vec![
+                            FieldDef {
+                                label: "Key",
+                                default: "",
+                                required: true,
+                            },
+                            FieldDef {
+                                label: "Value",
+                                default: "",
+                                required: true,
+                            },
+                        ],
+                        action_id: ActionId::ConfigSet,
+                    },
+                },
+                ActionDef {
+                    name: "Config Path",
+                    description: "Show config file location",
+                    kind: ActionKind::Direct(vec!["config", "path"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Templates",
+            icon: "📦",
+            description: "Browse, search, create",
+            actions: vec![
+                ActionDef {
+                    name: "Browse & Scaffold",
+                    description: "Interactive template browser",
+                    kind: ActionKind::TemplateBrowser,
+                },
+                ActionDef {
+                    name: "List",
+                    description: "Show available templates",
+                    kind: ActionKind::Direct(vec!["list"]),
+                },
+                ActionDef {
+                    name: "Search GitHub",
+                    description: "Find templates on GitHub",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Search query",
+                            default: "",
+                            required: false,
+                        }],
+                        action_id: ActionId::SearchTemplates,
+                    },
+                },
+                ActionDef {
+                    name: "Create Template",
+                    description: "Scaffold a new fledge template",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Template name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::CreateTemplate,
+                    },
+                },
+                ActionDef {
+                    name: "Validate",
+                    description: "Validate templates in current directory",
+                    kind: ActionKind::Direct(vec!["validate-template"]),
+                },
+                ActionDef {
+                    name: "Update Project",
+                    description: "Re-apply source template to project",
+                    kind: ActionKind::Direct(vec!["update", "--yes"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "AI",
+            icon: "✦",
+            description: "Code review and Q&A",
+            actions: vec![
+                ActionDef {
+                    name: "Code Review",
+                    description: "AI-powered review of current changes",
+                    kind: ActionKind::Direct(vec!["review"]),
+                },
+                ActionDef {
+                    name: "Ask Question",
+                    description: "Ask a question about your codebase",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Question",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::AskQuestion,
+                    },
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Doctor",
+            icon: "🩺",
+            description: "Environment diagnostics",
+            actions: vec![ActionDef {
+                name: "Run Diagnostics",
+                description: "Check project environment health",
+                kind: ActionKind::Direct(vec!["doctor"]),
+            }],
+        },
+        CategoryDef {
+            name: "Changelog",
+            icon: "📝",
+            description: "Release history",
+            actions: vec![
+                ActionDef {
+                    name: "Generate",
+                    description: "Changelog from git tags and commits",
+                    kind: ActionKind::Direct(vec!["changelog"]),
+                },
+                ActionDef {
+                    name: "Unreleased",
+                    description: "Changes since latest tag",
+                    kind: ActionKind::Direct(vec!["changelog", "--unreleased"]),
+                },
+            ],
+        },
+        CategoryDef {
+            name: "Plugins",
+            icon: "🔌",
+            description: "Community extensions",
+            actions: vec![
+                ActionDef {
+                    name: "List Installed",
+                    description: "Show installed plugins",
+                    kind: ActionKind::Direct(vec!["plugin", "list"]),
+                },
+                ActionDef {
+                    name: "Search",
+                    description: "Find plugins on GitHub",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Search query",
+                            default: "",
+                            required: false,
+                        }],
+                        action_id: ActionId::PluginSearch,
+                    },
+                },
+                ActionDef {
+                    name: "Install",
+                    description: "Install a plugin from GitHub (owner/repo)",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Source (owner/repo)",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::PluginInstall,
+                    },
+                },
+                ActionDef {
+                    name: "Remove",
+                    description: "Remove an installed plugin",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Plugin name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::PluginRemove,
+                    },
+                },
+                ActionDef {
+                    name: "Run Command",
+                    description: "Execute a plugin command",
+                    kind: ActionKind::WithInput {
+                        fields: vec![FieldDef {
+                            label: "Command name",
+                            default: "",
+                            required: true,
+                        }],
+                        action_id: ActionId::PluginRun,
+                    },
+                },
+            ],
+        },
+    ]
+}
+
+fn build_command(action_id: ActionId, fields: &[String]) -> Vec<String> {
+    match action_id {
+        ActionId::WorkStart => {
+            let mut args = vec!["work".into(), "start".into(), fields[0].clone()];
+            let typ = if fields[1].is_empty() {
+                "feat"
+            } else {
+                &fields[1]
+            };
+            if typ != "feat" {
+                args.extend(["--type".into(), typ.to_string()]);
+            }
+            if !fields[2].is_empty() {
+                args.extend(["--issue".into(), fields[2].clone()]);
+            }
+            let base = if fields[3].is_empty() {
+                "main"
+            } else {
+                &fields[3]
+            };
+            if base != "main" {
+                args.extend(["--base".into(), base.to_string()]);
+            }
+            args
+        }
+        ActionId::WorkPr => {
+            let mut args = vec!["work".into(), "pr".into()];
+            if !fields[0].is_empty() {
+                args.extend(["--title".into(), fields[0].clone()]);
+            }
+            if !fields[1].is_empty() {
+                args.extend(["--body".into(), fields[1].clone()]);
+            }
+            args
+        }
+        ActionId::SpecNew => vec!["spec".into(), "new".into(), fields[0].clone()],
+        ActionId::RunTask => vec!["run".into(), fields[0].clone()],
+        ActionId::RunFlow => vec!["flow".into(), fields[0].clone()],
+        ActionId::SearchTemplates => {
+            let mut args = vec!["search".into()];
+            if !fields[0].is_empty() {
+                args.push(fields[0].clone());
+            }
+            args
+        }
+        ActionId::CreateTemplate => {
+            vec!["create-template".into(), fields[0].clone()]
+        }
+        ActionId::ConfigGet => vec!["config".into(), "get".into(), fields[0].clone()],
+        ActionId::ConfigSet => {
+            vec![
+                "config".into(),
+                "set".into(),
+                fields[0].clone(),
+                fields[1].clone(),
+            ]
+        }
+        ActionId::AskQuestion => {
+            let mut args = vec!["ask".into()];
+            args.extend(fields[0].split_whitespace().map(String::from));
+            args
+        }
+        ActionId::IssueView => {
+            vec!["issues".into(), "view".into(), fields[0].clone()]
+        }
+        ActionId::PrView => {
+            vec!["prs".into(), "view".into(), fields[0].clone()]
+        }
+        ActionId::PluginInstall => {
+            vec!["plugin".into(), "install".into(), fields[0].clone()]
+        }
+        ActionId::PluginRemove => {
+            vec!["plugin".into(), "remove".into(), fields[0].clone()]
+        }
+        ActionId::PluginSearch => {
+            let mut args = vec!["plugin".into(), "search".into()];
+            if !fields[0].is_empty() {
+                args.push(fields[0].clone());
+            }
+            args
+        }
+        ActionId::PluginRun => {
+            vec!["plugin".into(), "run".into(), fields[0].clone()]
+        }
+    }
+}
+
+// ─── Dashboard State ────────────────────────────────────────────────────────
+
+enum DashFocus {
+    Categories,
+    Actions,
+}
+
+enum DashScreen {
+    Browse,
+    Input,
+    Output,
+}
+
+struct InputField {
+    label: String,
+    default: String,
+    value: String,
+    required: bool,
+}
+
+struct DashboardApp {
+    categories: Vec<CategoryDef>,
+    focus: DashFocus,
+    screen: DashScreen,
+    cat_state: ListState,
+    act_state: ListState,
+    selected_cat: usize,
+    selected_action: usize,
+    input_fields: Vec<InputField>,
+    active_field: usize,
+    current_action_id: Option<ActionId>,
+    output_lines: Vec<String>,
+    output_scroll: usize,
+    error_message: Option<String>,
+    should_quit: bool,
+}
+
+impl DashboardApp {
+    fn new() -> Self {
+        let categories = build_categories();
+        let mut cat_state = ListState::default();
+        cat_state.select(Some(0));
+        let mut act_state = ListState::default();
+        act_state.select(Some(0));
+        Self {
+            categories,
+            focus: DashFocus::Categories,
+            screen: DashScreen::Browse,
+            cat_state,
+            act_state,
+            selected_cat: 0,
+            selected_action: 0,
+            input_fields: Vec::new(),
+            active_field: 0,
+            current_action_id: None,
+            output_lines: Vec::new(),
+            output_scroll: 0,
+            error_message: None,
+            should_quit: false,
+        }
+    }
+
+    fn current_actions(&self) -> &[ActionDef] {
+        &self.categories[self.selected_cat].actions
+    }
+
+    fn execute_action(&mut self, action: &ActionDef) {
+        match &action.kind {
+            ActionKind::Direct(args) => {
+                let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+                self.run_command(&args);
+            }
+            ActionKind::WithInput { fields, action_id } => {
+                self.input_fields = fields
+                    .iter()
+                    .map(|f| InputField {
+                        label: f.label.to_string(),
+                        default: f.default.to_string(),
+                        value: String::new(),
+                        required: f.required,
+                    })
+                    .collect();
+                self.active_field = 0;
+                self.current_action_id = Some(*action_id);
+                self.screen = DashScreen::Input;
+            }
+            ActionKind::TemplateBrowser => {}
+        }
+    }
+
+    fn submit_input(&mut self) {
+        for field in &self.input_fields {
+            if field.required && field.value.is_empty() && field.default.is_empty() {
+                self.error_message = Some(format!("{} is required", field.label));
+                return;
+            }
+        }
+
+        let field_values: Vec<String> = self
+            .input_fields
+            .iter()
+            .map(|f| {
+                if f.value.is_empty() {
+                    f.default.clone()
+                } else {
+                    f.value.clone()
+                }
+            })
+            .collect();
+
+        if let Some(action_id) = self.current_action_id {
+            let args = build_command(action_id, &field_values);
+            self.run_command(&args);
+        }
+    }
+
+    fn run_command(&mut self, args: &[String]) {
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                self.output_lines = vec![format!("Error finding executable: {}", e)];
+                self.output_scroll = 0;
+                self.screen = DashScreen::Output;
+                return;
+            }
+        };
+
+        let result = Command::new(&exe).args(args).env("NO_COLOR", "1").output();
+
+        match result {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let mut lines: Vec<String> = Vec::new();
+
+                let cmd_display = format!("fledge {}", args.join(" "));
+                lines.push(format!("$ {}", cmd_display));
+                lines.push(String::new());
+
+                if !stdout.is_empty() {
+                    for line in stdout.lines() {
+                        lines.push(strip_ansi(line));
+                    }
+                }
+
+                if !stderr.is_empty() {
+                    if !stdout.is_empty() {
+                        lines.push(String::new());
+                    }
+                    for line in stderr.lines() {
+                        lines.push(strip_ansi(line));
+                    }
+                }
+
+                if stdout.is_empty() && stderr.is_empty() {
+                    lines.push("(no output)".into());
+                }
+
+                if !output.status.success() {
+                    lines.push(String::new());
+                    lines.push(format!("Exit code: {}", output.status.code().unwrap_or(-1)));
+                }
+
+                self.output_lines = lines;
+            }
+            Err(e) => {
+                self.output_lines = vec![format!("Failed to run command: {}", e)];
+            }
+        }
+
+        self.output_scroll = 0;
+        self.screen = DashScreen::Output;
+    }
+}
+
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if nc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+// ─── Dashboard Entry Point ──────────────────────────────────────────────────
+
+pub fn run(output_dir: PathBuf, no_git: bool) -> Result<()> {
+    let mut app = DashboardApp::new();
+
+    enable_raw_mode()?;
+    crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = dashboard_loop(&mut terminal, &mut app, output_dir, no_git);
+
+    disable_raw_mode()?;
+    crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
+
+    result
+}
+
+fn dashboard_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut DashboardApp,
+    output_dir: PathBuf,
+    no_git: bool,
+) -> Result<()> {
+    loop {
+        terminal.draw(|f| draw_dashboard(f, app))?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                return Ok(());
+            }
+
+            app.error_message = None;
+
+            match app.screen {
+                DashScreen::Browse => {
+                    if handle_browse(app, key.code) {
+                        let action = app.current_actions()[app.selected_action].clone();
+                        if matches!(action.kind, ActionKind::TemplateBrowser) {
+                            disable_raw_mode()?;
+                            crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
+
+                            let tui_result = run_template_browser(output_dir.clone(), no_git);
+
+                            enable_raw_mode()?;
+                            crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
+                            *terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+
+                            if let Err(e) = tui_result {
+                                app.error_message = Some(format!("{}", e));
+                            }
+                        } else {
+                            app.execute_action(&action);
+                        }
+                    }
+                }
+                DashScreen::Input => handle_input(app, key.code),
+                DashScreen::Output => handle_output(app, key.code),
+            }
+
+            if app.should_quit {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn handle_browse(app: &mut DashboardApp, key: KeyCode) -> bool {
+    match app.focus {
+        DashFocus::Categories => match key {
+            KeyCode::Up | KeyCode::Char('k') => {
+                let total = app.categories.len();
+                let cur = app.selected_cat;
+                app.selected_cat = if cur == 0 { total - 1 } else { cur - 1 };
+                app.cat_state.select(Some(app.selected_cat));
+                app.selected_action = 0;
+                app.act_state.select(Some(0));
+                false
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let total = app.categories.len();
+                let cur = app.selected_cat;
+                app.selected_cat = if cur >= total - 1 { 0 } else { cur + 1 };
+                app.cat_state.select(Some(app.selected_cat));
+                app.selected_action = 0;
+                app.act_state.select(Some(0));
+                false
+            }
+            KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => {
+                app.focus = DashFocus::Actions;
+                false
+            }
+            KeyCode::Char('q') | KeyCode::Esc => {
+                app.should_quit = true;
+                false
+            }
+            _ => false,
+        },
+        DashFocus::Actions => match key {
+            KeyCode::Up | KeyCode::Char('k') => {
+                let total = app.current_actions().len();
+                let cur = app.selected_action;
+                app.selected_action = if cur == 0 { total - 1 } else { cur - 1 };
+                app.act_state.select(Some(app.selected_action));
+                false
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let total = app.current_actions().len();
+                let cur = app.selected_action;
+                app.selected_action = if cur >= total - 1 { 0 } else { cur + 1 };
+                app.act_state.select(Some(app.selected_action));
+                false
+            }
+            KeyCode::Enter => true,
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::Esc | KeyCode::BackTab => {
+                app.focus = DashFocus::Categories;
+                false
+            }
+            KeyCode::Char('q') => {
+                app.should_quit = true;
+                false
+            }
+            _ => false,
+        },
+    }
+}
+
+fn handle_input(app: &mut DashboardApp, key: KeyCode) {
+    match key {
+        KeyCode::Up => {
+            if app.active_field > 0 {
+                app.active_field -= 1;
+            }
+        }
+        KeyCode::Down => {
+            if app.active_field < app.input_fields.len() - 1 {
+                app.active_field += 1;
+            }
+        }
+        KeyCode::Tab => {
+            app.active_field = (app.active_field + 1) % app.input_fields.len();
+        }
+        KeyCode::BackTab => {
+            app.active_field = if app.active_field == 0 {
+                app.input_fields.len() - 1
+            } else {
+                app.active_field - 1
+            };
+        }
+        KeyCode::Char(c) => {
+            app.input_fields[app.active_field].value.push(c);
+        }
+        KeyCode::Backspace => {
+            app.input_fields[app.active_field].value.pop();
+        }
+        KeyCode::Enter => {
+            app.submit_input();
+        }
+        KeyCode::Esc => {
+            app.screen = DashScreen::Browse;
+            app.focus = DashFocus::Actions;
+        }
+        _ => {}
+    }
+}
+
+fn handle_output(app: &mut DashboardApp, key: KeyCode) {
+    match key {
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.output_scroll = app.output_scroll.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.output_scroll + 1 < app.output_lines.len() {
+                app.output_scroll += 1;
+            }
+        }
+        KeyCode::PageUp => {
+            app.output_scroll = app.output_scroll.saturating_sub(20);
+        }
+        KeyCode::PageDown => {
+            app.output_scroll =
+                (app.output_scroll + 20).min(app.output_lines.len().saturating_sub(1));
+        }
+        KeyCode::Home | KeyCode::Char('g') => {
+            app.output_scroll = 0;
+        }
+        KeyCode::End | KeyCode::Char('G') => {
+            app.output_scroll = app.output_lines.len().saturating_sub(1);
+        }
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Backspace => {
+            app.screen = DashScreen::Browse;
+            app.focus = DashFocus::Actions;
+        }
+        _ => {}
+    }
+}
+
+// ─── Dashboard Drawing ──────────────────────────────────────────────────────
+
+fn draw_dashboard(f: &mut Frame, app: &mut DashboardApp) {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    draw_dash_header(f, outer[0]);
+
+    match app.screen {
+        DashScreen::Browse => draw_browse_panels(f, app, outer[1]),
+        DashScreen::Input => draw_input_form(f, app, outer[1]),
+        DashScreen::Output => draw_output_panel(f, app, outer[1]),
+    }
+
+    draw_dash_footer(f, app, outer[2]);
+
+    if let Some(ref msg) = app.error_message {
+        draw_error_popup(f, msg);
+    }
+}
+
+fn draw_dash_header(f: &mut Frame, area: Rect) {
+    let title = Line::from(vec![
+        Span::styled(
+            " fledge ",
+            Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("— dev lifecycle dashboard", Style::default().fg(DIM)),
+    ]);
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(DIM));
+    f.render_widget(Paragraph::new(title).block(block), area);
+}
+
+fn draw_dash_footer(f: &mut Frame, app: &DashboardApp, area: Rect) {
+    let hints = match app.screen {
+        DashScreen::Browse => match app.focus {
+            DashFocus::Categories => "↑↓ navigate  ⏎/→ open category  q quit",
+            DashFocus::Actions => "↑↓ navigate  ⏎ run  ←/Esc back  q quit",
+        },
+        DashScreen::Input => "↑↓/Tab fields  type to edit  ⏎ submit  Esc back",
+        DashScreen::Output => "↑↓ scroll  PgUp/PgDn  g/G top/bottom  Esc back",
+    };
+    let footer = Paragraph::new(Line::from(Span::styled(hints, Style::default().fg(DIM)))).block(
+        Block::default()
+            .borders(Borders::TOP)
+            .border_style(Style::default().fg(DIM)),
+    );
+    f.render_widget(footer, area);
+}
+
+fn draw_browse_panels(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
+    let panels = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+        .split(area);
+
+    draw_category_list(f, app, panels[0]);
+    draw_action_list(f, app, panels[1]);
+}
+
+fn draw_category_list(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
+    let is_focused = matches!(app.focus, DashFocus::Categories);
+    let border_color = if is_focused { CYAN } else { DIM };
+
+    let items: Vec<ListItem> = app
+        .categories
+        .iter()
+        .map(|cat| {
+            let line = Line::from(vec![
+                Span::styled(format!(" {} ", cat.icon), Style::default().fg(DIM)),
+                Span::styled(format!("{:<12}", cat.name), Style::default().fg(GREEN)),
+                Span::styled(cat.description, Style::default().fg(DIM)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(" Categories ")
+                .title_style(
+                    Style::default()
+                        .fg(if is_focused { CYAN } else { DIM })
+                        .add_modifier(Modifier::BOLD),
+                )
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(border_color)),
+        )
+        .highlight_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(list, area, &mut app.cat_state);
+}
+
+fn draw_action_list(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
+    let is_focused = matches!(app.focus, DashFocus::Actions);
+    let border_color = if is_focused { CYAN } else { DIM };
+    let cat_name = app.categories[app.selected_cat].name;
+
+    let actions = app.current_actions();
+    let items: Vec<ListItem> = actions
+        .iter()
+        .map(|act| {
+            let tag = match &act.kind {
+                ActionKind::Direct(_) => Span::styled("  ", Style::default()),
+                ActionKind::WithInput { .. } => Span::styled(" ✎ ", Style::default().fg(YELLOW)),
+                ActionKind::TemplateBrowser => Span::styled(" ⊞ ", Style::default().fg(YELLOW)),
+            };
+            let line = Line::from(vec![
+                tag,
+                Span::styled(format!("{:<20}", act.name), Style::default().fg(GREEN)),
+                Span::styled(act.description, Style::default().fg(DIM)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(format!(" {} ", cat_name))
+                .title_style(
+                    Style::default()
+                        .fg(if is_focused { CYAN } else { DIM })
+                        .add_modifier(Modifier::BOLD),
+                )
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(border_color)),
+        )
+        .highlight_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+
+    f.render_stateful_widget(list, area, &mut app.act_state);
+}
+
+fn draw_input_form(f: &mut Frame, app: &DashboardApp, area: Rect) {
+    let cat_name = app.categories[app.selected_cat].name;
+    let act_name = app.current_actions()[app.selected_action].name;
+
+    let block = Block::default()
+        .title(format!(" {} — {} ", cat_name, act_name))
+        .title_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(CYAN));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let field_height = 2u16;
+    let scroll_offset = if app.active_field as u16 * field_height > inner.height.saturating_sub(2) {
+        (app.active_field as u16 * field_height).saturating_sub(inner.height.saturating_sub(2))
+    } else {
+        0
+    };
+
+    for (i, field) in app.input_fields.iter().enumerate() {
+        let field_y = (i as u16 * field_height).saturating_sub(scroll_offset);
+        if field_y + field_height > inner.height || (i as u16 * field_height) < scroll_offset {
+            continue;
+        }
+
+        let actual_y = inner.y + field_y;
+        if actual_y >= inner.y + inner.height {
+            break;
+        }
+
+        let is_active = i == app.active_field;
+
+        let label_style = if is_active {
+            Style::default().fg(CYAN).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(WHITE)
+        };
+
+        let req_marker = if field.required { "*" } else { "" };
+
+        let label_area = Rect::new(inner.x + 1, actual_y, inner.width.saturating_sub(2), 1);
+        let label = Paragraph::new(Line::from(vec![
+            Span::styled(&field.label, label_style),
+            Span::styled(req_marker, Style::default().fg(RED)),
+            Span::styled(": ", label_style),
+        ]));
+        f.render_widget(label, label_area);
+
+        let prefix_len = field.label.len() + req_marker.len() + 2;
+        let input_x = inner.x + 1 + prefix_len as u16;
+        let input_width = inner.width.saturating_sub(prefix_len as u16 + 2);
+        let input_area = Rect::new(input_x, actual_y, input_width, 1);
+
+        let display_val = if field.value.is_empty() && !field.default.is_empty() {
+            Span::styled(&field.default, Style::default().fg(DIM))
+        } else {
+            Span::styled(&field.value, Style::default().fg(WHITE))
+        };
+
+        let mut spans = vec![display_val];
+        if is_active {
+            spans.push(Span::styled("▎", Style::default().fg(CYAN)));
+        }
+
+        f.render_widget(Paragraph::new(Line::from(spans)), input_area);
+    }
+}
+
+fn draw_output_panel(f: &mut Frame, app: &DashboardApp, area: Rect) {
+    let block = Block::default()
+        .title(" Output ")
+        .title_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(CYAN));
+
+    let inner = block.inner(area);
+    let visible_height = inner.height as usize;
+
+    let lines: Vec<Line> = app
+        .output_lines
+        .iter()
+        .skip(app.output_scroll)
+        .take(visible_height)
+        .map(|line| {
+            if line.starts_with("$ ") {
+                Line::from(Span::styled(
+                    line.as_str(),
+                    Style::default().fg(YELLOW).add_modifier(Modifier::BOLD),
+                ))
+            } else if line.starts_with("Exit code:") || line.starts_with("error:") {
+                Line::from(Span::styled(line.as_str(), Style::default().fg(RED)))
+            } else if line.starts_with("(no output)") {
+                Line::from(Span::styled(line.as_str(), Style::default().fg(DIM)))
+            } else {
+                Line::from(Span::styled(line.as_str(), Style::default().fg(WHITE)))
+            }
+        })
+        .collect();
+
+    let total = app.output_lines.len();
+    let scroll_info = if total > visible_height {
+        format!(
+            " {}/{} ",
+            app.output_scroll + 1,
+            total.saturating_sub(visible_height) + 1
+        )
+    } else {
+        String::new()
+    };
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(" Output ")
+            .title_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
+            .title_bottom(Line::from(Span::styled(
+                scroll_info,
+                Style::default().fg(DIM),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(CYAN)),
+    );
+
+    f.render_widget(paragraph, area);
+}
+
+fn draw_error_popup(f: &mut Frame, msg: &str) {
+    let area = f.area();
+    let popup_width = (msg.len() as u16 + 6).min(area.width.saturating_sub(4));
+    let popup_height = 5;
+    let x = (area.width.saturating_sub(popup_width)) / 2;
+    let y = (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Error ")
+        .title_style(Style::default().fg(RED).add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(RED));
+
+    let text = Paragraph::new(Line::from(Span::styled(msg, Style::default().fg(RED))))
+        .block(block)
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(text, popup_area);
+}
+
+// ─── Template Browser (existing functionality) ──────────────────────────────
 
 struct VariableField {
     key: String,
@@ -38,10 +1297,18 @@ struct VariableField {
     default: String,
 }
 
-pub struct TuiApp {
+#[derive(PartialEq)]
+enum TemplateScreen {
+    SelectTemplate,
+    InputVariables,
+    Confirm,
+    Done,
+}
+
+struct TemplateBrowserApp {
     config: Config,
     templates: Vec<Template>,
-    screen: Screen,
+    screen: TemplateScreen,
     list_state: ListState,
     selected_template: Option<usize>,
     variables: Vec<VariableField>,
@@ -54,22 +1321,16 @@ pub struct TuiApp {
     should_quit: bool,
 }
 
-impl TuiApp {
-    pub fn new(
-        config: Config,
-        templates: Vec<Template>,
-        output_dir: PathBuf,
-        no_git: bool,
-    ) -> Self {
+impl TemplateBrowserApp {
+    fn new(config: Config, templates: Vec<Template>, output_dir: PathBuf, no_git: bool) -> Self {
         let mut list_state = ListState::default();
         if !templates.is_empty() {
             list_state.select(Some(0));
         }
-
         Self {
             config,
             templates,
-            screen: Screen::SelectTemplate,
+            screen: TemplateScreen::SelectTemplate,
             list_state,
             selected_template: None,
             variables: Vec::new(),
@@ -215,7 +1476,7 @@ fn to_pascal_case(s: &str) -> String {
         .collect()
 }
 
-pub fn run(output_dir: PathBuf, no_git: bool) -> Result<()> {
+fn run_template_browser(output_dir: PathBuf, no_git: bool) -> Result<()> {
     let config = Config::load().context("loading config")?;
     let extra_paths = config.extra_template_paths();
     let token = config.github_token();
@@ -229,14 +1490,14 @@ pub fn run(output_dir: PathBuf, no_git: bool) -> Result<()> {
         bail!("No templates found.");
     }
 
-    let mut app = TuiApp::new(config, templates, output_dir, no_git);
+    let mut app = TemplateBrowserApp::new(config, templates, output_dir, no_git);
 
     enable_raw_mode()?;
     crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_loop(&mut terminal, &mut app);
+    let result = template_browser_loop(&mut terminal, &mut app);
 
     disable_raw_mode()?;
     crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
@@ -244,9 +1505,12 @@ pub fn run(output_dir: PathBuf, no_git: bool) -> Result<()> {
     result
 }
 
-fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut TuiApp) -> Result<()> {
+fn template_browser_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut TemplateBrowserApp,
+) -> Result<()> {
     loop {
-        terminal.draw(|f| draw(f, app))?;
+        terminal.draw(|f| draw_template_browser(f, app))?;
 
         if let Event::Key(key) = event::read()? {
             if key.kind != KeyEventKind::Press {
@@ -264,10 +1528,10 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut Tui
             app.error_message = None;
 
             match app.screen {
-                Screen::SelectTemplate => handle_select_template(app, key.code),
-                Screen::InputVariables => handle_input_variables(app, key.code),
-                Screen::Confirm => handle_confirm(app, key.code),
-                Screen::Done => {
+                TemplateScreen::SelectTemplate => handle_select_template(app, key.code),
+                TemplateScreen::InputVariables => handle_input_variables(app, key.code),
+                TemplateScreen::Confirm => handle_confirm(app, key.code),
+                TemplateScreen::Done => {
                     if matches!(key.code, KeyCode::Enter | KeyCode::Char('q') | KeyCode::Esc) {
                         return Ok(());
                     }
@@ -281,7 +1545,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut Tui
     }
 }
 
-fn handle_select_template(app: &mut TuiApp, key: KeyCode) {
+fn handle_select_template(app: &mut TemplateBrowserApp, key: KeyCode) {
     match key {
         KeyCode::Up | KeyCode::Char('k') => {
             let i = app.list_state.selected().unwrap_or(0);
@@ -307,7 +1571,7 @@ fn handle_select_template(app: &mut TuiApp, key: KeyCode) {
                 let tpl = &app.templates[idx];
                 let tpl_clone = clone_template_for_fields(tpl);
                 app.build_variable_fields(&tpl_clone);
-                app.screen = Screen::InputVariables;
+                app.screen = TemplateScreen::InputVariables;
             }
         }
         KeyCode::Esc | KeyCode::Char('q') => {
@@ -355,7 +1619,7 @@ fn clone_template_for_fields(tpl: &Template) -> Template {
     }
 }
 
-fn handle_input_variables(app: &mut TuiApp, key: KeyCode) {
+fn handle_input_variables(app: &mut TemplateBrowserApp, key: KeyCode) {
     match key {
         KeyCode::Up => {
             if app.active_field > 0 {
@@ -391,27 +1655,27 @@ fn handle_input_variables(app: &mut TuiApp, key: KeyCode) {
                 return;
             }
             app.project_name = project_name;
-            app.screen = Screen::Confirm;
+            app.screen = TemplateScreen::Confirm;
         }
         KeyCode::Esc => {
-            app.screen = Screen::SelectTemplate;
+            app.screen = TemplateScreen::SelectTemplate;
         }
         _ => {}
     }
 }
 
-fn handle_confirm(app: &mut TuiApp, key: KeyCode) {
+fn handle_confirm(app: &mut TemplateBrowserApp, key: KeyCode) {
     match key {
         KeyCode::Enter | KeyCode::Char('y') => match app.scaffold() {
             Ok(()) => {
-                app.screen = Screen::Done;
+                app.screen = TemplateScreen::Done;
             }
             Err(e) => {
                 app.error_message = Some(format!("Error: {}", e));
             }
         },
         KeyCode::Esc | KeyCode::Char('n') => {
-            app.screen = Screen::InputVariables;
+            app.screen = TemplateScreen::InputVariables;
         }
         KeyCode::Char('q') => {
             app.should_quit = true;
@@ -420,7 +1684,9 @@ fn handle_confirm(app: &mut TuiApp, key: KeyCode) {
     }
 }
 
-fn draw(f: &mut Frame, app: &mut TuiApp) {
+// ─── Template Browser Drawing ───────────────────────────────────────────────
+
+fn draw_template_browser(f: &mut Frame, app: &mut TemplateBrowserApp) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -430,45 +1696,43 @@ fn draw(f: &mut Frame, app: &mut TuiApp) {
         ])
         .split(f.area());
 
-    draw_header(f, chunks[0]);
+    draw_tb_header(f, chunks[0]);
 
     match app.screen {
-        Screen::SelectTemplate => draw_template_list(f, app, chunks[1]),
-        Screen::InputVariables => draw_variable_form(f, app, chunks[1]),
-        Screen::Confirm => draw_confirm(f, app, chunks[1]),
-        Screen::Done => draw_done(f, app, chunks[1]),
+        TemplateScreen::SelectTemplate => draw_template_list(f, app, chunks[1]),
+        TemplateScreen::InputVariables => draw_variable_form(f, app, chunks[1]),
+        TemplateScreen::Confirm => draw_tb_confirm(f, app, chunks[1]),
+        TemplateScreen::Done => draw_tb_done(f, app, chunks[1]),
     }
 
-    draw_footer(f, app, chunks[2]);
+    draw_tb_footer(f, app, chunks[2]);
 
     if let Some(ref msg) = app.error_message {
         draw_error_popup(f, msg);
     }
 }
 
-fn draw_header(f: &mut Frame, area: Rect) {
+fn draw_tb_header(f: &mut Frame, area: Rect) {
     let title = Line::from(vec![
         Span::styled(
             " fledge ",
             Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
         ),
-        Span::styled("— get your projects ready to fly", Style::default().fg(DIM)),
+        Span::styled("— template browser", Style::default().fg(DIM)),
     ]);
     let block = Block::default()
         .borders(Borders::BOTTOM)
         .border_style(Style::default().fg(DIM));
-    let paragraph = Paragraph::new(title).block(block);
-    f.render_widget(paragraph, area);
+    f.render_widget(Paragraph::new(title).block(block), area);
 }
 
-fn draw_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn draw_tb_footer(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
     let hints = match app.screen {
-        Screen::SelectTemplate => "↑↓ navigate  ⏎ select  q quit",
-        Screen::InputVariables => "↑↓/Tab navigate  type to edit  ⏎ continue  Esc back",
-        Screen::Confirm => "⏎/y scaffold  Esc back  q quit",
-        Screen::Done => "⏎/q exit",
+        TemplateScreen::SelectTemplate => "↑↓ navigate  ⏎ select  q quit",
+        TemplateScreen::InputVariables => "↑↓/Tab navigate  type to edit  ⏎ continue  Esc back",
+        TemplateScreen::Confirm => "⏎/y scaffold  Esc back  q quit",
+        TemplateScreen::Done => "⏎/q exit",
     };
-
     let footer = Paragraph::new(Line::from(Span::styled(hints, Style::default().fg(DIM)))).block(
         Block::default()
             .borders(Borders::TOP)
@@ -477,7 +1741,7 @@ fn draw_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(footer, area);
 }
 
-fn draw_template_list(f: &mut Frame, app: &mut TuiApp, area: Rect) {
+fn draw_template_list(f: &mut Frame, app: &mut TemplateBrowserApp, area: Rect) {
     let items: Vec<ListItem> = app
         .templates
         .iter()
@@ -504,7 +1768,7 @@ fn draw_template_list(f: &mut Frame, app: &mut TuiApp, area: Rect) {
     f.render_stateful_widget(list, area, &mut app.list_state);
 }
 
-fn draw_variable_form(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn draw_variable_form(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
     let tpl_idx = app.selected_template.unwrap();
     let tpl_name = &app.templates[tpl_idx].name;
 
@@ -570,7 +1834,7 @@ fn draw_variable_form(f: &mut Frame, app: &TuiApp, area: Rect) {
     }
 }
 
-fn draw_confirm(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn draw_tb_confirm(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
     let tpl_idx = app.selected_template.unwrap();
     let tpl = &app.templates[tpl_idx];
 
@@ -638,11 +1902,10 @@ fn draw_confirm(f: &mut Frame, app: &TuiApp, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(DIM));
 
-    let paragraph = Paragraph::new(lines).block(block);
-    f.render_widget(paragraph, area);
+    f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-fn draw_done(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn draw_tb_done(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
     let mut lines = vec![
         Line::from(""),
         Line::from(vec![
@@ -710,32 +1973,5 @@ fn draw_done(f: &mut Frame, app: &TuiApp, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(DIM));
 
-    let paragraph = Paragraph::new(lines).block(block);
-    f.render_widget(paragraph, area);
-}
-
-fn draw_error_popup(f: &mut Frame, msg: &str) {
-    let area = f.area();
-    let popup_width = (msg.len() as u16 + 6).min(area.width.saturating_sub(4));
-    let popup_height = 5;
-    let x = (area.width.saturating_sub(popup_width)) / 2;
-    let y = (area.height.saturating_sub(popup_height)) / 2;
-    let popup_area = Rect::new(x, y, popup_width, popup_height);
-
-    f.render_widget(Clear, popup_area);
-
-    let block = Block::default()
-        .title(" Error ")
-        .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red));
-
-    let text = Paragraph::new(Line::from(Span::styled(
-        msg,
-        Style::default().fg(Color::Red),
-    )))
-    .block(block)
-    .wrap(Wrap { trim: true });
-
-    f.render_widget(text, popup_area);
+    f.render_widget(Paragraph::new(lines).block(block), area);
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -53,6 +53,7 @@ enum ActionId {
     RunFlow,
     SearchTemplates,
     CreateTemplate,
+    PublishTemplate,
     ConfigGet,
     ConfigSet,
     AskQuestion,
@@ -386,6 +387,25 @@ fn build_categories() -> Vec<CategoryDef> {
                     },
                 },
                 ActionDef {
+                    name: "Publish",
+                    description: "Publish a template to GitHub",
+                    kind: ActionKind::WithInput {
+                        fields: vec![
+                            FieldDef {
+                                label: "Template path",
+                                default: ".",
+                                required: false,
+                            },
+                            FieldDef {
+                                label: "Organization (optional)",
+                                default: "",
+                                required: false,
+                            },
+                        ],
+                        action_id: ActionId::PublishTemplate,
+                    },
+                },
+                ActionDef {
                     name: "Validate",
                     description: "Validate templates in current directory",
                     kind: ActionKind::Direct(vec!["validate-template"]),
@@ -558,6 +578,21 @@ fn build_command(action_id: ActionId, fields: &[String]) -> Vec<String> {
         }
         ActionId::CreateTemplate => {
             vec!["create-template".into(), fields[0].clone()]
+        }
+        ActionId::PublishTemplate => {
+            let mut args = vec!["publish".into()];
+            let path = if fields[0].is_empty() {
+                "."
+            } else {
+                &fields[0]
+            };
+            if path != "." {
+                args.push(path.to_string());
+            }
+            if !fields[1].is_empty() {
+                args.extend(["--org".into(), fields[1].clone()]);
+            }
+            args
         }
         ActionId::ConfigGet => vec!["config".into(), "get".into(), fields[0].clone()],
         ActionId::ConfigSet => {


### PR DESCRIPTION
## Summary
- Expands `fledge tui` from a template-only browser into a full interactive dashboard wrapping **all** fledge commands
- 12 categories (Work, GitHub, Run, Specs, Metrics, Config, Templates, AI, Doctor, Changelog, Plugins) with 40+ actions
- Two-panel layout: categories on the left, actions/output on the right
- Commands run as subprocesses with output in a scrollable panel, input forms for commands needing parameters
- Template browser still accessible as a sub-screen within the dashboard
- Keyboard nav: arrows/j/k, Tab to switch panels, Enter to run, Esc to go back

## Test plan
- [ ] `cargo install --path . --features tui` then `fledge tui`
- [ ] Navigate all 12 categories with arrow keys
- [ ] Run direct commands (doctor, metrics, issues, etc.)
- [ ] Test input forms (work start, ask, config set)
- [ ] Test template browser from Templates > Browse & Scaffold
- [ ] Verify scrollable output for long command output
- [ ] Test Esc/back navigation at every level

🤖 Generated with [Claude Code](https://claude.com/claude-code)