### PR TITLE
feat: generalize parallel lane steps for 1.0

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -100,6 +100,14 @@ token = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
 | `FLEDGE_GITHUB_TOKEN` | GitHub token (overrides config) |
 | `GITHUB_TOKEN` | GitHub token (fallback) |
 
+## Project Configuration (fledge.toml)
+
+Per-project settings live in `fledge.toml` in your project root. This file defines tasks, lanes, and project metadata. It's created by `fledge run --init` or `fledge init`.
+
+For task and lane configuration, see:
+- [Lanes & Pipelines](./lanes.md) — defining lanes, step types, parallel groups, importing community lanes
+- [Plugins](./plugins.md) — extending fledge with community plugins
+
 ## Priority Order
 
 When creating a project, values come from (highest to lowest):

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -73,7 +73,7 @@ steps = [
 
 ### Parallel Groups
 
-Run multiple tasks at the same time. Everything in the group finishes before the next step starts.
+Run multiple items at the same time. Everything in the group finishes before the next step starts. Items can be task references or inline commands.
 
 ```toml
 steps = [
@@ -84,6 +84,15 @@ steps = [
 ```
 
 Here `fmt` and `lint` run concurrently, then `test`, then `build`.
+
+You can mix task references and inline commands in a parallel group:
+
+```toml
+steps = [
+  { parallel = ["lint", { run = "echo checking..." }, "fmt"] },
+  "test"
+]
+```
 
 ## Failure Behavior
 
@@ -232,6 +241,13 @@ You can pin to a specific branch or tag:
 ```bash
 fledge lane import CorvidLabs/fledge-lanes@v1.0.0
 ```
+
+## Related
+
+- [Configuration](./configuration.md) — global config, GitHub tokens
+- [Plugins](./plugins.md) — extend fledge with community commands, use plugins in lanes
+- [CLI Reference](./cli-reference.md) — full `fledge lane` subcommand reference
+- [Example Lanes](https://github.com/CorvidLabs/fledge-lanes) — official community lane collection
 
 ## Tips
 

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -165,6 +165,33 @@ Hooks fire in response to fledge events.
 | `event` | string | Yes | Event to hook (e.g. `lane:post`) |
 | `binary` | string | Yes | Path to executable (relative to plugin root) |
 
+## Using Plugins in Lanes
+
+Plugin commands can be called from lane steps as inline commands:
+
+```toml
+[lanes.deploy]
+description = "Test, build, and deploy"
+steps = [
+  "test",
+  { run = "cargo build --release" },
+  { run = "fledge deploy --target production" },
+]
+```
+
+You can also run plugin commands in parallel with other tasks:
+
+```toml
+[lanes.ci]
+steps = [
+  { parallel = ["lint", "test"] },
+  "build",
+  { parallel = [{ run = "fledge deploy --target staging" }, { run = "fledge notify --channel ci" }] },
+]
+```
+
+See [Lanes & Pipelines](./lanes.md) for full step type documentation.
+
 ## File Locations
 
 | Path | What's there |

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 4
+version: 5
 status: active
 files:
   - src/lanes.rs
@@ -36,6 +36,7 @@ Composable workflow pipelines defined in `fledge.toml`. Lanes chain multiple tas
 | `LaneAction` | Action enum for the lane subcommand (Run, List, Init, Search, Import) |
 | `LaneDef` | A named lane with description, steps, and fail_fast flag |
 | `Step` | A single step: task reference, inline command, or parallel group |
+| `ParallelItem` | An item within a parallel group: task reference or inline command |
 
 ### Functions
 
@@ -62,11 +63,20 @@ steps = [
   "publish"
 ]
 
-# Parallel groups — steps inside { parallel = [...] } run concurrently
+# Parallel groups — items inside { parallel = [...] } run concurrently
+# Items can be task references or inline commands
 [lanes.check]
 description = "Quick quality check"
 steps = [
   { parallel = ["lint", "fmt"] },
+  "test"
+]
+
+# Parallel with mixed types
+[lanes.prep]
+description = "Parallel tasks and inline commands"
+steps = [
+  { parallel = ["lint", { run = "echo checking" }] },
   "test"
 ]
 
@@ -83,12 +93,12 @@ steps = ["deps-audit", "license-check", "security-scan"]
 |------|--------|-------------|
 | Task reference | `"task_name"` | Runs a task defined in `[tasks]` |
 | Inline command | `{ run = "command" }` | Runs a shell command directly |
-| Parallel group | `{ parallel = ["a", "b"] }` | Runs referenced tasks concurrently |
+| Parallel group | `{ parallel = ["a", "b"] }` | Runs items concurrently (task refs or inline commands) |
 
 ## Invariants
 
 1. Lanes are read from `fledge.toml` alongside tasks
-2. Each step in a lane is either a task reference (string), inline command (`{ run = "..." }`), or parallel group (`{ parallel = [...] }`)
+2. Each step in a lane is either a task reference (string), inline command (`{ run = "..." }`), or parallel group (`{ parallel = [...] }`) — parallel groups accept both task references and inline commands
 3. Task references must resolve to tasks defined in `[tasks]` — unknown references produce an error before execution
 4. Parallel groups spawn threads and collect results; if any thread fails and `fail_fast` is true, remaining steps are skipped
 5. Steps execute sequentially by default; only `{ parallel = [...] }` groups run concurrently
@@ -182,6 +192,7 @@ $ fledge lane import CorvidLabs/fledge-lanes@v1.0.0
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-04-21 | Generalize parallel groups to accept inline commands, not just task refs |
 | 4 | 2026-04-21 | Rename from flows to lanes — 1.0 branding |
 | 3 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |
 | 2 | 2026-04-20 | Add community lane registry (search + import) |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -84,7 +84,14 @@ fn default_true() -> bool {
 enum Step {
     TaskRef(String),
     Inline { run: String },
-    Parallel { parallel: Vec<String> },
+    Parallel { parallel: Vec<ParallelItem> },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ParallelItem {
+    TaskRef(String),
+    Inline { run: String },
 }
 
 pub enum LaneAction {
@@ -216,18 +223,20 @@ fn validate_lane(lane_name: &str, lane: &LaneDef, tasks: &BTreeMap<String, TaskD
             }
             Step::Inline { .. } => {}
             Step::Parallel { parallel } => {
-                for name in parallel {
-                    if !tasks.contains_key(name) {
-                        bail!(
-                            "Lane '{}' step {} parallel group references unknown task '{}'.\n  Define it in [tasks] first.",
-                            lane_name,
-                            i + 1,
-                            name
-                        );
+                for item in parallel {
+                    if let ParallelItem::TaskRef(name) = item {
+                        if !tasks.contains_key(name) {
+                            bail!(
+                                "Lane '{}' step {} parallel group references unknown task '{}'.\n  Define it in [tasks] first.",
+                                lane_name,
+                                i + 1,
+                                name
+                            );
+                        }
+                        check_dep_cycle(name, tasks, &mut HashSet::new()).map_err(|e| {
+                            anyhow::anyhow!("Lane '{}' step {}: {}", lane_name, i + 1, e)
+                        })?;
                     }
-                    check_dep_cycle(name, tasks, &mut HashSet::new()).map_err(|e| {
-                        anyhow::anyhow!("Lane '{}' step {}: {}", lane_name, i + 1, e)
-                    })?;
                 }
             }
         }
@@ -282,10 +291,17 @@ fn dry_run_lane(lane_name: &str, lane: &LaneDef) -> Result<()> {
                 );
             }
             Step::Parallel { parallel } => {
+                let names: Vec<String> = parallel
+                    .iter()
+                    .map(|item| match item {
+                        ParallelItem::TaskRef(name) => name.clone(),
+                        ParallelItem::Inline { run: cmd } => format!("run: {cmd}"),
+                    })
+                    .collect();
                 println!(
                     "  {}. {} {}",
                     i + 1,
-                    style(parallel.join(", ")).cyan(),
+                    style(names.join(", ")).cyan(),
                     style("(parallel)").dim()
                 );
             }
@@ -322,7 +338,16 @@ fn execute_lane(
             let step_desc = match step {
                 Step::TaskRef(name) => name.clone(),
                 Step::Inline { run: cmd } => cmd.clone(),
-                Step::Parallel { parallel } => format!("parallel({})", parallel.join(", ")),
+                Step::Parallel { parallel } => {
+                    let names: Vec<String> = parallel
+                        .iter()
+                        .map(|item| match item {
+                            ParallelItem::TaskRef(name) => name.clone(),
+                            ParallelItem::Inline { run: cmd } => cmd.clone(),
+                        })
+                        .collect();
+                    format!("parallel({})", names.join(", "))
+                }
             };
             if lane.fail_fast {
                 bail!(
@@ -458,15 +483,21 @@ fn execute_inline(cmd: &str, project_dir: &Path) -> Result<()> {
 }
 
 fn execute_parallel(
-    task_names: &[String],
+    items: &[ParallelItem],
     tasks: &BTreeMap<String, TaskDef>,
     project_dir: &Path,
 ) -> Result<()> {
-    let names_display = task_names.join(", ");
+    let names_display: Vec<String> = items
+        .iter()
+        .map(|item| match item {
+            ParallelItem::TaskRef(name) => name.clone(),
+            ParallelItem::Inline { run: cmd } => cmd.clone(),
+        })
+        .collect();
     println!(
         "  {} {}",
         style("▶️").cyan().bold(),
-        style(format!("Running parallel: {names_display}")).bold()
+        style(format!("Running parallel: {}", names_display.join(", "))).bold()
     );
 
     let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -474,12 +505,20 @@ fn execute_parallel(
     thread::scope(|s| {
         let mut handles = Vec::new();
 
-        for name in task_names {
+        for item in items {
             let errors = Arc::clone(&errors);
             let handle = s.spawn(move || {
-                if let Err(e) = execute_task_with_deps(name, tasks, project_dir) {
+                let result = match item {
+                    ParallelItem::TaskRef(name) => execute_task_with_deps(name, tasks, project_dir),
+                    ParallelItem::Inline { run: cmd } => execute_inline(cmd, project_dir),
+                };
+                if let Err(e) = result {
+                    let label = match item {
+                        ParallelItem::TaskRef(name) => name.clone(),
+                        ParallelItem::Inline { run: cmd } => cmd.clone(),
+                    };
                     if let Ok(mut errs) = errors.lock() {
-                        errs.push(format!("{}: {}", name, e));
+                        errs.push(format!("{}: {}", label, e));
                     }
                 }
             });
@@ -851,8 +890,16 @@ fn format_lane_toml(name: &str, lane: &LaneDef) -> String {
                 out.push_str(&format!("{{ run = \"{}\" }}", cmd));
             }
             Step::Parallel { parallel } => {
-                let names: Vec<String> = parallel.iter().map(|n| format!("\"{}\"", n)).collect();
-                out.push_str(&format!("{{ parallel = [{}] }}", names.join(", ")));
+                let items: Vec<String> = parallel
+                    .iter()
+                    .map(|item| match item {
+                        ParallelItem::TaskRef(name) => format!("\"{}\"", name),
+                        ParallelItem::Inline { run: cmd } => {
+                            format!("{{ run = \"{}\" }}", cmd)
+                        }
+                    })
+                    .collect();
+                out.push_str(&format!("{{ parallel = [{}] }}", items.join(", ")));
             }
         }
     }
@@ -956,7 +1003,9 @@ steps = [
         assert_eq!(config.lanes["check"].steps.len(), 2);
         match &config.lanes["check"].steps[0] {
             Step::Parallel { parallel } => {
-                assert_eq!(parallel, &["lint", "fmt"]);
+                assert_eq!(parallel.len(), 2);
+                assert!(matches!(&parallel[0], ParallelItem::TaskRef(n) if n == "lint"));
+                assert!(matches!(&parallel[1], ParallelItem::TaskRef(n) if n == "fmt"));
             }
             _ => panic!("expected parallel step"),
         }
@@ -1235,6 +1284,101 @@ steps = [{ parallel = ["a", "b"] }]
     }
 
     #[test]
+    fn parse_parallel_inline_items() {
+        let config = parse_config(
+            r#"
+[tasks]
+lint = "cargo clippy"
+
+[lanes.mixed]
+description = "Mixed parallel"
+steps = [
+  { parallel = ["lint", { run = "echo inline" }] },
+]
+"#,
+        );
+        match &config.lanes["mixed"].steps[0] {
+            Step::Parallel { parallel } => {
+                assert_eq!(parallel.len(), 2);
+                assert!(matches!(&parallel[0], ParallelItem::TaskRef(n) if n == "lint"));
+                assert!(
+                    matches!(&parallel[1], ParallelItem::Inline { run } if run == "echo inline")
+                );
+            }
+            _ => panic!("expected parallel step"),
+        }
+    }
+
+    #[test]
+    fn execute_parallel_with_inline() {
+        let config = parse_config(
+            r#"
+[tasks]
+a = "echo task-a"
+
+[lanes.mixed]
+steps = [{ parallel = ["a", { run = "echo inline-b" }] }]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane("mixed", &config.lanes["mixed"], &config.tasks, &project_dir);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_parallel_all_inline() {
+        let config = parse_config(
+            r#"
+[tasks]
+
+[lanes.inlines]
+steps = [{ parallel = [{ run = "echo one" }, { run = "echo two" }] }]
+"#,
+        );
+        let project_dir = std::env::current_dir().unwrap();
+        let result = execute_lane(
+            "inlines",
+            &config.lanes["inlines"],
+            &config.tasks,
+            &project_dir,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_parallel_inline_no_task_check() {
+        let config = parse_config(
+            r#"
+[tasks]
+
+[lanes.ci]
+steps = [{ parallel = [{ run = "echo hello" }] }]
+"#,
+        );
+        let result = validate_lane("ci", &config.lanes["ci"], &config.tasks);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn format_lane_toml_with_parallel_inline() {
+        let lane = LaneDef {
+            description: None,
+            steps: vec![Step::Parallel {
+                parallel: vec![
+                    ParallelItem::TaskRef("lint".to_string()),
+                    ParallelItem::Inline {
+                        run: "echo done".to_string(),
+                    },
+                ],
+            }],
+            fail_fast: true,
+        };
+        let toml = format_lane_toml("mixed", &lane);
+        assert!(toml.contains("\"lint\""));
+        assert!(toml.contains("{ run = \"echo done\" }"));
+    }
+
+    #[test]
     fn execute_fail_fast_stops() {
         let config = parse_config(
             r#"
@@ -1428,7 +1572,10 @@ steps = ["build"]
         let lane = LaneDef {
             description: None,
             steps: vec![Step::Parallel {
-                parallel: vec!["lint".to_string(), "fmt".to_string()],
+                parallel: vec![
+                    ParallelItem::TaskRef("lint".to_string()),
+                    ParallelItem::TaskRef("fmt".to_string()),
+                ],
             }],
             fail_fast: true,
         };


### PR DESCRIPTION
## Summary

- **Parallel groups now accept inline commands**, not just task references. Before: `{ parallel = ["lint", "fmt"] }`. Now also: `{ parallel = ["lint", { run = "echo checking" }] }`. This removes the most restrictive contract in the lane system before we lock it in at 1.0.
- **Documentation cross-linking** — lanes, plugins, and configuration docs now reference each other properly. Plugins doc shows how to use plugin commands in lane steps (including parallel).
- **Spec updated** to v5 with the new `ParallelItem` type.

## Changes

| File | What |
|------|------|
| `src/lanes.rs` | New `ParallelItem` enum, updated validation/execution/display/formatting |
| `specs/lanes/lanes.spec.md` | v5 — documents generalized parallel, adds `ParallelItem` type |
| `docs/src/lanes.md` | Mixed parallel examples, cross-links to related docs |
| `docs/src/plugins.md` | New "Using Plugins in Lanes" section with parallel examples |
| `docs/src/configuration.md` | Added fledge.toml cross-reference to lanes and plugins docs |

## Test plan

- [x] All 426 unit tests pass (5 new parallel-inline tests added)
- [x] All 144 integration tests pass
- [x] Zero clippy warnings
- [x] 28/28 specs valid
- [x] Existing TOML configs parse identically (backwards compatible)
- [x] New mixed parallel configs parse and execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)