### PR TITLE
feat: plugin build hooks, auto-detect, update command

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -524,9 +524,10 @@ fledge plugin <install|remove|list|search|run> [OPTIONS]
 
 **Subcommands:**
 
-- `install <source>` - Install from GitHub (`owner/repo` or URL). `--force` to reinstall.
+- `install <source[@ref]>` - Install from GitHub (`owner/repo[@tag]` or URL). `--force` to reinstall. Use `@ref` to pin to a tag, branch, or commit.
 - `remove <name>` - Uninstall a plugin
-- `list` - Show installed plugins
+- `update [name]` - Update plugins. Unpinned plugins get `git pull`; pinned plugins check for newer tags.
+- `list` - Show installed plugins (includes pinned version info)
 - `search [query]` - Find plugins on GitHub (`--limit`)
 - `run <name> [args...]` - Run a plugin command
 
@@ -553,6 +554,8 @@ binary = "fledge-deploy-notify"
 
 ```bash
 fledge plugin install someone/fledge-deploy
+fledge plugin install someone/fledge-deploy@v1.2.0   # pin to version
+fledge plugin update                                   # update all
 fledge plugin list
 fledge plugin search deploy
 fledge plugin remove fledge-deploy

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -94,7 +94,8 @@ Community extensions, git-style:
 
 ```bash
 fledge plugin search deploy
-fledge plugin install someone/fledge-deploy
+fledge plugin install someone/fledge-deploy           # latest
+fledge plugin install someone/fledge-deploy@v1.0.0    # pinned version
 fledge plugin list
 ```
 

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -8,18 +8,26 @@ Plugins extend fledge with community-built commands. They're external executable
 # From GitHub
 fledge plugin install someone/fledge-deploy
 
+# Pin to a specific version (tag, branch, or commit)
+fledge plugin install someone/fledge-deploy@v1.2.0
+
 # Full URL works too
 fledge plugin install https://github.com/someone/fledge-deploy.git
 
-# Reinstall
-fledge plugin install someone/fledge-deploy --force
+# Full URL with version pin
+fledge plugin install https://github.com/someone/fledge-deploy.git@v1.2.0
+
+# Reinstall (or upgrade a pinned plugin)
+fledge plugin install someone/fledge-deploy@v2.0.0 --force
 ```
 
 What happens when you install:
 1. Repo gets cloned to `~/.config/fledge/plugins/<name>/`
-2. fledge reads `plugin.toml`
-3. Command binaries get symlinked to `~/.config/fledge/plugins/bin/`
-4. Plugin is registered in `~/.config/fledge/plugins.toml`
+2. If `@ref` was specified, that tag/branch/commit is checked out
+3. fledge reads `plugin.toml`
+4. Build hook runs (or auto-detects Rust/Swift/Go/Node)
+5. Command binaries get symlinked to `~/.config/fledge/plugins/bin/`
+6. Plugin is registered in `~/.config/fledge/plugins.toml` (with `pinned_ref` if pinned)
 
 ## Using Plugins
 
@@ -36,8 +44,27 @@ fledge deploy --target production
 ```bash
 fledge plugin list              # what's installed
 fledge plugin search deploy     # find plugins on GitHub
+fledge plugin update            # update all unpinned plugins
+fledge plugin update fledge-deploy  # update a specific plugin
 fledge plugin remove fledge-deploy
 fledge plugin list --json       # for scripting
+```
+
+## Version Pinning
+
+Use `@ref` to pin a plugin to a specific version:
+
+```bash
+fledge plugin install someone/fledge-deploy@v1.2.0
+```
+
+Pinned plugins behave differently on update:
+- **Unpinned** plugins get `git pull` and rebuild automatically
+- **Pinned** plugins check for newer tags and suggest an upgrade command, but don't change automatically
+
+To upgrade a pinned plugin:
+```bash
+fledge plugin install someone/fledge-deploy@v2.0.0 --force
 ```
 
 ## Discovery

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 3
+version: 4
 status: active
 files:
   - src/plugin.rs
@@ -36,7 +36,7 @@ Plugin system for community extensions. Plugins are external executables that re
 |------|-------------|
 | `PluginOptions` | CLI options: `action`, `json` |
 | `PluginAction` | Enum: Install, Remove, Update, List, Search, Run |
-| `PluginEntry` | Installed plugin record: name, source, version, installed date, commands |
+| `PluginEntry` | Installed plugin record: name, source, version, installed date, commands, pinned_ref |
 | `PluginManifest` | (private) Parsed `plugin.toml`: name, version, description, commands, hooks |
 
 ### Functions
@@ -89,7 +89,11 @@ Plugins are discovered via:
 
 ### Plugin Installation
 
-`fledge plugin install <repo>` clones the repo to `~/.config/fledge/plugins/<name>/`, reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks them.
+`fledge plugin install <repo>[@ref]` clones the repo to `~/.config/fledge/plugins/<name>/`, optionally checks out a pinned git ref (tag, branch, or commit), reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks them.
+
+### Version Pinning
+
+Install a specific version with `@ref` syntax: `fledge plugin install owner/repo@v1.2.0`. The ref is stored in `plugins.toml` as `pinned_ref`. Pinned plugins skip `git pull` on update and instead check for newer tags, suggesting an upgrade command if one exists.
 
 ## Config Format
 
