### PR TITLE
docs: add example repos section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ fledge init my-app                         # interactive picker
 
 Browse community templates: `fledge search <keyword>`
 
+## Examples
+
+- **[Official Templates](https://github.com/CorvidLabs/fledge-templates)** — hello-world, bun-api, ts-lib, and more
+- **[Example Flows](https://github.com/CorvidLabs/fledge-flows)** — language-specific CI/CD pipelines
+- **[Example Plugin](https://github.com/CorvidLabs/fledge-deploy)** — deploy/rollback plugin reference
+
 ## Learn More
 
 - **[Full Documentation](https://corvidlabs.github.io/fledge/)** — commands, configuration, guides


### PR DESCRIPTION
## Summary
- Adds an "Examples" section to the README linking to the three example repos: fledge-templates, fledge-flows, and fledge-deploy
- Placed above the "Learn More" section so new users can easily find working examples

## Test plan
- [ ] Verify links resolve to the correct GitHub repos
- [ ] Check README renders correctly on GitHub