### PR TITLE
feat: step timing + plugin lifecycle hooks for 1.0

### DIFF
--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -113,6 +113,23 @@ fail_fast = false
 steps = ["lint", "test", "security-check", "license-check"]
 ```
 
+## Step Timing
+
+Every step prints its elapsed time, and the lane summary shows total time:
+
+```
+▶️ Lane: ci — Full CI pipeline
+  ▶️ Running parallel: fmt, lint
+  ✔ Step 1 done (245ms)
+  ▶️ Running task: test
+  ✔ Step 2 done (1.032s)
+  ▶️ Running task: build
+  ✔ Step 3 done (3.456s)
+✅ Lane ci completed (3 steps in 4.733s)
+```
+
+This helps identify slow steps in your pipeline without any extra tooling.
+
 ## Task Configuration
 
 ### Short Form

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -156,14 +156,20 @@ Each entry registers a subcommand.
 | `description` | string | No | What it does |
 | `binary` | string | Yes | Path to executable (relative to plugin root) |
 
-### [[hooks]]
+### [hooks]
 
-Hooks fire in response to fledge events.
+Hooks fire in response to fledge lifecycle events. All fields are optional — plugins only participate in events they declare.
 
-| Field | Type | Required | |
-|-------|------|----------|-|
-| `event` | string | Yes | Event to hook (e.g. `lane:post`) |
-| `binary` | string | Yes | Path to executable (relative to plugin root) |
+| Field | Type | Description |
+|-------|------|-------------|
+| `build` | string | Runs after clone, before binary check |
+| `post_install` | string | Runs after `fledge plugin install` |
+| `post_remove` | string | Runs before `fledge plugin remove` deletes files |
+| `pre_init` | string | Runs before `fledge init` starts |
+| `post_work_start` | string | Runs after `fledge work start` creates a branch |
+| `pre_pr` | string | Runs before `fledge work pr` pushes and creates a PR |
+
+Values can be a path to a script (relative to plugin root) or an inline shell command.
 
 ## Using Plugins in Lanes
 

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 5
+version: 6
 status: active
 files:
   - src/lanes.rs
@@ -106,6 +106,7 @@ steps = ["deps-audit", "license-check", "security-scan"]
 7. `--init` appends language-aware default lanes to an existing `fledge.toml`
 8. `--dry-run` prints the execution plan without running anything
 9. Task dependencies (deps) are resolved within each step — a task's deps run before the task itself
+10. Each step prints its elapsed time on completion; the lane summary includes total elapsed time
 
 ## Behavioral Examples
 
@@ -116,13 +117,16 @@ Available lanes:
   ci       Full CI pipeline
   release  Build and publish a release
 
-# Run a lane
+# Run a lane (with step timing)
 $ fledge lane ci
 ▶️ Lane: ci — Full CI pipeline
   ▶️ Running task: lint
+  ✔ Step 1 done (245ms)
   ▶️ Running task: test
+  ✔ Step 2 done (1.032s)
   ▶️ Running task: build
-✅ Lane ci completed (3 steps)
+  ✔ Step 3 done (3.456s)
+✅ Lane ci completed (3 steps in 4.733s)
 
 # Dry run
 $ fledge lane ci --dry-run
@@ -192,6 +196,7 @@ $ fledge lane import CorvidLabs/fledge-lanes@v1.0.0
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 6 | 2026-04-21 | Add step timing — each step prints elapsed time, lane summary includes total |
 | 5 | 2026-04-21 | Generalize parallel groups to accept inline commands, not just task refs |
 | 4 | 2026-04-21 | Rename from flows to lanes — 1.0 branding |
 | 3 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 4
+version: 5
 status: active
 files:
   - src/plugin.rs
@@ -46,6 +46,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `run` | `(PluginOptions) -> Result<()>` | Main entry — dispatch to install/list/remove/run |
 | `resolve_plugin_command` | `(&str) -> Option<PathBuf>` | Find plugin executable by command name |
 | `list_installed` | `() -> Result<Vec<PluginEntry>>` | List all installed plugins |
+| `run_lifecycle_hook` | `(&str) -> Result<()>` | Run a named lifecycle hook across all installed plugins |
 
 ## Plugin Format
 
@@ -67,6 +68,9 @@ binary = "target/release/fledge-deploy"  # relative to plugin dir
 build = "cargo build --release"          # runs after clone, before binary check
 post_install = "hooks/post-install.sh"   # runs after `fledge plugin install`
 post_remove  = "hooks/post-remove.sh"    # runs after `fledge plugin remove`
+pre_init = "hooks/pre-init.sh"           # runs before `fledge init`
+post_work_start = "hooks/setup-hooks.sh" # runs after `fledge work start`
+pre_pr = "hooks/lint-all.sh"             # runs before `fledge work pr` pushes
 ```
 
 ### Build System Auto-Detection
@@ -79,6 +83,18 @@ When no `build` hook is specified, fledge auto-detects the build system:
 | `Package.swift` | Swift | `swift build -c release` |
 | `go.mod` | Go | `go build .` |
 | `package.json` | Node | `npm install` |