@@ -98,9 +102,16 @@ Plugins are tracked in `~/.config/fledge/plugins.toml`:
 ```toml
 [[plugins]]
 name = "deploy"
-source = "github:someone/fledge-deploy"
+source = "someone/fledge-deploy"
 version = "0.1.0"
 installed = "2026-04-20"
+
+[[plugins]]
+name = "fledge-pet"
+source = "corvid-agent/fledge-plugin-pet"
+version = "0.2.0"
+installed = "2026-04-21"
+pinned_ref = "v0.2.0"
 ```
 
 ## Invariants
@@ -110,7 +121,7 @@ installed = "2026-04-20"
 3. `resolve_plugin_command` checks `plugins/bin/` then PATH for `fledge-<name>`
 4. `plugin install` clones the repo, reads `plugin.toml`, runs build hook (or auto-detects), creates symlinks
 5. `plugin remove` deletes the plugin directory and its symlinks
-6. `plugin update` git pulls and rebuilds plugins, re-symlinks binaries
+6. `plugin update` git pulls and rebuilds unpinned plugins; pinned plugins check for newer tags
 7. `plugin list` shows installed plugins with name, version, source, and description
 8. `plugin search` uses GitHub topic search (same as template search)
 9. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
@@ -151,6 +162,16 @@ $ fledge plugin update fledge-deploy
 $ fledge plugin search deploy
   fledge-deploy   v0.1.0  Deploy to various cloud providers  (someone/fledge-deploy)
   fledge-k8s      v0.3.0  Kubernetes deployment helpers       (other/fledge-k8s)
+
+# Install a specific version
+$ fledge plugin install someone/fledge-deploy@v1.2.0
+✅ Installed fledge-deploy v1.2.0 (pinned to v1.2.0)
+  Commands: deploy
+
+# Update pinned plugin — shows newer tags without changing
+$ fledge plugin update fledge-deploy
+  * fledge-deploy — pinned to v1.2.0, latest tag is v1.3.0. To upgrade:
+    fledge plugin install someone/fledge-deploy@v1.3.0 --force
 ```
 
 ## Error Cases
@@ -163,6 +184,7 @@ $ fledge plugin search deploy
 | Not installed | remove when absent | Error listing installed plugins |
 | Binary not found | plugin.toml references missing binary | Error with build hint |
 | Build failed | build hook or auto-detect build fails | Error with toolchain suggestion |
+| Ref not found | `@ref` doesn't exist in repo | Error with `git ls-remote` hint |
 | Permission denied | Binary not executable | Error with guidance |
 
 ## Dependencies
@@ -174,6 +196,7 @@ $ fledge plugin search deploy
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-21 | Add version pinning with @ref syntax, pinned_ref in registry, smart update for pinned plugins |
 | 3 | 2026-04-21 | Add build hook, auto-detect build systems, plugin update command, improved error messages |
 | 2 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |
 | 1 | 2026-04-20 | Initial spec |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 2
+version: 3
 status: active
 files:
   - src/plugin.rs
@@ -35,7 +35,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | Type | Description |
 |------|-------------|
 | `PluginOptions` | CLI options: `action`, `json` |
-| `PluginAction` | Enum: Install, Remove, List, Search, Run |
+| `PluginAction` | Enum: Install, Remove, Update, List, Search, Run |
 | `PluginEntry` | Installed plugin record: name, source, version, installed date, commands |
 | `PluginManifest` | (private) Parsed `plugin.toml`: name, version, description, commands, hooks |
 
@@ -61,12 +61,24 @@ author = "someone"
 [[commands]]
 name = "deploy"
 description = "Deploy the project"
-binary = "fledge-deploy"  # relative to plugin dir
+binary = "target/release/fledge-deploy"  # relative to plugin dir
 
 [hooks]
-post_install = "hooks/post-install.sh"  # runs after `fledge plugin install`
-post_remove  = "hooks/post-remove.sh"   # runs after `fledge plugin remove`
+build = "cargo build --release"          # runs after clone, before binary check
+post_install = "hooks/post-install.sh"   # runs after `fledge plugin install`
+post_remove  = "hooks/post-remove.sh"    # runs after `fledge plugin remove`
 ```
+
+### Build System Auto-Detection
+
+When no `build` hook is specified, fledge auto-detects the build system:
+
+| File | Language | Command |
+|------|----------|---------|
+| `Cargo.toml` | Rust | `cargo build --release` |
+| `Package.swift` | Swift | `swift build -c release` |
+| `go.mod` | Go | `go build .` |
+| `package.json` | Node | `npm install` |
 
 ### Plugin Discovery
 
@@ -77,7 +89,7 @@ Plugins are discovered via:
 
 ### Plugin Installation
 
-`fledge plugin install <repo>` clones the repo to `~/.config/fledge/plugins/<name>/`, reads `plugin.toml`, and symlinks binaries.
+`fledge plugin install <repo>` clones the repo to `~/.config/fledge/plugins/<name>/`, reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks them.
 
 ## Config Format
 
@@ -96,12 +108,13 @@ installed = "2026-04-20"
 1. Plugins are installed to `~/.config/fledge/plugins/<name>/`
 2. Plugin binaries are symlinked to `~/.config/fledge/plugins/bin/`
 3. `resolve_plugin_command` checks `plugins/bin/` then PATH for `fledge-<name>`
