### PR TITLE
docs: streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-brightgreen)](https://corvidlabs.github.io/fledge/)
 
-**Zero config for the common case.** One CLI, your whole dev lifecycle.
+**One CLI, your whole dev lifecycle.** Scaffold, build, review, ship — zero config for the common case.
 
 ```bash
 fledge init my-tool --template rust-cli
@@ -14,208 +14,66 @@ cd my-tool
 fledge flow ci     # lint + test + build, works out of the box
 ```
 
-I got tired of juggling `cookiecutter` for scaffolding, `make` for tasks, `gh` for GitHub stuff, and a dozen scripts to glue it all together. So I built fledge: one Rust binary that handles the full loop from `init` to `changelog`. Every feature gets measured against one question: *does this preserve the zero-config path?*
-
-## Why fledge?
-
-- **It's fast.** Native Rust binary. No runtime, no node_modules, no waiting around.
-- **Smart defaults.** Pulls your name and org from git config, auto-detects your project type, generates sensible task configs.
-- **Remote templates.** Any GitHub repo works as a template with `owner/repo` syntax. No special registry needed.
-- **Six pillars.** Start, Build, Develop, Review, Ship, Extend. Every stage of your project has a home.
-- **Flows.** Chain tasks into pipelines with parallel groups. `fledge flow ci` and you're done.
-- **Plugins.** Git-style subcommand pattern. Drop in community extensions or write your own.
-- **Language-agnostic.** Auto-detects Rust, Node, Go, Python, Ruby, Java, Swift and adapts.
-- **Safe.** Remote template hooks always ask before running. No surprises.
-- **Optional TUI.** Interactive template browser if you want it (`--features tui`).
-
 ## Install
 
 ```bash
-# From crates.io (easiest)
-cargo install fledge
-
-# With TUI support
-cargo install fledge --features tui
-
-# Homebrew
-brew install CorvidLabs/tap/fledge
-
-# Install script
-curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/install.sh | sh
-
-# Nix
-nix run github:CorvidLabs/fledge
-
-# From source
-git clone https://github.com/CorvidLabs/fledge.git
-cd fledge && cargo install --path .
+cargo install fledge              # from crates.io
+brew install CorvidLabs/tap/fledge # homebrew
 ```
+
+<details>
+<summary>More install options</summary>
+
+```bash
+cargo install fledge --features tui   # with TUI browser
+curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/install.sh | sh
+nix run github:CorvidLabs/fledge
+git clone https://github.com/CorvidLabs/fledge.git && cd fledge && cargo install --path .
+```
+
+</details>
 
 ## Quick Start
 
-### Existing project? Just use it.
+**Already have a project?** Just use it — fledge auto-detects your stack:
 
 ```bash
-cd my-project
-fledge run test          # auto-detects your stack, zero config needed
-fledge run build
-fledge review            # AI code review works in any git repo
-fledge run --init        # optional: generate fledge.toml to customize
+fledge run test       # runs your language's test command
+fledge run build      # same for build
+fledge review         # AI code review via Claude
 ```
 
-### New project? Scaffold it.
+**Starting fresh?** Scaffold from a template:
 
 ```bash
-# Scaffold a Rust CLI
-fledge init my-tool --template rust-cli
-
-# Don't know what you want? Browse interactively
-fledge init my-project
-
-# Use a template from GitHub
-fledge init my-app --template CorvidLabs/fledge-templates/python-api
-
-# See what you'd get before committing
-fledge init my-tool --template rust-cli --dry-run
-
-# Workflow pipelines
-fledge flow --init       # generate default flows
-fledge flow ci           # run lint + test + build
-
-# Project health
-fledge doctor            # check your environment
-fledge metrics           # LOC by language
-fledge deps --outdated   # stale dependencies
-
-# Plugins
-fledge plugin search deploy
-fledge plugin install someone/fledge-deploy
-
-# CI + changelogs
-fledge checks
-fledge changelog
+fledge init my-app --template rust-cli     # built-in template
+fledge init my-app --template user/repo    # any GitHub repo
+fledge init my-app                         # interactive picker
 ```
+
+## What's Inside
+
+| Stage | Commands | What it does |
+|-------|----------|-------------|
+| **Start** | `init`, `list`, `search`, `create-template` | Scaffold projects from local or remote templates |
+| **Build** | `run`, `flow`, `config`, `doctor` | Task runner, workflow pipelines, environment checks |
+| **Develop** | `work`, `spec` | Feature branches, PRs, spec-sync |
+| **Review** | `review`, `ask`, `metrics`, `deps` | AI code review, codebase Q&A, health checks |
+| **Ship** | `issues`, `prs`, `checks`, `changelog` | GitHub integration, CI status, release notes |
+| **Extend** | `plugin`, `completions`, `tui` | Community plugins, shell completions, TUI browser |
 
 ## Built-in Templates
 
-| Template | What you get |
-|----------|--------------|
-| `rust-cli` | Rust CLI with clap, CI, release automation |
-| `ts-bun` | TypeScript project on Bun with Biome |
-| `python-cli` | Python CLI with Click and Ruff |
-| `go-cli` | Go CLI with Cobra |
-| `ts-node` | TypeScript on Node with tsx and Biome |
-| `static-site` | Vanilla HTML/CSS/JS, no dependencies |
+`rust-cli` · `ts-bun` · `python-cli` · `go-cli` · `ts-node` · `static-site`
 
-These ship offline with the binary. For more templates (Angular, MCP server, Deno, Swift, monorepo, etc.), see [CorvidLabs/fledge-templates](https://github.com/CorvidLabs/fledge-templates).
+Browse community templates: `fledge search <keyword>`
 
-## CLI Reference
+## Learn More
 
-Full docs at [corvidlabs.github.io/fledge](https://corvidlabs.github.io/fledge/). Here's the quick version:
-
-### Start: Scaffold and discover
-
-| Command | What it does |
-|---------|-------------|
-| `fledge init <name>` | Create a project from a template |
-| `fledge list` | Show available templates |
-| `fledge search [query]` | Find templates on GitHub |
-| `fledge create-template <name>` | Scaffold a new template |
-| `fledge publish [path]` | Push a template to GitHub |
-| `fledge validate-template [path]` | Check a template for issues |
-| `fledge update` | Re-apply source template to existing project |
-
-### Build: Configure and run
-
-| Command | What it does |
-|---------|-------------|
-| `fledge run [task]` | Run tasks from fledge.toml |
-| `fledge flow [name]` | Run a workflow pipeline |
-| `fledge config <action>` | Manage global config |
-| `fledge doctor` | Environment diagnostics |
-
-### Develop: Branch and spec
-
-| Command | What it does |
-|---------|-------------|
-| `fledge work <action>` | Feature branches + PRs |
-| `fledge spec <action>` | Spec-sync management |
-
-### Review: Quality and insight
-
-| Command | What it does |
-|---------|-------------|
-| `fledge review` | AI code review via Claude |
-| `fledge ask <question>` | Ask about your codebase |
-| `fledge metrics` | Code metrics (LOC, churn, test ratio) |
-| `fledge deps` | Dependency health (outdated, audit, licenses) |
-
-### Ship: Track and release
-
-| Command | What it does |
-|---------|-------------|
-| `fledge issues` | List/view GitHub issues |
-| `fledge prs` | List/view pull requests |
-| `fledge checks` | CI/CD status |
-| `fledge changelog` | Generate changelog from git tags |
-
-### Extend: Grow the tool
-
-| Command | What it does |
-|---------|-------------|
-| `fledge plugin <action>` | Install, remove, search, run plugins |
-| `fledge completions [shell]` | Shell completions (bash, zsh, fish) |
-| `fledge tui` | Interactive template browser (requires `--features tui`) |
-
-## Remote Templates
-
-Any GitHub repo can be a template. Use `owner/repo` syntax:
-
-```bash
-fledge init my-app --template user/my-template
-fledge init my-app --template CorvidLabs/templates/python-api
-fledge init my-app --template user/my-template@v1.0.0  # pin a version
-fledge init my-app --template user/my-template --refresh  # force re-download
-```
-
-Register template repos so they show up in `fledge list`:
-
-```toml
-# ~/.config/fledge/config.toml
-[templates]
-repos = ["CorvidLabs/fledge-templates", "myorg/templates"]
-```
-
-## Configuration
-
-Lives at `~/.config/fledge/config.toml`:
-
-```toml
-[defaults]
-author = "Your Name"
-github_org = "YourOrg"
-license = "MIT"
-
-[templates]
-paths = ["~/my-templates"]
-repos = ["CorvidLabs/fledge-templates"]
-
-[github]
-token = "ghp_..."  # also reads FLEDGE_GITHUB_TOKEN / GITHUB_TOKEN env vars
-```
-
-If `author` isn't set, fledge pulls it from `git config user.name`.
-
-## Creating Templates
-
-```bash
-fledge create-template my-template   # scaffold the skeleton
-# edit template.toml and files
-fledge init test --template ./my-template --dry-run  # test it
-fledge publish ./my-template         # ship it
-```
-
-Full guide: [Template Authoring Guide](https://corvidlabs.github.io/fledge/template-authoring.html)
+- **[Full Documentation](https://corvidlabs.github.io/fledge/)** — commands, configuration, guides
+- **[Template Authoring](https://corvidlabs.github.io/fledge/template-authoring.html)** — create and publish your own templates
+- **[Flows Guide](https://corvidlabs.github.io/fledge/flows.html)** — task pipelines and workflow automation
+- **[Plugins Guide](https://corvidlabs.github.io/fledge/plugins.html)** — extend fledge with community tools
 
 ## License
 


### PR DESCRIPTION
## Summary
- Cut README from ~220 lines to ~75 — hero, install, quick start, one CLI reference table
- Collapsed install options into a `<details>` fold
- Merged 6 separate CLI tables into one organized by stage (Start/Build/Develop/Review/Ship/Extend)
- Added "Learn More" section linking to docs, template authoring, flows, and plugins guides
- Moved configuration, remote templates, and template creation details to the docs site

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all doc links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)