### PR TITLE
fix: support inline shell commands in plugin hooks

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -816,20 +816,29 @@ fn run_plugin(name: &str, args: &[String]) -> Result<()> {
 }
 
 fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
-    let hook_path = plugin_dir.join(hook);
-    if !hook_path.exists() {
-        return Ok(());
-    }
-    make_executable(&hook_path)?;
     println!(
         "  {} Running {} hook...",
         style("▶️").cyan().bold(),
         style(event).dim()
     );
-    let status = Command::new(&hook_path)
-        .current_dir(plugin_dir)
-        .status()
-        .with_context(|| format!("running {event} hook"))?;
+
+    let hook_path = plugin_dir.join(hook);
+    let status = if hook_path.exists() {
+        make_executable(&hook_path)?;
+        Command::new(&hook_path)
+            .current_dir(plugin_dir)
+            .status()
+            .with_context(|| format!("running {event} hook"))?
+    } else {
+        let shell = if cfg!(windows) { "cmd" } else { "sh" };
+        let flag = if cfg!(windows) { "/C" } else { "-c" };
+        Command::new(shell)
+            .args([flag, hook])
+            .current_dir(plugin_dir)
+            .status()
+            .with_context(|| format!("running {event} hook"))?
+    };
+
     if !status.success() {
         let code = status.code().unwrap_or(1);
         bail!("Hook '{}' exited with code {}", event, code);


### PR DESCRIPTION
## Summary
- `run_hook` previously only supported file paths — if the hook string wasn't an existing file, it silently did nothing
- Now falls back to executing the hook as a shell command (`sh -c` on Unix, `cmd /C` on Windows)
- Plugins can use either file paths (`build = "bin/build.sh"`) or inline commands (`build = "cargo build --release"`)
- This was discovered while testing remote plugin installs — the pet plugin's `build = "cargo build --release"` was silently skipped

## Test plan
- [x] 144 tests pass
- [x] Clippy clean
- [x] E2E: `fledge plugin install corvid-agent/fledge-plugin-pet` builds via inline command
- [x] E2E: `fledge plugin install corvid-agent/fledge-plugin-todo` builds via file-path hook
- [x] E2E: `fledge plugin install corvid-agent/fledge-plugin-loc` builds via file-path hook
- [x] E2E: `fledge plugin update` updates all three
- [x] E2E: version-pinned install works (`@v0.2.0`)
- [x] All three plugins execute correctly after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)