-4. `plugin install` clones the repo, reads `plugin.toml`, creates symlinks
+4. `plugin install` clones the repo, reads `plugin.toml`, runs build hook (or auto-detects), creates symlinks
 5. `plugin remove` deletes the plugin directory and its symlinks
-6. `plugin list` shows installed plugins with name, version, source, and description
-7. `plugin search` uses GitHub topic search (same as template search)
-8. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
-9. `--json` outputs structured data for all list/search operations
+6. `plugin update` git pulls and rebuilds plugins, re-symlinks binaries
+7. `plugin list` shows installed plugins with name, version, source, and description
+8. `plugin search` uses GitHub topic search (same as template search)
+9. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
+10. `--json` outputs structured data for all list/search operations
 
 ## Behavioral Examples
 
@@ -125,6 +138,15 @@ $ fledge deploy staging
 $ fledge plugin remove deploy
 ✅ Removed fledge-deploy
 
+# Update all plugins
+$ fledge plugin update
+  ✅ fledge-deploy → v0.2.0
+  ✅ fledge-todo → v1.1.0
+
+# Update a specific plugin
+$ fledge plugin update fledge-deploy
+  ✅ fledge-deploy → v0.2.0
+
 # Search for plugins
 $ fledge plugin search deploy
   fledge-deploy   v0.1.0  Deploy to various cloud providers  (someone/fledge-deploy)
@@ -139,7 +161,8 @@ $ fledge plugin search deploy
 | No plugin.toml | Repo missing manifest | Error explaining requirement |
 | Already installed | install when present | Error with `--force` suggestion |
 | Not installed | remove when absent | Error listing installed plugins |
-| Binary not found | plugin.toml references missing binary | Error during install |
+| Binary not found | plugin.toml references missing binary | Error with build hint |
+| Build failed | build hook or auto-detect build fails | Error with toolchain suggestion |
 | Permission denied | Binary not executable | Error with guidance |
 
 ## Dependencies
