### PR TITLE
fix: spinner animation and visibility improvements

### DIFF
--- a/src/ask.rs
+++ b/src/ask.rs
@@ -17,7 +17,7 @@ pub fn run(options: AskOptions) -> Result<()> {
         options.question
     );
 
-    let sp = crate::spinner::Spinner::start("Thinking...");
+    let sp = crate::spinner::Spinner::start("Thinking:");
 
     let output = Command::new("claude").args(["--print", &prompt]).output()?;
 

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -8,8 +8,6 @@ pub struct AskOptions {
 pub fn run(options: AskOptions) -> Result<()> {
     ensure_claude_cli()?;
 
-    let sp = crate::spinner::Spinner::start("Thinking...");
-
     let prompt = format!(
         "You are a helpful assistant answering questions about a codebase.\n\
         The user is in a project directory and wants to understand their code.\n\
@@ -19,14 +17,22 @@ pub fn run(options: AskOptions) -> Result<()> {
         options.question
     );
 
+    let sp = crate::spinner::Spinner::start("Thinking...");
+
+    let output = Command::new("claude").args(["--print", &prompt]).output()?;
+
     sp.finish();
     println!();
 
-    let status = Command::new("claude").args(["--print", &prompt]).status()?;
-
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
         bail!("claude CLI exited with an error.");
     }
+
+    print!("{}", String::from_utf8_lossy(&output.stdout));
 
     Ok(())
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -19,7 +19,7 @@ pub fn run(opts: ChecksOptions) -> Result<()> {
         None => current_branch()?,
     };
 
-    let sp = crate::spinner::Spinner::start("Fetching CI checks...");
+    let sp = crate::spinner::Spinner::start("Fetching CI checks:");
     let ref_path = format!("/repos/{owner}/{repo}/commits/{branch}/check-runs");
     let data = github::github_api_get(&ref_path, token.as_deref(), &[]);
     sp.finish();

--- a/src/flows.rs
+++ b/src/flows.rs
@@ -553,7 +553,7 @@ fn search_flows(keyword: Option<&str>, json: bool) -> Result<()> {
         None => "topic:fledge-flow".to_string(),
     };
 
-    let sp = crate::spinner::Spinner::start("Searching GitHub for community flows...");
+    let sp = crate::spinner::Spinner::start("Searching GitHub for community flows:");
 
     let body = crate::github::github_api_get(
         "/search/repositories",
@@ -645,7 +645,7 @@ fn import_flows(source: &str) -> Result<()> {
             .unwrap_or_default()
     );
 
-    let sp = crate::spinner::Spinner::start(&format!("Fetching flows from {}...", display_source,));
+    let sp = crate::spinner::Spinner::start(&format!("Fetching flows from {}:", display_source,));
 
     let ref_param = git_ref.as_deref().unwrap_or("HEAD");
     let remote_path = match &subpath {

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -62,7 +62,7 @@ fn list(
         params.push(("labels", l));
     }
 
-    let sp = crate::spinner::Spinner::start("Fetching issues...");
+    let sp = crate::spinner::Spinner::start("Fetching issues:");
     let path = format!("/repos/{}/{}/issues", owner, repo);
     let items = github::github_api_get(&path, token, &params);
     sp.finish();
@@ -108,7 +108,7 @@ fn list(
 }
 
 fn view(owner: &str, repo: &str, number: u64, json: bool, token: Option<&str>) -> Result<()> {
-    let sp = crate::spinner::Spinner::start(&format!("Fetching issue #{}...", number));
+    let sp = crate::spinner::Spinner::start(&format!("Fetching issue #{}:", number));
     let path = format!("/repos/{}/{}/issues/{}", owner, repo, number);
     let issue = github::github_api_get(&path, token, &[]);
     sp.finish();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -175,7 +175,7 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
         fs::remove_dir_all(&plugin_dir).context("removing existing plugin")?;
     }
 
-    let sp = crate::spinner::Spinner::start(&format!("Cloning {}...", &url));
+    let sp = crate::spinner::Spinner::start(&format!("Cloning {}:", &url));
 
     let status = Command::new("git")
         .args(["clone", "--depth", "1", &url])
@@ -401,7 +401,7 @@ fn search_plugins(query: Option<&str>, limit: usize, json: bool) -> Result<()> {
         None => "fledge-plugin".to_string(),
     };
 
-    let sp = crate::spinner::Spinner::start("Searching GitHub for plugins...");
+    let sp = crate::spinner::Spinner::start("Searching GitHub for plugins:");
 
     let config = crate::config::Config::load().ok();
     let token = config.as_ref().and_then(|c| c.github_token());

--- a/src/prs.rs
+++ b/src/prs.rs
@@ -45,7 +45,7 @@ fn list(
         ("direction", "desc"),
     ];
 
-    let sp = crate::spinner::Spinner::start("Fetching pull requests...");
+    let sp = crate::spinner::Spinner::start("Fetching pull requests:");
     let path = format!("/repos/{}/{}/pulls", owner, repo);
     let items = github::github_api_get(&path, token, &params);
     sp.finish();
@@ -85,7 +85,7 @@ fn list(
 }
 
 fn view(owner: &str, repo: &str, number: u64, json: bool, token: Option<&str>) -> Result<()> {
-    let sp = crate::spinner::Spinner::start(&format!("Fetching PR #{}...", number));
+    let sp = crate::spinner::Spinner::start(&format!("Fetching PR #{}:", number));
     let path = format!("/repos/{}/{}/pulls/{}", owner, repo, number);
     let pr = github::github_api_get(&path, token, &[]);
     sp.finish();

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -46,7 +46,7 @@ pub fn run(options: PublishOptions) -> Result<()> {
         style(repo_name).green()
     );
 
-    let sp = crate::spinner::Spinner::start("Checking repository...");
+    let sp = crate::spinner::Spinner::start("Checking repository:");
     let repo_exists = check_repo_exists(&owner, repo_name, &token)?;
     sp.finish();
 
@@ -64,7 +64,7 @@ pub fn run(options: PublishOptions) -> Result<()> {
             return Ok(());
         }
     } else {
-        let sp = crate::spinner::Spinner::start("Creating repository...");
+        let sp = crate::spinner::Spinner::start("Creating repository:");
         create_github_repo(
             repo_name,
             description,
@@ -81,7 +81,7 @@ pub fn run(options: PublishOptions) -> Result<()> {
         );
     }
 
-    let sp = crate::spinner::Spinner::start("Setting repository topics...");
+    let sp = crate::spinner::Spinner::start("Setting repository topics:");
     set_repo_topics(&owner, repo_name, &token)?;
     sp.finish();
     println!(
@@ -90,7 +90,7 @@ pub fn run(options: PublishOptions) -> Result<()> {
         style("fledge-template").cyan()
     );
 
-    let sp = crate::spinner::Spinner::start("Pushing template files...");
+    let sp = crate::spinner::Spinner::start("Pushing template files:");
     push_template(&path, &owner, repo_name, &token)?;
     sp.finish();
     println!("  {} Pushed template files", style("✅").green().bold());

--- a/src/review.rs
+++ b/src/review.rs
@@ -43,7 +43,7 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         diff
     );
 
-    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}...", &base));
+    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}:", &base));
 
     let output = Command::new("claude").args(["--print", &prompt]).output()?;
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -24,10 +24,7 @@ pub fn run(options: ReviewOptions) -> Result<()> {
 
     let diff_stats = get_diff_stats(&base, options.file.as_deref())?;
 
-    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}...", &base));
-
     if !diff_stats.is_empty() {
-        sp.finish();
         println!("{}\n", style(&diff_stats).dim());
     }
 
@@ -46,14 +43,22 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         diff
     );
 
+    let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}...", &base));
+
+    let output = Command::new("claude").args(["--print", &prompt]).output()?;
+
     sp.finish();
     println!();
 
