### PR TITLE
fix: cross-platform path fallbacks and mutex poison handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ impl Config {
             return PathBuf::from(dir).join("config.toml");
         }
         dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("~/.config"))
+            .unwrap_or_else(std::env::temp_dir)
             .join("fledge")
             .join("config.toml")
     }

--- a/src/flows.rs
+++ b/src/flows.rs
@@ -425,19 +425,20 @@ fn execute_parallel(
             let errors = Arc::clone(&errors);
             let handle = s.spawn(move || {
                 if let Err(e) = execute_task_with_deps(name, tasks, project_dir) {
-                    let mut errs = errors.lock().unwrap();
-                    errs.push(format!("{}: {}", name, e));
+                    if let Ok(mut errs) = errors.lock() {
+                        errs.push(format!("{}: {}", name, e));
+                    }
                 }
             });
             handles.push(handle);
         }
 
         for handle in handles {
-            handle.join().unwrap();
+            let _ = handle.join();
         }
     });
 
-    let errs = errors.lock().unwrap();
+    let errs = errors.lock().unwrap_or_else(|e| e.into_inner());
     if !errs.is_empty() {
         bail!("Parallel step failed:\n  {}", errs.join("\n  "));
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -95,7 +95,7 @@ pub fn list_installed() -> Result<Vec<PluginEntry>> {
 
 fn plugins_dir() -> PathBuf {
     dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("~/.config"))
+        .unwrap_or_else(std::env::temp_dir)
         .join("fledge")
         .join("plugins")
 }
@@ -106,7 +106,7 @@ fn plugin_bin_dir() -> PathBuf {
 
 fn registry_path() -> PathBuf {
     dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("~/.config"))
+        .unwrap_or_else(std::env::temp_dir)
         .join("fledge")
         .join("plugins.toml")
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 pub fn cache_dir() -> PathBuf {
     dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("~/.cache"))
+        .unwrap_or_else(std::env::temp_dir)
         .join("fledge")
         .join("templates")
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -180,7 +180,7 @@ fn builtin_template_dir() -> PathBuf {
 fn extract_embedded_templates() -> PathBuf {
     let version = env!("CARGO_PKG_VERSION");
     let cache_dir = dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(std::env::temp_dir)
         .join("fledge")
         .join(format!("templates-v{}", version));
 


### PR DESCRIPTION
## Summary
- Replace broken path fallbacks (`~/.config`, `~/.cache`, `/tmp`) with `std::env::temp_dir()` — tilde paths don't expand in Rust's `PathBuf` and `/tmp` doesn't exist on Windows
- Handle mutex poisoning in parallel flow execution (`flows.rs`) so a panicked thread doesn't cascade into a panic on lock acquisition
- 5 files across `config.rs`, `plugin.rs`, `remote.rs`, `templates.rs`, `flows.rs`

## Test plan
- [x] All 135 tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)