### PR TITLE
fix: polish and stability improvements across core modules

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -144,6 +144,13 @@ fn commits_between(from: Option<&str>, to: &str) -> Result<Vec<(String, String)>
         .context("running git log")?;
 
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!(
+            "  {} git log for range '{}' failed: {}",
+            style("⚠").yellow().bold(),
+            range,
+            stderr.trim()
+        );
         return Ok(Vec::new());
     }
 

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -200,6 +200,7 @@ fn parse_npm_lock(path: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
 fn parse_yarn_lock(path: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
     let content = std::fs::read_to_string(path).context("reading yarn.lock")?;
     let mut deps = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     let mut current_name: Option<String> = None;
 
     for line in content.lines() {
@@ -218,7 +219,7 @@ fn parse_yarn_lock(path: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
         } else if trimmed.starts_with("version ") {
             if let Some(name) = current_name.take() {
                 let version = unquote(trimmed.trim_start_matches("version "));
-                if !deps.iter().any(|d: &Dep| d.name == name) {
+                if seen.insert(name.clone()) {
                     deps.push(Dep { name, version });
                 }
             }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -3,6 +3,7 @@ use console::style;
 use serde::Serialize;
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use crate::run::detect_project_type;
 
@@ -130,8 +131,65 @@ pub fn run(opts: DoctorOptions) -> Result<()> {
 }
 
 fn check_tool(name: &str, version_args: &[&str], fix: &str) -> CheckResult {
-    let output = Command::new(name).args(version_args).output();
+    let child = Command::new(name)
+        .args(version_args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn();
 
+    let mut child = match child {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return CheckResult {
+                name: name.to_string(),
+                status: CheckStatus::Missing,
+                version: None,
+                detail: Some("not found".to_string()),
+                fix: Some(fix.to_string()),
+            };
+        }
+        Err(e) => {
+            return CheckResult {
+                name: name.to_string(),
+                status: CheckStatus::Error,
+                version: None,
+                detail: Some(format!("error: {}", e)),
+                fix: Some(fix.to_string()),
+            };
+        }
+    };
+
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    return CheckResult {
+                        name: name.to_string(),
+                        status: CheckStatus::Error,
+                        version: None,
+                        detail: Some("timed out after 10s".to_string()),
+                        fix: Some(fix.to_string()),
+                    };
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                return CheckResult {
+                    name: name.to_string(),
+                    status: CheckStatus::Error,
+                    version: None,
+                    detail: Some(format!("error: {}", e)),
+                    fix: Some(fix.to_string()),
+                };
+            }
+        }
+    }
+
+    let output = child.wait_with_output();
     match output {
         Ok(out) => {
             let text = String::from_utf8_lossy(&out.stdout);
@@ -150,13 +208,6 @@ fn check_tool(name: &str, version_args: &[&str], fix: &str) -> CheckResult {
                 fix: None,
             }
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => CheckResult {
-            name: name.to_string(),
-            status: CheckStatus::Missing,
-            version: None,
-            detail: Some("not found".to_string()),
-            fix: Some(fix.to_string()),
-        },
         Err(e) => CheckResult {
             name: name.to_string(),
             status: CheckStatus::Error,

--- a/src/flows.rs
+++ b/src/flows.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use console::style;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -198,6 +198,8 @@ fn validate_flow(flow_name: &str, flow: &FlowDef, tasks: &BTreeMap<String, TaskD
                         name
                     );
                 }
+                check_dep_cycle(name, tasks, &mut HashSet::new())
+                    .map_err(|e| anyhow::anyhow!("Flow '{}' step {}: {}", flow_name, i + 1, e))?;
             }
             Step::Inline { .. } => {}
             Step::Parallel { parallel } => {
@@ -210,10 +212,30 @@ fn validate_flow(flow_name: &str, flow: &FlowDef, tasks: &BTreeMap<String, TaskD
                             name
                         );
                     }
+                    check_dep_cycle(name, tasks, &mut HashSet::new()).map_err(|e| {
+                        anyhow::anyhow!("Flow '{}' step {}: {}", flow_name, i + 1, e)
+                    })?;
                 }
             }
         }
     }