+
+### Lifecycle Hooks
+
+Plugins can register hooks for lifecycle events beyond install/remove:
+
+| Hook | When | Use Case |
+|------|------|----------|
+| `pre_init` | Before `fledge init` | Inject custom template variables, validate prerequisites |
+| `post_work_start` | After `fledge work start` creates a branch | Set up git hooks, configure branch-specific env |
+| `pre_pr` | Before `fledge work pr` pushes and creates PR | Run lint, format, security scans before PR creation |
+
+Lifecycle hooks are called across all installed plugins. Hooks are optional — plugins only participate in events they declare.
 
 ### Plugin Discovery
 
@@ -196,6 +212,7 @@ $ fledge plugin update fledge-deploy
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-04-21 | Add lifecycle hooks: pre_init, post_work_start, pre_pr — run across all installed plugins |
 | 4 | 2026-04-21 | Add version pinning with @ref syntax, pinned_ref in registry, smart update for pinned plugins |
 | 3 | 2026-04-21 | Add build hook, auto-detect build systems, plugin update command, improved error messages |
 | 2 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |

--- a/src/init.rs
+++ b/src/init.rs
@@ -21,6 +21,7 @@ pub struct InitOptions {
 }
 
 pub fn run(opts: InitOptions) -> Result<()> {
+    crate::plugin::run_lifecycle_hook("pre_init").ok();
     let config = Config::load().context("loading config")?;
     let extra_paths = config.extra_template_paths();
     let token = config.github_token();

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Instant;
 
 use crate::run::detect_project_type;
 
@@ -326,13 +327,16 @@ fn execute_lane(
 
     let total_steps = lane.steps.len();
     let mut failures: Vec<String> = Vec::new();
+    let lane_start = Instant::now();
 
     for (i, step) in lane.steps.iter().enumerate() {
+        let step_start = Instant::now();
         let result = match step {
             Step::TaskRef(name) => execute_task_with_deps(name, tasks, project_dir),
             Step::Inline { run: cmd } => execute_inline(cmd, project_dir),
             Step::Parallel { parallel } => execute_parallel(parallel, tasks, project_dir),
         };
+        let elapsed = step_start.elapsed();
 
         if let Err(e) = result {
             let step_desc = match step {
@@ -351,41 +355,68 @@ fn execute_lane(
             };
             if lane.fail_fast {
                 bail!(
-                    "Lane '{}' failed at step {} ({}): {}",
+                    "Lane '{}' failed at step {} ({}) after {}: {}",
                     lane_name,
                     i + 1,
                     step_desc,
+                    format_duration(elapsed),
                     e
                 );
             }
             eprintln!(
-                "  {} Step {} ({}) failed: {}",
+                "  {} Step {} ({}) failed after {}: {}",
                 style("❌").red().bold(),
                 i + 1,
                 step_desc,
+                format_duration(elapsed),
                 e
             );
             failures.push(step_desc);
+        } else {
+            println!(
+                "  {} Step {} done {}",
+                style("✔").green(),
+                i + 1,
+                style(format!("({})", format_duration(elapsed))).dim()
+            );
         }
     }
 
+    let total_elapsed = lane_start.elapsed();
+
     if failures.is_empty() {
         println!(
-            "{} Lane {} completed ({} steps)",
+            "{} Lane {} completed ({} steps in {})",
             style("✅").green().bold(),
             style(lane_name).green(),
-            total_steps
+            total_steps,
+            format_duration(total_elapsed)
         );
     } else {
         bail!(
-            "Lane '{}' completed with {} failure(s): {}",
+            "Lane '{}' completed with {} failure(s) in {}: {}",
             lane_name,
             failures.len(),
+            format_duration(total_elapsed),
             failures.join(", ")
         );
     }
 
     Ok(())
+}
+
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    let millis = d.subsec_millis();
+    if secs >= 60 {
+        let mins = secs / 60;
+        let remaining = secs % 60;
+        format!("{mins}m {remaining}.{millis:03}s")
+    } else if secs > 0 {
+        format!("{secs}.{millis:03}s")
+    } else {
+        format!("{millis}ms")
+    }
 }
 
 fn execute_task_with_deps(
@@ -1631,5 +1662,29 @@ steps = ["build"]
         let cleaned: String = encoded.chars().filter(|c| !c.is_whitespace()).collect();
         let decoded = base64_decode(&cleaned).unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), "Hello");
