### PR TITLE
fix: resolve CI spec-check strict warnings

### DIFF
--- a/specs/main/context.md
+++ b/specs/main/context.md
@@ -1,0 +1,1 @@
+Binary entry point — thin dispatcher that parses CLI args and routes to module handlers.

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,0 +1,93 @@
+---
+module: main
+version: 1
+status: active
+files:
+  - src/main.rs
+
+db_tables: []
+depends_on:
+  - ask
+  - changelog
+  - checks
+  - config
+  - create_template
+  - deps
+  - doctor
+  - github
+  - init
+  - issues
+  - lanes
+  - metrics
+  - plugin
+  - prompts
+  - prs
+  - publish
+  - release
+  - remote
+  - review
+  - run
+  - search
+  - spec
+  - spinner
+  - templates
+  - tui
+  - update
+  - validate
+  - versioning
+  - work
+---
+
+# Main
+
+## Purpose
+
+CLI entry point. Defines the top-level `Cli` struct and `Commands` enum using clap derive, parses arguments, and dispatches to the appropriate module. Also handles shell completions generation and plugin command pass-through via clap's `External` variant.
+
+## Public API
+
+### Exported Functions
+
+No public exports — `main.rs` is the binary entry point.
+
+## Behavioral Examples
+
+```
+$ fledge --version
+fledge 0.8.0
+
+$ fledge --help
+Dev-lifecycle CLI — get your projects ready to fly.
+[lists all subcommands]
+
+$ fledge completions bash --install
+✅ Completions installed for bash
+
+$ fledge unknown-command arg1
+▶️ Running plugin: unknown-command
+[delegates to plugin if installed, else error]
+```
+
+## Error Cases
+
+| Error | When | Behavior |
+|-------|------|----------|
+| Unknown command | No matching subcommand or plugin | clap error with suggestions |
+| Plugin not found | External command with no matching plugin | Error with `fledge plugin search` hint |
+
+## Dependencies
+
+All modules are dependencies — main dispatches to every subcommand module. See `depends_on` in frontmatter.
+
+## Invariants
+
+1. All subcommands are defined in the `Commands` enum
+2. Unknown commands are forwarded to `plugin::resolve_plugin_command` for plugin pass-through
+3. Shell completions support bash, zsh, fish, and PowerShell via `--install` flag
+4. The `--version` and `--help` flags are handled by clap
+
+## Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1 | 2026-04-21 | Initial spec |

--- a/specs/main/requirements.md
+++ b/specs/main/requirements.md
@@ -1,0 +1,4 @@
+- Parse CLI arguments via clap derive
+- Dispatch each subcommand to its module's entry function
+- Forward unknown commands to installed plugins
+- Generate shell completions on demand

--- a/specs/main/tasks.md
+++ b/specs/main/tasks.md
@@ -1,0 +1,4 @@
+- [x] Define Cli struct and Commands enum
+- [x] Route all subcommands to module handlers
+- [x] Plugin pass-through via External variant
+- [x] Shell completion generation with --install

--- a/specs/main/testing.md
+++ b/specs/main/testing.md
@@ -1,0 +1,1 @@
+Main is tested indirectly through integration tests (`tests/`) which exercise CLI commands end-to-end.

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -28,6 +28,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `PluginEntry` | Installed plugin metadata: name, source, version, install date, commands |
 | `PluginAction` | Enum of plugin operations: Install, Remove, List, Search, Run |
 | `resolve_plugin_command` | Check if a command name matches an installed plugin |
+| `run_lifecycle_hook` | Run a named lifecycle hook across all installed plugins |
 
 ### Structs & Enums
 


### PR DESCRIPTION
## Summary
- Add `run_lifecycle_hook` to plugin spec Exported Functions table (was in Functions table but missing from summary)
- Create `specs/main/` spec for `main.rs` to reach 30/30 (100%) file coverage

Fixes the `spec check --strict` CI failure introduced by #152.

## Test plan
- [x] `cargo run -- spec check --strict` passes locally (30 specs, 0 errors, 0 warnings)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 611 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)