### PR TITLE
docs: add example repos section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ fledge init my-app                         # interactive picker
 
 Browse community templates: `fledge search <keyword>`
 
+## Examples
+
+- **[Official Templates](https://github.com/CorvidLabs/fledge-templates)** — hello-world, bun-api, ts-lib, and more
+- **[Example Flows](https://github.com/CorvidLabs/fledge-flows)** — language-specific CI/CD pipelines
+- **[Example Plugin](https://github.com/CorvidLabs/fledge-deploy)** — deploy/rollback plugin reference
+
 ## Learn More
 
 - **[Full Documentation](https://corvidlabs.github.io/fledge/)** — commands, configuration, guides


### PR DESCRIPTION
## Summary
- Adds an **Examples** section to the README linking to our official example repos
- Links to [fledge-templates](https://github.com/CorvidLabs/fledge-templates), [fledge-flows](https://github.com/CorvidLabs/fledge-flows), and [fledge-deploy](https://github.com/CorvidLabs/fledge-deploy)
- Placed above "Learn More" so users see concrete examples before docs links

## Test plan
- [ ] Verify all three repo links resolve correctly
- [ ] Check README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)