+    }
+
+    #[test]
+    fn format_duration_millis() {
+        let d = std::time::Duration::from_millis(42);
+        assert_eq!(format_duration(d), "42ms");
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        let d = std::time::Duration::from_millis(3456);
+        assert_eq!(format_duration(d), "3.456s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        let d = std::time::Duration::from_secs(125) + std::time::Duration::from_millis(100);
+        assert_eq!(format_duration(d), "2m 5.100s");
+    }
+
+    #[test]
+    fn format_duration_zero() {
+        let d = std::time::Duration::from_millis(0);
+        assert_eq!(format_duration(d), "0ms");
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -37,6 +37,9 @@ struct PluginHooks {
     build: Option<String>,
     post_install: Option<String>,
     post_remove: Option<String>,
+    pre_init: Option<String>,
+    post_work_start: Option<String>,
+    pre_pr: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -96,6 +99,41 @@ pub fn resolve_plugin_command(name: &str) -> Option<PathBuf> {
 pub fn list_installed() -> Result<Vec<PluginEntry>> {
     let registry = load_registry()?;
     Ok(registry.plugins)
+}
+
+pub fn run_lifecycle_hook(event: &str) -> Result<()> {
+    let registry = load_registry()?;
+    for entry in &registry.plugins {
+        let plugin_dir = plugins_dir().join(&entry.name);
+        let manifest_path = plugin_dir.join("plugin.toml");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let content = match fs::read_to_string(&manifest_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let manifest: PluginManifest = match toml::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let hook = match event {
+            "pre_init" => &manifest.hooks.pre_init,
+            "post_work_start" => &manifest.hooks.post_work_start,
+            "pre_pr" => &manifest.hooks.pre_pr,
+            _ => &None,
+        };
+        if let Some(hook_cmd) = hook {
+            println!(
+                "  {} {} ({})",
+                style("▶️").cyan().bold(),
+                style(format!("Plugin hook: {event}")).dim(),
+                style(&entry.name).cyan()
+            );
+            run_hook(&plugin_dir, hook_cmd, &format!("{}/{event}", entry.name))?;
+        }
+    }
+    Ok(())
 }
 
 fn plugins_dir() -> PathBuf {
@@ -1262,5 +1300,45 @@ post_install = "scripts/setup.sh"
             manifest.hooks.post_install.as_deref(),
             Some("scripts/setup.sh")
         );
+    }
+
+    #[test]
+    fn parse_manifest_with_lifecycle_hooks() {
+        let manifest_str = r#"
+[plugin]
+name = "fledge-lint"
+version = "0.1.0"
+
+[hooks]
+pre_init = "scripts/pre-init.sh"
+post_work_start = "scripts/setup-hooks.sh"
+pre_pr = "scripts/lint-all.sh"
+"#;
+        let manifest: PluginManifest = toml::from_str(manifest_str).unwrap();
+        assert_eq!(
+            manifest.hooks.pre_init.as_deref(),
+            Some("scripts/pre-init.sh")
+        );
+        assert_eq!(
+            manifest.hooks.post_work_start.as_deref(),
+            Some("scripts/setup-hooks.sh")
+        );
+        assert_eq!(
+            manifest.hooks.pre_pr.as_deref(),
+            Some("scripts/lint-all.sh")
+        );
+    }
+
+    #[test]
+    fn parse_manifest_lifecycle_hooks_default_none() {
+        let manifest_str = r#"
+[plugin]
+name = "fledge-simple"
+version = "0.1.0"
+"#;
+        let manifest: PluginManifest = toml::from_str(manifest_str).unwrap();
+        assert!(manifest.hooks.pre_init.is_none());
+        assert!(manifest.hooks.post_work_start.is_none());
+        assert!(manifest.hooks.pre_pr.is_none());
     }
 }

--- a/src/work.rs
+++ b/src/work.rs
@@ -246,6 +246,8 @@ fn start(
         style(&branch_name).cyan()
     );
 
+    crate::plugin::run_lifecycle_hook("post_work_start").ok();
+
     Ok(())
 }
 
@@ -273,6 +275,8 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
             base.unwrap_or(&default)
         );
     }
+
+    crate::plugin::run_lifecycle_hook("pre_pr")?;
 
     let sp = crate::spinner::Spinner::start(&format!("Pushing {} to origin:", &branch));
     let push_output = Command::new("git")


### PR DESCRIPTION
## Summary

Two core additions for 1.0 MVP:

- **Step timing in lane runner**: Each step prints its elapsed time on completion (`✔ Step 1 done (245ms)`), and the lane summary includes total elapsed time (`✅ Lane ci completed (3 steps in 4.733s)`). Helps identify slow pipeline steps without external tooling.

- **Plugin lifecycle hooks**: Three new hooks — `pre_init`, `post_work_start`, `pre_pr` — that fire across all installed plugins at key workflow points. Enables plugins to do things like auto-lint before PR creation, set up git hooks on branch start, or validate prerequisites before init.

## Changes

- `src/lanes.rs` — `Instant::now()` timing around each step + total lane time, `format_duration()` helper, 4 new unit tests
- `src/plugin.rs` — 3 new hook fields in `PluginHooks`, `run_lifecycle_hook()` public function, 2 new tests
- `src/init.rs` — calls `pre_init` hook
- `src/work.rs` — calls `post_work_start` after branch creation, `pre_pr` before push
- Specs and docs updated for both features

## Test plan

- [x] 432 unit tests passing (4 new: format_duration + lifecycle hook parsing)
- [x] 144 integration tests passing
- [x] Zero clippy warnings
- [x] 28/28 specs valid
- [ ] Manual test: run `fledge lane ci` and verify timing output
- [ ] Manual test: install a plugin with lifecycle hooks and verify they fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)