### PR TITLE
fix: spinner stays visible during AI commands

### DIFF
--- a/src/ask.rs
+++ b/src/ask.rs
@@ -8,8 +8,6 @@ pub struct AskOptions {
 pub fn run(options: AskOptions) -> Result<()> {
     ensure_claude_cli()?;
 
-    let sp = crate::spinner::Spinner::start("Thinking...");
-
     let prompt = format!(
         "You are a helpful assistant answering questions about a codebase.\n\
         The user is in a project directory and wants to understand their code.\n\
@@ -19,14 +17,22 @@ pub fn run(options: AskOptions) -> Result<()> {
         options.question
     );
 
+    let sp = crate::spinner::Spinner::start("Thinking...");
+
+    let output = Command::new("claude").args(["--print", &prompt]).output()?;
+
     sp.finish();
     println!();
 
-    let status = Command::new("claude").args(["--print", &prompt]).status()?;
-
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
         bail!("claude CLI exited with an error.");
     }
+
+    print!("{}", String::from_utf8_lossy(&output.stdout));
 
     Ok(())
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -24,10 +24,7 @@ pub fn run(options: ReviewOptions) -> Result<()> {
 
     let diff_stats = get_diff_stats(&base, options.file.as_deref())?;
 
-    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}...", &base));
-
     if !diff_stats.is_empty() {
-        sp.finish();
         println!("{}\n", style(&diff_stats).dim());
     }
 
@@ -46,14 +43,22 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         diff
     );
 
+    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}...", &base));
+
+    let output = Command::new("claude").args(["--print", &prompt]).output()?;
+
     sp.finish();
     println!();
 
-    let status = Command::new("claude").args(["--print", &prompt]).status()?;
-
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
         bail!("claude CLI exited with an error.");
     }
+
+    print!("{}", String::from_utf8_lossy(&output.stdout));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Fixed `fledge ask` and `fledge review` where the spinner finished instantly before the `claude` CLI ran — users saw no loading indicator
- Now uses `.output()` instead of `.status()` so the spinner animates while waiting for the AI response, then prints the result after

## Test plan
- [ ] Run `fledge ask "what does this project do"` — spinner should animate until response appears
- [ ] Run `fledge review` — spinner should animate during review
- [ ] All 135 tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)