### PR TITLE
fix: plugin command resolution, flow subcommands, and TUI emojis

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -216,12 +216,13 @@ steps = [
 
 ```bash
 fledge flow
-fledge flow ci
-fledge flow ci --dry-run
-fledge flow --init
-fledge flow --search
-fledge flow rust --search
-fledge flow --import CorvidLabs/fledge-flows
+fledge flow run ci
+fledge flow run ci --dry-run
+fledge flow list
+fledge flow init
+fledge flow search
+fledge flow search rust
+fledge flow import CorvidLabs/fledge-flows
 ```
 
 ---

--- a/docs/src/flows.md
+++ b/docs/src/flows.md
@@ -187,20 +187,20 @@ steps = [
 ## CLI
 
 ```bash
-fledge flow              # list flows
-fledge flow ci           # run one
-fledge flow ci --dry-run # preview the plan
-fledge flow --init       # generate defaults
-fledge flow --list --json
-fledge flow --search              # find community flows
-fledge flow rust --search         # search with keyword
-fledge flow --import owner/repo   # import flows from GitHub
-fledge flow --import owner/repo@v1.0.0  # pin to a version
+fledge flow              # list flows (same as fledge flow list)
+fledge flow run ci       # run one
+fledge flow run ci --dry-run # preview the plan
+fledge flow init         # generate defaults
+fledge flow list --json
+fledge flow search              # find community flows
+fledge flow search rust         # search with keyword
+fledge flow import owner/repo   # import flows from GitHub
+fledge flow import owner/repo@v1.0.0  # pin to a version
 ```
 
 ## Community Flow Registry
 
-Share and discover flows via GitHub. Repos with the `fledge-flow` topic are discoverable through `--search`.
+Share and discover flows via GitHub. Repos with the `fledge-flow` topic are discoverable through `fledge flow search`.
 
 ### Official Examples
 
@@ -208,21 +208,21 @@ Share and discover flows via GitHub. Repos with the `fledge-flow` topic are disc
 
 | Language | Import command |
 |----------|---------------|
-| Rust | `fledge flow --import CorvidLabs/fledge-flows/rust` |
-| Python | `fledge flow --import CorvidLabs/fledge-flows/python` |
-| Node/TypeScript | `fledge flow --import CorvidLabs/fledge-flows/node-typescript` |
-| Go | `fledge flow --import CorvidLabs/fledge-flows/go` |
+| Rust | `fledge flow import CorvidLabs/fledge-flows/rust` |
+| Python | `fledge flow import CorvidLabs/fledge-flows/python` |
+| Node/TypeScript | `fledge flow import CorvidLabs/fledge-flows/node-typescript` |
+| Go | `fledge flow import CorvidLabs/fledge-flows/go` |
 
 ### Publishing Flows
 
 1. Create a repo with a `fledge.toml` containing your flows and tasks
 2. Add the `fledge-flow` topic to the repo on GitHub
-3. Others can find it with `fledge flow --search` and import it
+3. Others can find it with `fledge flow search` and import it
 
 ### Importing Flows
 
 ```bash
-fledge flow --import CorvidLabs/fledge-flows
+fledge flow import CorvidLabs/fledge-flows
 ```
 
 This fetches the remote repo's `fledge.toml`, extracts its flows and any required tasks, and merges them into your local `fledge.toml`. Existing flows with the same name are skipped (not overwritten).
@@ -230,12 +230,12 @@ This fetches the remote repo's `fledge.toml`, extracts its flows and any require
 You can pin to a specific branch or tag:
 
 ```bash
-fledge flow --import CorvidLabs/fledge-flows@v1.0.0
+fledge flow import CorvidLabs/fledge-flows@v1.0.0
 ```
 
 ## Tips
 
-- Start with `fledge flow --init` and customize from there.
+- Start with `fledge flow init` and customize from there.
 - Use parallel groups for independent checks. Linting and formatting don't need to wait for each other.
 - Keep `fail_fast = true` for CI. No point building if tests fail.
 - Use `fail_fast = false` for audit flows where you want the full report.

--- a/specs/flows/flows.spec.md
+++ b/specs/flows/flows.spec.md
@@ -25,15 +25,15 @@ Composable workflow pipelines defined in `fledge.toml`. Flows chain multiple tas
 
 | Export | Description |
 |--------|-------------|
-| `run` | Entry point — lists, executes, searches, or imports flows |
-| `FlowOptions` | Options: `flow`, `list`, `init`, `dry_run`, `json`, `search`, `import` |
+| `run` | Entry point — dispatches flow actions |
+| `FlowAction` | Enum: `Run`, `List`, `Init`, `Search`, `Import` |
 | `FlowDef` | Flow definition: description, steps, and fail_fast flag |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `FlowOptions` | CLI options for the flow subcommand |
+| `FlowAction` | Action enum for the flow subcommand (Run, List, Init, Search, Import) |
 | `FlowDef` | A named flow with description, steps, and fail_fast flag |
 | `Step` | A single step: task reference, inline command, or parallel group |
 
@@ -41,7 +41,7 @@ Composable workflow pipelines defined in `fledge.toml`. Flows chain multiple tas
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `run` | `(FlowOptions) -> Result<()>` | Main entry — dispatch to init/list/execute |
+| `run` | `(FlowAction) -> Result<()>` | Main entry — dispatch to init/list/execute/search/import |
 
 ## Config Format
 
@@ -122,29 +122,29 @@ Flow: ci — Full CI pipeline
   3. build (task)
 
 # Parallel steps
-$ fledge flow check
+$ fledge flow run check
 ▸ Flow: check — Quick quality check
   ▸ Running parallel: lint, fmt
   ▸ Running task: test
 ✓ Flow check completed (2 steps)
 
 # Init default flows
-$ fledge flow --init
+$ fledge flow init
 ✓ Added default flows to fledge.toml
 
 # Search community flows on GitHub
-$ fledge flow --search
+$ fledge flow search
 Community flows on GitHub:
   CorvidLabs/fledge-flows  (★ 12)  Official community flow collection
   user/rust-release-flow   (★ 3)   Rust release pipeline with cargo-dist
 
 # Search with keyword
-$ fledge flow rust --search
+$ fledge flow search rust
 Community flows on GitHub:
   user/rust-release-flow   (★ 3)   Rust release pipeline with cargo-dist
 
 # Import flows from a remote repo
-$ fledge flow --import CorvidLabs/fledge-flows
+$ fledge flow import CorvidLabs/fledge-flows
 ✓ Imported 3 flow(s) from CorvidLabs/fledge-flows
   + release
   + deploy
@@ -153,7 +153,7 @@ $ fledge flow --import CorvidLabs/fledge-flows
   * Skipped (already exist): ci
 
 # Import with version pinning
-$ fledge flow --import CorvidLabs/fledge-flows@v1.0.0
+$ fledge flow import CorvidLabs/fledge-flows@v1.0.0
 ```
 
 ## Error Cases

--- a/src/flows.rs
+++ b/src/flows.rs
@@ -87,29 +87,51 @@ enum Step {
     Parallel { parallel: Vec<String> },
 }
 
-pub struct FlowOptions {
-    pub flow: Option<String>,
-    pub list: bool,
-    pub init: bool,
-    pub dry_run: bool,
-    pub json: bool,
-    pub search: bool,
-    pub import: Option<String>,
+pub enum FlowAction {
+    Run { name: String, dry_run: bool },
+    List { json: bool },
+    Init,
+    Search { query: Option<String>, json: bool },
+    Import { source: String },
 }
 
-pub fn run(opts: FlowOptions) -> Result<()> {
-    if opts.search {
-        return search_flows(opts.flow.as_deref(), opts.json);
-    }
+pub fn run(action: FlowAction) -> Result<()> {
+    match action {
+        FlowAction::Search { query, json } => search_flows(query.as_deref(), json),
+        FlowAction::Import { source } => import_flows(&source),
+        FlowAction::Init => init_flows(),
+        FlowAction::List { json } => {
+            let config = load_flow_config()?;
+            list_flows(&config.flows, json)
+        }
+        FlowAction::Run { name, dry_run } => {
+            let config = load_flow_config()?;
+            let flow = config.flows.get(&name).ok_or_else(|| {
+                let available: Vec<&str> = config.flows.keys().map(|s| s.as_str()).collect();
+                anyhow::anyhow!(
+                    "Unknown flow '{}'. Available flows: {}",
+                    name,
+                    available.join(", ")
+                )
+            })?;
 
-    if let Some(ref source) = opts.import {
-        return import_flows(source);
-    }
+            if flow.steps.is_empty() {
+                bail!("Flow '{}' has no steps defined", name);
+            }
 
-    if opts.init {
-        return init_flows();
-    }
+            validate_flow(&name, flow, &config.tasks)?;
 
+            if dry_run {
+                dry_run_flow(&name, flow)
+            } else {
+                let project_dir = std::env::current_dir().context("getting current directory")?;
+                execute_flow(&name, flow, &config.tasks, &project_dir)
+            }
+        }
+    }
+}
+
+fn load_flow_config() -> Result<FledgeFileWithFlows> {
     let project_dir = std::env::current_dir().context("getting current directory")?;
     let config_path = project_dir.join("fledge.toml");
 
@@ -126,35 +148,11 @@ pub fn run(opts: FlowOptions) -> Result<()> {
     if config.flows.is_empty() {
         bail!(
             "No flows defined in fledge.toml.\n  Add a [flows] section or run {} to add defaults.",
-            style("fledge flow --init").cyan()
+            style("fledge flow init").cyan()
         );
     }
 
-    if opts.list || opts.flow.is_none() {
-        return list_flows(&config.flows, opts.json);
-    }
-
-    let flow_name = opts.flow.as_ref().unwrap();
-    let flow = config.flows.get(flow_name).ok_or_else(|| {
-        let available: Vec<&str> = config.flows.keys().map(|s| s.as_str()).collect();
-        anyhow::anyhow!(
-            "Unknown flow '{}'. Available flows: {}",
-            flow_name,
-            available.join(", ")
-        )
-    })?;
-
-    if flow.steps.is_empty() {
-        bail!("Flow '{}' has no steps defined", flow_name);
-    }
-
-    validate_flow(flow_name, flow, &config.tasks)?;
-
-    if opts.dry_run {
-        return dry_run_flow(flow_name, flow);
-    }
-
-    execute_flow(flow_name, flow, &config.tasks, &project_dir)
+    Ok(config)
 }
 
 fn list_flows(flows: &BTreeMap<String, FlowDef>, json: bool) -> Result<()> {
@@ -612,7 +610,7 @@ fn search_flows(keyword: Option<&str>, json: bool) -> Result<()> {
     }
     println!(
         "\n{}",
-        style("Import with: fledge flow --import <owner/repo>").dim()
+        style("Import with: fledge flow import <owner/repo>").dim()
     );
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,8 @@ enum Commands {
         #[arg(long)]
         no_git: bool,
     },
+    #[command(external_subcommand)]
+    External(Vec<String>),
 }
 
 #[derive(clap::Subcommand)]
@@ -722,6 +724,25 @@ fn run() -> Result<()> {
         #[cfg(feature = "tui")]
         Commands::Tui { output, no_git } => {
             tui::run(output, no_git)?;
+        }
+        Commands::External(args) => {
+            let cmd_name = &args[0];
+            let cmd_args: Vec<String> = args[1..].to_vec();
+            if plugin::resolve_plugin_command(cmd_name).is_some() {
+                plugin::run(plugin::PluginOptions {
+                    action: plugin::PluginAction::Run {
+                        name: cmd_name.clone(),
+                        args: cmd_args,
+                    },
+                    json: false,
+                })?;
+            } else {
+                anyhow::bail!(
+                    "unrecognized subcommand '{}'\n\n  tip: use {} for help",
+                    cmd_name,
+                    style("fledge help").cyan()
+                );
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,28 +201,10 @@ enum Commands {
         #[arg(short, long)]
         list: bool,
     },
-    /// Run a composable workflow pipeline
+    /// Manage and run composable workflow pipelines
     Flow {
-        /// Flow name to run (lists flows if omitted)
-        flow: Option<String>,
-        /// List available flows
-        #[arg(short, long)]
-        list: bool,
-        /// Add default flows to fledge.toml
-        #[arg(long)]
-        init: bool,
-        /// Show execution plan without running
-        #[arg(long)]
-        dry_run: bool,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-        /// Search GitHub for community flows
-        #[arg(long)]
-        search: bool,
-        /// Import flows from a GitHub repo (owner/repo)
-        #[arg(long, value_name = "SOURCE")]
-        import: Option<String>,
+        #[command(subcommand)]
+        action: Option<FlowSubcommand>,
     },
     /// Generate a changelog from git tags and commits
     Changelog {
@@ -432,6 +414,39 @@ enum ConfigAction {
 }
 
 #[derive(clap::Subcommand)]
+enum FlowSubcommand {
+    /// Run a flow by name
+    Run {
+        /// Flow name
+        name: String,
+        /// Show execution plan without running
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// List available flows
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add default flows to fledge.toml
+    Init,
+    /// Search GitHub for community flows
+    Search {
+        /// Keyword to filter results
+        query: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Import flows from a GitHub repo (owner/repo)
+    Import {
+        /// GitHub repo (owner/repo) or full URL, optionally with @ref
+        source: String,
+    },
+}
+
+#[derive(clap::Subcommand)]
 enum PluginSubcommand {
     /// Install a plugin from GitHub
     Install {
@@ -605,24 +620,20 @@ fn run() -> Result<()> {
         Commands::Review { base, file } => {
             review::run(review::ReviewOptions { base, file })?;
         }
-        Commands::Flow {
-            flow,
-            list,
-            init,
-            dry_run,
-            json,
-            search,
-            import,
-        } => {
-            flows::run(flows::FlowOptions {
-                flow,
-                list,
-                init,
-                dry_run,
-                json,
-                search,
-                import,
-            })?;
+        Commands::Flow { action } => {
+            let action = match action {
+                Some(FlowSubcommand::Run { name, dry_run }) => {
+                    flows::FlowAction::Run { name, dry_run }
+                }
+                Some(FlowSubcommand::List { json }) => flows::FlowAction::List { json },
+                Some(FlowSubcommand::Init) => flows::FlowAction::Init,
+                Some(FlowSubcommand::Search { query, json }) => {
+                    flows::FlowAction::Search { query, json }
+                }
+                Some(FlowSubcommand::Import { source }) => flows::FlowAction::Import { source },
+                None => flows::FlowAction::List { json: false },
+            };
+            flows::run(action)?;
         }
         Commands::Changelog {
             limit,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -488,13 +488,23 @@ fn search_plugins(query: Option<&str>, limit: usize, json: bool) -> Result<()> {
 }
 
 fn run_plugin(name: &str, args: &[String]) -> Result<()> {
-    let bin_path = resolve_plugin_command(name).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Plugin command '{}' not found.\n  Run {} to see installed plugins.",
-            name,
-            style("fledge plugin list").cyan()
-        )
-    })?;
+    let bin_path = resolve_plugin_command(name)
+        .or_else(|| resolve_plugin_by_name(name))
+        .ok_or_else(|| {
+            let hint = match find_commands_for_plugin(name) {
+                Some(cmds) if !cmds.is_empty() => format!(
+                    "\n  Did you mean one of its commands? {}",
+                    style(cmds.join(", ")).cyan()
+                ),
+                _ => String::new(),
+            };
+            anyhow::anyhow!(
+                "Plugin command '{}' not found.{}\n  Run {} to see installed plugins.",
+                name,
+                hint,
+                style("fledge plugin list").cyan()
+            )
+        })?;
 
     let status = Command::new(&bin_path)
         .args(args)
@@ -529,6 +539,25 @@ fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
         bail!("Hook '{}' exited with code {}", event, code);
     }
     Ok(())
+}
+
+fn resolve_plugin_by_name(plugin_name: &str) -> Option<PathBuf> {
+    let registry = load_registry().ok()?;
+    let entry = registry
+        .plugins
+        .iter()
+        .find(|p| p.name == plugin_name || p.name == format!("fledge-{plugin_name}"))?;
+    let first_cmd = entry.commands.first()?;
+    resolve_plugin_command(first_cmd)
+}
+
+fn find_commands_for_plugin(plugin_name: &str) -> Option<Vec<String>> {
+    let registry = load_registry().ok()?;
+    registry
+        .plugins
+        .iter()
+        .find(|p| p.name == plugin_name || p.name == format!("fledge-{plugin_name}"))
+        .map(|p| p.commands.clone())
 }
 
 fn which_fledge_plugin(name: &str) -> Option<PathBuf> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1128,7 +1128,7 @@ fn draw_category_list(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
                 .border_style(Style::default().fg(border_color)),
         )
         .highlight_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
-        .highlight_symbol("▶ ");
+        .highlight_symbol("👉 ");
 
     f.render_stateful_widget(list, area, &mut app.cat_state);
 }
@@ -1143,7 +1143,7 @@ fn draw_action_list(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
         .iter()
         .map(|act| {
             let tag = match &act.kind {
-                ActionKind::Direct(_) => Span::styled(" ▸ ", Style::default().fg(GREEN)),
+                ActionKind::Direct(_) => Span::styled(" ▶️ ", Style::default().fg(GREEN)),
                 ActionKind::WithInput { .. } => Span::styled(" ✏️ ", Style::default().fg(YELLOW)),
                 ActionKind::TemplateBrowser => Span::styled(" 📂 ", Style::default().fg(YELLOW)),
             };
@@ -1169,7 +1169,7 @@ fn draw_action_list(f: &mut Frame, app: &mut DashboardApp, area: Rect) {
                 .border_style(Style::default().fg(border_color)),
         )
         .highlight_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
-        .highlight_symbol("▶ ");
+        .highlight_symbol("👉 ");
 
     f.render_stateful_widget(list, area, &mut app.act_state);
 }
@@ -1798,7 +1798,7 @@ fn draw_template_list(f: &mut Frame, app: &mut TemplateBrowserApp, area: Rect) {
                 .border_style(Style::default().fg(DIM)),
         )
         .highlight_style(Style::default().fg(CYAN).add_modifier(Modifier::BOLD))
-        .highlight_symbol("▶ ");
+        .highlight_symbol("👉 ");
 
     f.render_stateful_widget(list, area, &mut app.list_state);
 }
@@ -1945,7 +1945,7 @@ fn draw_tb_done(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
         Line::from(""),
         Line::from(vec![
             Span::styled(
-                "  ✓ ",
+                "  ✅ ",
                 Style::default().fg(GREEN).add_modifier(Modifier::BOLD),
             ),
             Span::styled(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -548,7 +548,7 @@ steps = ["fmt", "lint", "test"]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "--list"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "list"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("ci"));
@@ -568,7 +568,7 @@ steps = ["build"]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "ci", "--dry-run"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "run", "ci", "--dry-run"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!stdout.contains("BUILT"));
@@ -588,7 +588,7 @@ steps = ["step1", "step2"]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "pipeline"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "run", "pipeline"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("STEP1"));
@@ -603,7 +603,7 @@ fn cli_flow_unknown_flow_fails() {
         "[tasks]\nbuild = \"echo build\"\n[flows.ci]\nsteps = [\"build\"]\n",
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "nonexistent"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "run", "nonexistent"]);
     assert!(!output.status.success());
 }
 
@@ -620,7 +620,7 @@ fn cli_flow_init_adds_default_flows() {
         "[tasks]\nbuild = \"echo build\"\n",
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "--init"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "init"]);
     assert!(output.status.success());
     let content = fs::read_to_string(tmp.path().join("fledge.toml")).unwrap();
     assert!(content.contains("[flows"));
@@ -640,7 +640,7 @@ steps = ["build"]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "--list", "--json"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "list", "--json"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
@@ -1079,7 +1079,7 @@ steps = [{ run = "echo INLINE_HELLO" }]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "greet"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "run", "greet"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("INLINE_HELLO"));
@@ -1099,7 +1099,7 @@ steps = [{ parallel = ["a", "b"] }]
 "#,
     )
     .unwrap();
-    let output = run_fledge_in(tmp.path(), &["flow", "par"]);
+    let output = run_fledge_in(tmp.path(), &["flow", "run", "par"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("ALPHA"));
@@ -1275,23 +1275,23 @@ fn e2e_rust_project_lifecycle() {
     assert!(stdout.contains("build") || stdout.contains("test"));
 
     // Step 4: Generate default flows
-    let output = run_fledge_in(&project, &["flow", "--init"]);
+    let output = run_fledge_in(&project, &["flow", "init"]);
     assert!(
         output.status.success(),
-        "flow --init failed: {}",
+        "flow init failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     let fledge_toml = fs::read_to_string(project.join("fledge.toml")).unwrap();
     assert!(fledge_toml.contains("[flows"));
 
     // Step 5: List flows
-    let output = run_fledge_in(&project, &["flow", "--list"]);
+    let output = run_fledge_in(&project, &["flow", "list"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("ci"));
 
     // Step 6: Dry-run a flow
-    let output = run_fledge_in(&project, &["flow", "ci", "--dry-run"]);
+    let output = run_fledge_in(&project, &["flow", "run", "ci", "--dry-run"]);
     assert!(output.status.success());
 
     // Step 7: Doctor check


### PR DESCRIPTION
## Summary

- **Plugin command resolution**: `fledge plugin run <plugin-name>` now resolves by plugin name (not just command name), and unknown top-level subcommands delegate to plugin commands (e.g. `fledge hello` runs the `hello` command from `fledge-plugin-example`)
- **Flow subcommands**: Convert flow CLI from flags to subcommands (`fledge flow search`, `fledge flow import`, `fledge flow run` instead of `--search`, `--import`)
- **TUI emojis**: Replace ASCII/Unicode symbols with emojis in TUI icons

## Test plan

- [ ] `fledge plugin run fledge-plugin-example` — resolves by plugin name
- [ ] `fledge hello` — delegates to plugin command
- [ ] `fledge flow search` — uses subcommand (not flag)
- [ ] `fledge flow run ci` — runs a flow
- [ ] TUI displays emoji icons instead of ASCII symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)