@@ -151,5 +174,6 @@ $ fledge plugin search deploy
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-21 | Add build hook, auto-detect build systems, plugin update command, improved error messages |
 | 2 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |
 | 1 | 2026-04-20 | Initial spec |

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,7 +485,7 @@ enum LaneSubcommand {
 enum PluginSubcommand {
     /// Install a plugin from GitHub
     Install {
-        /// GitHub repo (owner/repo) or full URL
+        /// GitHub repo (owner/repo[@ref]) or full URL — use @tag to pin a version
         source: String,
         /// Reinstall if already present
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,6 +496,11 @@ enum PluginSubcommand {
         /// Plugin name
         name: String,
     },
+    /// Update installed plugins (git pull + rebuild)
+    Update {
+        /// Plugin name (omit to update all)
+        name: Option<String>,
+    },
     /// List installed plugins
     List,
     /// Search for plugins on GitHub
@@ -753,6 +758,7 @@ fn run() -> Result<()> {
                     plugin::PluginAction::Install { source, force }
                 }
                 PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },
+                PluginSubcommand::Update { name } => plugin::PluginAction::Update { name },
                 PluginSubcommand::List => plugin::PluginAction::List,
                 PluginSubcommand::Search { query, limit } => {
                     plugin::PluginAction::Search { query, limit }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -149,7 +149,11 @@ fn parse_source_ref(source: &str) -> (&str, Option<&str>) {
         return (source, None);
     }
     match source.rsplit_once('@') {
-        Some((before, after)) if !after.is_empty() && !before.is_empty() => (before, Some(after)),
+        Some((before, after))
+            if !after.is_empty() && !before.is_empty() && !after.contains('/') =>
+        {
+            (before, Some(after))
+        }
         _ => (source, None),
     }
 }
@@ -262,10 +266,23 @@ fn link_commands(
     Ok(command_names)
 }
 
+fn validate_plugin_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.starts_with('.')
+        || name.contains('/')
+        || name.contains('\\')
+        || name == ".."
+    {
+        bail!("Invalid plugin source: repo name '{}' is not safe.", name);
+    }
+    Ok(())
+}
+
 fn install_plugin(source: &str, force: bool) -> Result<()> {
     let (_, git_ref) = parse_source_ref(source);
     let url = normalize_source(source);
     let repo_name = extract_name_from_source(source);
+    validate_plugin_name(&repo_name)?;
 
     let plugins = plugins_dir();
     let bin_dir = plugin_bin_dir();
@@ -410,9 +427,7 @@ fn update_plugins(name: Option<&str>) -> Result<()> {
                 .plugins
                 .iter()
                 .find(|p| p.name == n || p.name == format!("fledge-{n}"))
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Plugin '{n}' is not installed.")
-                })?;
+                .ok_or_else(|| anyhow::anyhow!("Plugin '{n}' is not installed."))?;
             vec![entry]
         }
         None => {
@@ -497,11 +512,19 @@ fn update_plugins(name: Option<&str>) -> Result<()> {
             run_build(&plugin_dir, &manifest)?;
 
             let bin_dir = plugin_bin_dir();
+            for old_cmd in &entry.commands {
+                let old_link = bin_dir.join(format!("fledge-{old_cmd}"));
+                if old_link.exists() || old_link.is_symlink() {
+                    fs::remove_file(&old_link).ok();
+                }
+            }
             link_commands(&plugin_dir, &bin_dir, &manifest)?;
 
+            let new_cmds: Vec<String> = manifest.commands.iter().map(|c| c.name.clone()).collect();
             let mut reg = load_registry()?;
             if let Some(e) = reg.plugins.iter_mut().find(|p| p.name == entry.name) {
                 e.version = manifest.plugin.version.clone();
+                e.commands = new_cmds;
             }
             save_registry(&reg)?;
 
@@ -518,6 +541,13 @@ fn update_plugins(name: Option<&str>) -> Result<()> {
 }
 
 fn find_latest_tag(repo_dir: &Path) -> Option<String> {
+    Command::new("git")
+        .args(["fetch", "--tags"])
+        .current_dir(repo_dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .ok();
     let output = Command::new("git")
         .args(["tag", "--sort=-v:refname"])
         .current_dir(repo_dir)
@@ -1026,6 +1056,33 @@ mod tests {
             parse_source_ref("https://github.com/someone/fledge-deploy.git@v2.0.0");
         assert_eq!(base, "https://github.com/someone/fledge-deploy.git");
         assert_eq!(git_ref, Some("v2.0.0"));
+    }
+
+    #[test]
+    fn parse_source_ref_credential_url_no_split() {
+        let (base, git_ref) = parse_source_ref("https://user:token@github.com/owner/repo.git");
+        assert_eq!(base, "https://user:token@github.com/owner/repo.git");
+        assert!(git_ref.is_none());
+    }
+
+    #[test]
+    fn validate_plugin_name_rejects_dotdot() {
+        assert!(validate_plugin_name("..").is_err());
+    }
+
+    #[test]
+    fn validate_plugin_name_rejects_hidden() {
+        assert!(validate_plugin_name(".secret").is_err());
+    }
+
+    #[test]
+    fn validate_plugin_name_rejects_slashes() {
+        assert!(validate_plugin_name("../etc").is_err());
+    }
+
+    #[test]
+    fn validate_plugin_name_accepts_normal() {
+        assert!(validate_plugin_name("fledge-deploy").is_ok());
     }
 
     #[test]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -53,6 +53,8 @@ pub struct PluginEntry {
     installed: String,
     #[serde(default)]
     commands: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pinned_ref: Option<String>,
 }
 
 pub struct PluginOptions {
@@ -134,21 +136,40 @@ fn save_registry(registry: &PluginsRegistry) -> Result<()> {
     fs::write(&path, content).context("writing plugins.toml")
 }
 
+fn parse_source_ref(source: &str) -> (&str, Option<&str>) {
+    if source.starts_with("git@") {
+        if let Some(rest) = source.strip_prefix("git@") {
+            if let Some((_, after)) = rest.rsplit_once('@') {
+                if !after.is_empty() {
+                    let split_pos = source.len() - after.len() - 1;
+                    return (&source[..split_pos], Some(after));
+                }
+            }
+        }
+        return (source, None);
+    }
+    match source.rsplit_once('@') {
+        Some((before, after)) if !after.is_empty() && !before.is_empty() => (before, Some(after)),
+        _ => (source, None),
+    }
+}
+
 fn normalize_source(source: &str) -> String {
-    if source.starts_with("https://") || source.starts_with("git@") {
-        source.to_string()
-    } else if source.contains('/') {
-        format!("https://github.com/{}.git", source)
+    let (base, _) = parse_source_ref(source);
+    if base.starts_with("https://") || base.starts_with("git@") {
+        base.to_string()
+    } else if base.contains('/') {
+        format!("https://github.com/{}.git", base)
     } else {
-        source.to_string()
+        base.to_string()
     }
 }
 
 fn extract_name_from_source(source: &str) -> String {
-    source
-        .rsplit('/')
+    let (base, _) = parse_source_ref(source);
+    base.rsplit('/')
         .next()
-        .unwrap_or(source)
+        .unwrap_or(base)
         .trim_end_matches(".git")
         .to_string()
 }
@@ -242,6 +263,7 @@ fn link_commands(
 }
 
 fn install_plugin(source: &str, force: bool) -> Result<()> {
+    let (_, git_ref) = parse_source_ref(source);
     let url = normalize_source(source);
     let repo_name = extract_name_from_source(source);
 
@@ -266,10 +288,21 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
         fs::remove_dir_all(&plugin_dir).context("removing existing plugin")?;
     }
 
-    let sp = crate::spinner::Spinner::start(&format!("Cloning {}:", &url));
+    let clone_msg = match git_ref {
+        Some(r) => format!("Cloning {}@{}:", &url, r),
+        None => format!("Cloning {}:", &url),
+    };
+    let sp = crate::spinner::Spinner::start(&clone_msg);
+
+    let mut clone_args = vec!["clone"];
+    if git_ref.is_none() {
+        clone_args.push("--depth");
+        clone_args.push("1");
+    }
+    clone_args.push(&url);
 
     let status = Command::new("git")
-        .args(["clone", "--depth", "1", &url])
+        .args(&clone_args)
         .arg(&plugin_dir)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
@@ -283,6 +316,25 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
             "Failed to clone '{}'. Check the repository URL and your network connection.",
             source
         );
+    }
+
+    if let Some(ref_str) = git_ref {
+        let status = Command::new("git")
+            .args(["checkout", ref_str])
+            .current_dir(&plugin_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .status()
+            .with_context(|| format!("checking out ref '{ref_str}'"))?;
+        if !status.success() {
+            fs::remove_dir_all(&plugin_dir).ok();
+            bail!(
+                "Git ref '{}' not found in '{}'. Check available tags with:\n  {}",
+                ref_str,
+                source,
+                style(format!("git ls-remote --tags {url}")).cyan()
+            );
+        }
     }
 
     let manifest_path = plugin_dir.join("plugin.toml");
@@ -305,12 +357,14 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
         fs::remove_dir_all(&plugin_dir).ok();
     })?;
 
+    let (base_source, _) = parse_source_ref(source);
     let entry = PluginEntry {
         name: repo_name.clone(),
-        source: source.to_string(),
+        source: base_source.to_string(),
         version: manifest.plugin.version.clone(),
         installed: chrono::Local::now().format("%Y-%m-%d").to_string(),
         commands: command_names.clone(),
+        pinned_ref: git_ref.map(String::from),
     };
 
     if let Some(idx) = existing {
@@ -320,12 +374,22 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
     }
     save_registry(&registry)?;
 
-    println!(
-        "{} Installed {} v{}",
-        style("✅").green().bold(),
-        style(&manifest.plugin.name).green(),
-        manifest.plugin.version
-    );
+    if let Some(ref pinned) = git_ref {
+        println!(
+            "{} Installed {} v{} (pinned to {})",
+            style("✅").green().bold(),
+            style(&manifest.plugin.name).green(),
+            manifest.plugin.version,
+            style(pinned).cyan()
+        );
+    } else {
+        println!(
+            "{} Installed {} v{}",
+            style("✅").green().bold(),
+            style(&manifest.plugin.name).green(),
+            manifest.plugin.version
+        );
+    }
     if !command_names.is_empty() {
         println!("  Commands: {}", style(command_names.join(", ")).cyan());
     }
@@ -369,6 +433,35 @@ fn update_plugins(name: Option<&str>) -> Result<()> {
                 style(&entry.name).yellow(),
                 style(format!("fledge plugin install {} --force", entry.source)).cyan()
             );
+            continue;
+        }
+
+        if let Some(ref pinned) = entry.pinned_ref {
+            let latest = find_latest_tag(&plugin_dir);
+            match latest {
+                Some(ref tag) if tag != pinned => {
+                    println!(
+                        "  {} {} — pinned to {}, latest tag is {}. To upgrade:\n    {}",
+                        style("*").cyan().bold(),
+                        style(&entry.name).cyan(),
+                        style(pinned).dim(),
+                        style(tag).green(),
+                        style(format!(
+                            "fledge plugin install {}@{} --force",
+                            entry.source, tag
+                        ))
+                        .cyan()
+                    );
+                }
+                _ => {
+                    println!(
+                        "  {} {} — pinned to {}, already up to date.",
+                        style("✅").green().bold(),
+                        style(&entry.name).green(),
+                        style(pinned).dim()
+                    );
+                }
+            }
             continue;
         }
 
@@ -422,6 +515,23 @@ fn update_plugins(name: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn find_latest_tag(repo_dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["tag", "--sort=-v:refname"])
+        .current_dir(repo_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .next()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 fn remove_plugin(name: &str) -> Result<()> {
@@ -513,6 +623,7 @@ fn list_plugins(json: bool) -> Result<()> {
                     "source": p.source,
                     "installed": p.installed,
                     "commands": p.commands,
+                    "pinned_ref": p.pinned_ref,
                 })
             })
             .collect();
@@ -529,10 +640,14 @@ fn list_plugins(json: bool) -> Result<()> {
         .unwrap_or(0);
 
     for plugin in &registry.plugins {
+        let version_str = match &plugin.pinned_ref {
+            Some(r) => format!("v{} (pinned: {})", plugin.version, r),
+            None => format!("v{}", plugin.version),
+        };
         println!(
             "  {:<width$}  {}  {}",
             style(&plugin.name).green(),
-            style(format!("v{}", plugin.version)).dim(),
+            style(&version_str).dim(),
             style(format!("({})", plugin.source)).dim(),
             width = max_name,
         );
@@ -775,6 +890,14 @@ mod tests {
     }
 
     #[test]
+    fn normalize_github_shorthand_with_ref() {
+        assert_eq!(
+            normalize_source("someone/fledge-deploy@v1.0.0"),
+            "https://github.com/someone/fledge-deploy.git"
+        );
+    }
+
+    #[test]
     fn normalize_full_url() {
         let url = "https://github.com/someone/fledge-deploy.git";
         assert_eq!(normalize_source(url), url);
@@ -790,6 +913,14 @@ mod tests {
     fn extract_name_from_github_shorthand() {
         assert_eq!(
             extract_name_from_source("someone/fledge-deploy"),
+            "fledge-deploy"
+        );
+    }
+
+    #[test]
+    fn extract_name_with_ref() {
+        assert_eq!(
+            extract_name_from_source("someone/fledge-deploy@v1.0.0"),
             "fledge-deploy"
         );
     }
@@ -837,6 +968,7 @@ mod tests {
                 version: "1.0.0".to_string(),
                 installed: "2026-04-20".to_string(),
                 commands: vec!["test-cmd".to_string()],
+                pinned_ref: None,
             }],
         };
         let serialized = toml::to_string_pretty(&registry).unwrap();
@@ -844,6 +976,56 @@ mod tests {
         assert_eq!(deserialized.plugins.len(), 1);
         assert_eq!(deserialized.plugins[0].name, "fledge-test");
         assert_eq!(deserialized.plugins[0].commands, vec!["test-cmd"]);
+        assert!(deserialized.plugins[0].pinned_ref.is_none());
+    }
+
+    #[test]
+    fn registry_roundtrip_with_pinned_ref() {
+        let registry = PluginsRegistry {
+            plugins: vec![PluginEntry {
+                name: "fledge-test".to_string(),
+                source: "someone/fledge-test".to_string(),
+                version: "1.0.0".to_string(),
+                installed: "2026-04-20".to_string(),
+                commands: vec!["test-cmd".to_string()],
+                pinned_ref: Some("v1.0.0".to_string()),
+            }],
+        };
+        let serialized = toml::to_string_pretty(&registry).unwrap();
+        let deserialized: PluginsRegistry = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.plugins[0].pinned_ref,
+            Some("v1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_source_ref_with_tag() {
+        let (base, git_ref) = parse_source_ref("someone/fledge-deploy@v1.2.0");
+        assert_eq!(base, "someone/fledge-deploy");
+        assert_eq!(git_ref, Some("v1.2.0"));
+    }
+
+    #[test]
+    fn parse_source_ref_without_tag() {
+        let (base, git_ref) = parse_source_ref("someone/fledge-deploy");
+        assert_eq!(base, "someone/fledge-deploy");
+        assert!(git_ref.is_none());
+    }
+
+    #[test]
+    fn parse_source_ref_with_branch() {
+        let (base, git_ref) = parse_source_ref("someone/fledge-deploy@main");
+        assert_eq!(base, "someone/fledge-deploy");
+        assert_eq!(git_ref, Some("main"));
+    }
+
+    #[test]
+    fn parse_source_ref_full_url_with_tag() {
+        let (base, git_ref) =
+            parse_source_ref("https://github.com/someone/fledge-deploy.git@v2.0.0");
+        assert_eq!(base, "https://github.com/someone/fledge-deploy.git");
+        assert_eq!(git_ref, Some("v2.0.0"));
     }
 
     #[test]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -34,6 +34,7 @@ struct PluginCommand {
 
 #[derive(Debug, Deserialize, Default)]
 struct PluginHooks {
+    build: Option<String>,
     post_install: Option<String>,
     post_remove: Option<String>,
 }
@@ -62,6 +63,7 @@ pub struct PluginOptions {
 pub enum PluginAction {
     Install { source: String, force: bool },
     Remove { name: String },
+    Update { name: Option<String> },
     List,
     Search { query: Option<String>, limit: usize },
     Run { name: String, args: Vec<String> },
@@ -71,6 +73,7 @@ pub fn run(opts: PluginOptions) -> Result<()> {
     match opts.action {
         PluginAction::Install { source, force } => install_plugin(&source, force),
         PluginAction::Remove { name } => remove_plugin(&name),
+        PluginAction::Update { name } => update_plugins(name.as_deref()),
         PluginAction::List => list_plugins(opts.json),
         PluginAction::Search { query, limit } => search_plugins(query.as_deref(), limit, opts.json),
         PluginAction::Run { name, args } => run_plugin(&name, &args),
@@ -150,6 +153,94 @@ fn extract_name_from_source(source: &str) -> String {
         .to_string()
 }
 
+fn detect_build_command(plugin_dir: &Path) -> Option<(&'static str, Vec<&'static str>)> {
+    if plugin_dir.join("Cargo.toml").exists() {
+        Some(("Rust", vec!["cargo", "build", "--release"]))
+    } else if plugin_dir.join("Package.swift").exists() {
+        Some(("Swift", vec!["swift", "build", "-c", "release"]))
+    } else if plugin_dir.join("go.mod").exists() {
+        Some(("Go", vec!["go", "build", "."]))
+    } else if plugin_dir.join("package.json").exists() {
+        Some(("Node", vec!["npm", "install"]))
+    } else {
+        None
+    }
+}
+
+fn run_build(plugin_dir: &Path, manifest: &PluginManifest) -> Result<()> {
+    if let Some(hook) = &manifest.hooks.build {
+        run_hook(plugin_dir, hook, "build")?;
+        return Ok(());
+    }
+
+    if let Some((lang, cmd)) = detect_build_command(plugin_dir) {
+        let sp = crate::spinner::Spinner::start(&format!("Building ({lang}):"));
+        let status = Command::new(cmd[0])
+            .args(&cmd[1..])
+            .current_dir(plugin_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .status()
+            .with_context(|| format!("running {lang} build"))?;
+        sp.finish();
+        if !status.success() {
+            bail!("Build failed. Check your {lang} toolchain is installed.");
+        }
+    }
+
+    Ok(())
+}
+
+fn link_commands(
+    plugin_dir: &Path,
+    bin_dir: &Path,
+    manifest: &PluginManifest,
+) -> Result<Vec<String>> {
+    let mut command_names = Vec::new();
+    for cmd in &manifest.commands {
+        let binary_path = plugin_dir.join(&cmd.binary);
+        if !binary_path.exists() {
+            let mut hint = format!(
+                "Plugin '{}' references binary '{}' which does not exist.",
+                manifest.plugin.name, cmd.binary
+            );
+            if let Some((lang, _)) = detect_build_command(plugin_dir) {
+                hint.push_str(&format!(
+                    "\n  This looks like a {} project. Add a build hook to plugin.toml:",
+                    lang
+                ));
+                hint.push_str("\n  [hooks]");
+                let example = match lang {
+                    "Rust" => "build = \"cargo build --release\"",
+                    "Swift" => "build = \"swift build -c release\"",
+                    "Go" => "build = \"go build .\"",
+                    _ => "build = \"scripts/build.sh\"",
+                };
+                hint.push_str(&format!("\n  {example}"));
+            }
+            bail!("{hint}");
+        }
+
+        make_executable(&binary_path)?;
+
+        let link_name = format!("fledge-{}", cmd.name);
+        let link_path = bin_dir.join(&link_name);
+        if link_path.exists() || link_path.is_symlink() {
+            fs::remove_file(&link_path).ok();
+        }
+        create_symlink(&binary_path, &link_path).with_context(|| {
+            format!(
+                "creating symlink {} -> {}",
+                link_path.display(),
+                binary_path.display()
+            )
+        })?;
+
+        command_names.push(cmd.name.clone());
+    }
+    Ok(command_names)
+}
+
 fn install_plugin(source: &str, force: bool) -> Result<()> {
     let url = normalize_source(source);
     let repo_name = extract_name_from_source(source);
@@ -208,35 +299,11 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
     let manifest: PluginManifest =
         toml::from_str(&manifest_content).context("parsing plugin.toml")?;
 
-    let mut command_names = Vec::new();
-    for cmd in &manifest.commands {
-        let binary_path = plugin_dir.join(&cmd.binary);
-        if !binary_path.exists() {
-            fs::remove_dir_all(&plugin_dir).ok();
-            bail!(
-                "Plugin '{}' references binary '{}' which does not exist in the repository.",
-                manifest.plugin.name,
-                cmd.binary
-            );
-        }
+    run_build(&plugin_dir, &manifest)?;
 
-        make_executable(&binary_path)?;
-
-        let link_name = format!("fledge-{}", cmd.name);
-        let link_path = bin_dir.join(&link_name);
-        if link_path.exists() || link_path.is_symlink() {
-            fs::remove_file(&link_path).ok();
-        }
-        create_symlink(&binary_path, &link_path).with_context(|| {
-            format!(
-                "creating symlink {} -> {}",
-                link_path.display(),
-                binary_path.display()
-            )
-        })?;
-
-        command_names.push(cmd.name.clone());
-    }
+    let command_names = link_commands(&plugin_dir, &bin_dir, &manifest).inspect_err(|_| {
+        fs::remove_dir_all(&plugin_dir).ok();
+    })?;
 
     let entry = PluginEntry {
         name: repo_name.clone(),
@@ -265,6 +332,90 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
 
     if let Some(hook) = &manifest.hooks.post_install {
         run_hook(&plugin_dir, hook, "post_install")?;
+    }
+
+    Ok(())
+}
+
+fn update_plugins(name: Option<&str>) -> Result<()> {
+    let registry = load_registry()?;
+
+    if registry.plugins.is_empty() {
+        println!("{} No plugins installed.", style("*").cyan().bold());
+        return Ok(());
+    }
+
+    let targets: Vec<&PluginEntry> = match name {
+        Some(n) => {
+            let entry = registry
+                .plugins
+                .iter()
+                .find(|p| p.name == n || p.name == format!("fledge-{n}"))
+                .ok_or_else(|| anyhow::anyhow!("Plugin '{}' is not installed.", n))?;
+            vec![entry]
+        }
+        None => registry.plugins.iter().collect(),
+    };
+
+    for entry in &targets {
+        let plugin_dir = plugins_dir().join(&entry.name);
+        if !plugin_dir.exists() {
+            println!(
+                "  {} {} — directory missing, reinstall with {}",
+                style("⚠️").yellow(),
+                style(&entry.name).yellow(),
+                style(format!("fledge plugin install {} --force", entry.source)).cyan()
+            );
+            continue;
+        }
+
+        let sp = crate::spinner::Spinner::start(&format!("Updating {}:", &entry.name));
+
+        let status = Command::new("git")
+            .args(["pull", "--ff-only"])
+            .current_dir(&plugin_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .status()
+            .with_context(|| format!("updating {}", entry.name))?;
+
+        sp.finish();
+
+        if !status.success() {
+            println!(
+                "  {} {} — git pull failed, try reinstalling with {}",
+                style("⚠️").yellow(),
+                style(&entry.name).yellow(),
+                style(format!("fledge plugin install {} --force", entry.source)).cyan()
+            );
+            continue;
+        }
+
+        let manifest_path = plugin_dir.join("plugin.toml");
+        if manifest_path.exists() {
+            let manifest_content =
+                fs::read_to_string(&manifest_path).context("reading plugin.toml")?;
+            let manifest: PluginManifest =
+                toml::from_str(&manifest_content).context("parsing plugin.toml")?;
+
+            run_build(&plugin_dir, &manifest)?;
+
+            let bin_dir = plugin_bin_dir();
+            link_commands(&plugin_dir, &bin_dir, &manifest)?;
+
+            let mut reg = load_registry()?;
+            if let Some(e) = reg.plugins.iter_mut().find(|p| p.name == entry.name) {
+                e.version = manifest.plugin.version.clone();
+            }
+            save_registry(&reg)?;
+
+            println!(
+                "  {} {} → v{}",
+                style("✅").green().bold(),
+                style(&entry.name).green(),
+                manifest.plugin.version
+            );
+        }
     }
 
     Ok(())
@@ -787,5 +938,78 @@ version = "0.1.0"
         let pd = plugins_dir();
         let bd = plugin_bin_dir();
         assert!(bd.starts_with(&pd));
+    }
+
+    #[test]
+    fn detect_rust_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"x\"").unwrap();
+        let result = detect_build_command(tmp.path());
+        assert!(result.is_some());
+        let (lang, cmd) = result.unwrap();
+        assert_eq!(lang, "Rust");
+        assert_eq!(cmd[0], "cargo");
+    }
+
+    #[test]
+    fn detect_swift_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Package.swift"), "// swift").unwrap();
+        let result = detect_build_command(tmp.path());
+        assert!(result.is_some());
+        let (lang, _) = result.unwrap();
+        assert_eq!(lang, "Swift");
+    }
+
+    #[test]
+    fn detect_go_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("go.mod"), "module x").unwrap();
+        let result = detect_build_command(tmp.path());
+        assert!(result.is_some());
+        let (lang, _) = result.unwrap();
+        assert_eq!(lang, "Go");
+    }
+
+    #[test]
+    fn detect_node_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("package.json"), "{}").unwrap();
+        let result = detect_build_command(tmp.path());
+        assert!(result.is_some());
+        let (lang, _) = result.unwrap();
+        assert_eq!(lang, "Node");
+    }
+
+    #[test]
+    fn detect_no_build_system() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(detect_build_command(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn parse_manifest_with_build_hook() {
+        let manifest_str = r#"
+[plugin]
+name = "fledge-compiled"
+version = "0.1.0"
+
+[[commands]]
+name = "compiled"
+binary = "target/release/fledge-compiled"
+
+[hooks]
+build = "cargo build --release"
+post_install = "scripts/setup.sh"
+"#;
+        let manifest: PluginManifest = toml::from_str(manifest_str).unwrap();
+        assert_eq!(
+            manifest.hooks.build.as_deref(),
+            Some("cargo build --release")
+        );
+        assert_eq!(
+            manifest.hooks.post_install.as_deref(),
+            Some("scripts/setup.sh")
+        );
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -340,21 +340,24 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
 fn update_plugins(name: Option<&str>) -> Result<()> {
     let registry = load_registry()?;
 
-    if registry.plugins.is_empty() {
-        println!("{} No plugins installed.", style("*").cyan().bold());
-        return Ok(());
-    }
-
     let targets: Vec<&PluginEntry> = match name {
         Some(n) => {
             let entry = registry
                 .plugins
                 .iter()
                 .find(|p| p.name == n || p.name == format!("fledge-{n}"))
-                .ok_or_else(|| anyhow::anyhow!("Plugin '{}' is not installed.", n))?;
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Plugin '{n}' is not installed.")
+                })?;
             vec![entry]
         }
-        None => registry.plugins.iter().collect(),
+        None => {
+            if registry.plugins.is_empty() {
+                println!("{} No plugins installed.", style("*").cyan().bold());
+                return Ok(());
+            }
+            registry.plugins.iter().collect()
+        }
     };
 
     for entry in &targets {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1703,6 +1703,28 @@ fn cli_plugin_list_json() {
     assert!(parsed.is_array() || parsed.is_object());
 }
 
+#[test]
+fn cli_plugin_update_no_plugins() {
+    let output = run_fledge(&["plugin", "update"]);
+    assert!(output.status.success());
+}
+
+#[test]
+fn cli_plugin_update_nonexistent_fails() {
+    let output = run_fledge(&["plugin", "update", "nonexistent"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("not installed"));
+}
+
+#[test]
+fn cli_plugin_update_help() {
+    let output = run_fledge(&["plugin", "update", "--help"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Update installed plugins"));
+}
+
 // ──────────────────────────────────────────────────────────
 // Special characters and unicode in project names
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Build hook**: New `[hooks] build` field in `plugin.toml` runs after clone, before binary validation — compiled plugins (Rust, Swift, Go) can point to their build output directly without wrapper scripts
- **Auto-detect**: When no build hook specified, auto-detects Cargo.toml/Package.swift/go.mod/package.json and builds automatically — zero-config compiled plugins
- **Update command**: `fledge plugin update [name]` — git pulls latest, rebuilds, re-symlinks
- **Better errors**: When binary not found, suggests build hook with language-specific example
- **fledge-plugin-pet rewritten**: Now uses [CorvidLabs/corvid-pet](https://github.com/CorvidLabs/corvid-pet) crate with full simulation (hunger, energy, happiness, health stats, life stages, moods)

## Install flow (before → after)

**Before:** clone → check binaries exist → symlink → post_install hook  
**After:** clone → **run build hook (or auto-detect)** → check binaries exist → symlink → post_install hook

## Test plan

- [x] 144 tests pass (3 new: plugin update no-plugins, update nonexistent, update help)
- [x] 6 new unit tests for build detection (Rust, Swift, Go, Node, none, manifest parsing)
- [x] Clippy clean, cargo fmt, 28/28 specs valid
- [x] fledge-plugin-pet compiles and runs with corvid-pet dependency
- [ ] Manual: `fledge plugin install corvid-agent/fledge-plugin-pet` should auto-build

🤖 Generated with [Claude Code](https://claude.com/claude-code)