-    let status = Command::new("claude").args(["--print", &prompt]).status()?;
-
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
         bail!("claude CLI exited with an error.");
     }
+
+    print!("{}", String::from_utf8_lossy(&output.stdout));
 
     Ok(())
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -28,7 +28,7 @@ pub fn run(options: SearchOptions) -> Result<()> {
     let config = crate::config::Config::load()?;
     let token = config.github_token();
 
-    let sp = crate::spinner::Spinner::start("Searching GitHub for templates...");
+    let sp = crate::spinner::Spinner::start("Searching GitHub for templates:");
     let results = search_github(options.query.as_deref(), token.as_deref(), options.limit);
     sp.finish();
     let results = results?;

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -65,7 +65,7 @@ impl Spinner {
         bar.set_style(
             ProgressStyle::default_spinner()
                 .tick_strings(theme.frames)
-                .template("  {spinner} {msg}")
+                .template("  {msg} {spinner}")
                 .expect("valid spinner template"),
         );
         bar.set_message(message.to_string());

--- a/src/update.rs
+++ b/src/update.rs
@@ -62,7 +62,7 @@ pub fn run(opts: UpdateOptions) -> Result<()> {
     );
 
     let config = Config::load().context("loading config")?;
-    let sp = crate::spinner::Spinner::start("Fetching latest template...");
+    let sp = crate::spinner::Spinner::start("Fetching latest template:");
     let template = resolve_source_template(&meta, &config, opts.refresh);
     sp.finish();
     let template = template?;

--- a/src/work.rs
+++ b/src/work.rs
@@ -284,7 +284,7 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
         );
     }
 
-    let sp = crate::spinner::Spinner::start(&format!("Pushing {} to origin...", &branch));
+    let sp = crate::spinner::Spinner::start(&format!("Pushing {} to origin:", &branch));
     let push_output = Command::new("git")
         .args(["push", "-u", "origin", &branch])
         .output()?;
@@ -326,7 +326,7 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
         gh_args.push(b.to_string());
     }
 
-    let sp = crate::spinner::Spinner::start("Creating pull request...");
+    let sp = crate::spinner::Spinner::start("Creating pull request:");
     let gh_output = Command::new("gh").args(&gh_args).output()?;
     sp.finish();
 


### PR DESCRIPTION
## Summary
- Spinner now stays visible during AI commands (`fledge ask`, `fledge review`) — previously it vanished before the actual AI call started
- Spinner animation displays after the label text (`Thinking: ⠂`) instead of before (`⠂ Thinking...`)
- Updated all 18 spinner call sites across 12 files for consistency

## Test plan
- [x] `cargo test` — all 135 tests pass
- [x] `cargo fmt --check` — clean
- [ ] Manual test: `fledge ask "what does this project do?"` shows spinner while AI responds
- [ ] Manual test: `fledge review` shows spinner while AI reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)