### PR TITLE
feat: add feature, bug, task branch types

### DIFF
--- a/specs/work/requirements.md
+++ b/specs/work/requirements.md
@@ -20,7 +20,7 @@ spec: work.spec.md
 - `fledge work start <name> --issue 42` includes issue number in branch name
 - `fledge work start <name> --prefix user/leif` creates `user/leif/<name>` branch
 - `fledge work start` refuses if working tree is dirty
-- `fledge work start` rejects invalid branch types (not in feat, fix, chore, docs, hotfix, refactor)
+- `fledge work start` rejects invalid branch types (not in feat, feature, fix, bug, chore, task, docs, hotfix, refactor)
 - `fledge work pr` pushes the branch and creates a PR via `gh`
 - `fledge work pr --title "X"` uses the given title
 - `fledge work pr --draft` creates a draft PR

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -57,7 +57,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 
 1. Branch names are normalized via `sanitize_branch_name`: lowercase, special chars become hyphens, no consecutive or trailing hyphens
 2. Default branch format is `{author}/{type}/{name}` — configurable via `[work]` in `fledge.toml`
-3. Valid branch types: `feat`, `fix`, `chore`, `docs`, `hotfix`, `refactor` (enforced unless `--prefix` is used)
+3. Valid branch types: `feat`, `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, `refactor` (enforced unless `--prefix` is used)
 4. Default branch type is `feat` — configurable via `[work] default_type` in `fledge.toml`
 5. `{author}` resolves from global config `defaults.author` or `git config user.name`
 6. `start` refuses to create a branch if there are uncommitted changes
@@ -66,7 +66,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 9. `status` works without `gh` (gracefully degrades if not available)
 10. `--prefix` bypasses type validation and format template, using raw `prefix/name`
 11. `--issue N` prepends the issue number to the branch name segment: `N-name`
-12. `generate_title_from_branch` strips any valid branch type prefix (feat/, fix/, chore/, docs/, hotfix/, refactor/)
+12. `generate_title_from_branch` strips any valid branch type prefix (feat/, feature/, fix/, bug/, chore/, task/, docs/, hotfix/, refactor/)
 
 ## Behavioral Examples
 
@@ -114,7 +114,7 @@ error: uncommitted changes detected. Commit or stash before starting work.
 ### work start — invalid branch type
 ```
 $ fledge work start foo --type yolo
-error: Unknown branch type 'yolo'. Valid types: feat, fix, chore, docs, hotfix, refactor
+error: Unknown branch type 'yolo'. Valid types: feat, feature, fix, bug, chore, task, docs, hotfix, refactor
 ```
 
 ### work pr — create pull request
@@ -166,3 +166,4 @@ $ fledge work status
 |---------|------|---------|
 | 1 | 2026-04-19 | Initial spec for fledge work |
 | 2 | 2026-04-20 | Flexible branch types, configurable format, `{author}` support, `--type`/`--issue`/`--prefix` flags |
+| 3 | 2026-04-20 | Added `feature`, `bug`, `task` as valid branch types |

--- a/src/work.rs
+++ b/src/work.rs
@@ -5,7 +5,9 @@ use std::process::Command;
 
 use crate::config::Config;
 
-const VALID_BRANCH_TYPES: &[&str] = &["feat", "fix", "chore", "docs", "hotfix", "refactor"];
+const VALID_BRANCH_TYPES: &[&str] = &[
+    "feat", "feature", "fix", "bug", "chore", "task", "docs", "hotfix", "refactor",
+];
 
 #[derive(Debug, Deserialize)]
 pub struct WorkConfig {
@@ -696,8 +698,11 @@ test = "cargo test"
     #[test]
     fn test_valid_branch_types() {
         assert!(VALID_BRANCH_TYPES.contains(&"feat"));
+        assert!(VALID_BRANCH_TYPES.contains(&"feature"));
         assert!(VALID_BRANCH_TYPES.contains(&"fix"));
+        assert!(VALID_BRANCH_TYPES.contains(&"bug"));
         assert!(VALID_BRANCH_TYPES.contains(&"chore"));
+        assert!(VALID_BRANCH_TYPES.contains(&"task"));
         assert!(VALID_BRANCH_TYPES.contains(&"docs"));
         assert!(VALID_BRANCH_TYPES.contains(&"hotfix"));
         assert!(VALID_BRANCH_TYPES.contains(&"refactor"));


### PR DESCRIPTION
## Summary
- Adds `feature`, `bug`, and `task` as valid work branch types alongside the existing `feat`, `fix`, `chore`, `docs`, `hotfix`, `refactor`
- Now you can do `fledge work start login-page --type feature` or `--type bug` or `--type task`
- Updated spec, requirements, and tests to match

## Test plan
- [x] All 80 tests pass
- [x] Clippy clean
- [x] Spec check passes (27/27)
- [x] `cargo fmt --check` clean
- [ ] Manual: `fledge work start test --type feature` creates `feature/test` branch
- [ ] Manual: `fledge work start test --type bug` creates `bug/test` branch
- [ ] Manual: `fledge work start test --type task` creates `task/test` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)