+    Ok(())
+}
+
+fn check_dep_cycle(
+    name: &str,
+    tasks: &BTreeMap<String, TaskDef>,
+    visiting: &mut HashSet<String>,
+) -> Result<()> {
+    if !visiting.insert(name.to_string()) {
+        bail!("circular dependency detected involving task '{}'", name);
+    }
+    if let Some(task) = tasks.get(name) {
+        for dep in task.deps() {
+            check_dep_cycle(dep, tasks, visiting)?;
+        }
+    }
+    visiting.remove(name);
     Ok(())
 }
 
@@ -333,12 +355,30 @@ fn execute_task_with_deps(
     tasks: &BTreeMap<String, TaskDef>,
     project_dir: &Path,
 ) -> Result<()> {
+    let mut visited = HashSet::new();
+    execute_task_recursive(name, tasks, project_dir, &mut visited)
+}
+
+fn execute_task_recursive(
+    name: &str,
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+    visited: &mut HashSet<String>,
+) -> Result<()> {
+    if !visited.insert(name.to_string()) {
+        bail!(
+            "Circular dependency detected: task '{}' depends on itself (chain: {})",
+            name,
+            visited.iter().cloned().collect::<Vec<_>>().join(" → ")
+        );
+    }
+
     let task = tasks
         .get(name)
         .ok_or_else(|| anyhow::anyhow!("Task '{}' not found", name))?;
 
     for dep in task.deps() {
-        execute_task_with_deps(dep, tasks, project_dir)?;
+        execute_task_recursive(dep, tasks, project_dir, visited)?;
     }
 
     execute_single_task(name, task, project_dir)
@@ -990,6 +1030,54 @@ build = "cargo build"
 
 [flows.ci]
 steps = ["lint", "test", "build"]
+"#,
+        );
+        let result = validate_flow("ci", &config.flows["ci"], &config.tasks);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_circular_deps() {
+        let config = parse_config(
+            r#"
+[tasks.a]
+cmd = "echo a"
+deps = ["b"]
+
+[tasks.b]
+cmd = "echo b"
+deps = ["a"]
+
+[flows.ci]
+steps = ["a"]
+"#,
+        );
+        let result = validate_flow("ci", &config.flows["ci"], &config.tasks);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("circular"),
+            "expected circular error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_no_cycle_with_shared_deps() {
+        let config = parse_config(
+            r#"
+[tasks]
+common = "echo common"
+
+[tasks.a]
+cmd = "echo a"
+deps = ["common"]
+
+[tasks.b]
+cmd = "echo b"
+deps = ["common"]
+
+[flows.ci]
+steps = ["a", "b"]
 "#,
         );
         let result = validate_flow("ci", &config.flows["ci"], &config.tasks);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -379,7 +379,13 @@ struct LineCounts {
 fn count_lines(path: &Path, language: &str) -> LineCounts {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) => {
+            eprintln!(
+                "  {} skipping {}: {}",
+                console::style("⚠").yellow().bold(),
+                path.display(),
+                e
+            );
             return LineCounts {
                 lines: 0,
                 code: 0,


### PR DESCRIPTION
## Summary
- **flows.rs**: Add circular dependency detection — catches cycles at validation time (before execution) and at runtime with a visited-set guard. Includes 2 new tests.
- **doctor.rs**: Tool version checks now use a 10-second timeout via `spawn` + `try_wait` loop instead of blocking `output()`. Prevents `fledge doctor` from hanging if a tool is unresponsive.
- **changelog.rs**: Git log failures now print a warning with stderr context instead of silently returning an empty commit list.
- **metrics.rs**: Unreadable files now print a warning instead of silently reporting 0 lines.
- **deps.rs**: Yarn lock dedup uses `HashSet` for O(1) lookups instead of O(n) linear scan.

## Test plan
- [x] All 516 tests pass (381 unit + 135 integration)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` passes
- [ ] Manual: `fledge doctor` — verify timeout doesn't fire for normal tools
- [ ] Manual: Create a fledge.toml with circular task deps, confirm helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)