### PR TITLE
fix(security): path traversal, quote corruption, lock failure pre-1.0 (closes #153)

### DIFF
--- a/specs/main/context.md
+++ b/specs/main/context.md
@@ -1,0 +1,1 @@
+Binary entry point — thin dispatcher that parses CLI args and routes to module handlers.

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,0 +1,93 @@
+---
+module: main
+version: 1
+status: active
+files:
+  - src/main.rs
+
+db_tables: []
+depends_on:
+  - ask
+  - changelog
+  - checks
+  - config
+  - create_template
+  - deps
+  - doctor
+  - github
+  - init
+  - issues
+  - lanes
+  - metrics
+  - plugin
+  - prompts
+  - prs
+  - publish
+  - release
+  - remote
+  - review
+  - run
+  - search
+  - spec
+  - spinner
+  - templates
+  - tui
+  - update
+  - validate
+  - versioning
+  - work
+---
+
+# Main
+
+## Purpose
+
+CLI entry point. Defines the top-level `Cli` struct and `Commands` enum using clap derive, parses arguments, and dispatches to the appropriate module. Also handles shell completions generation and plugin command pass-through via clap's `External` variant.
+
+## Public API
+
+### Exported Functions
+
+No public exports — `main.rs` is the binary entry point.
+
+## Behavioral Examples
+
+```
+$ fledge --version
+fledge 0.8.0
+
+$ fledge --help
+Dev-lifecycle CLI — get your projects ready to fly.
+[lists all subcommands]
+
+$ fledge completions bash --install
+✅ Completions installed for bash
+
+$ fledge unknown-command arg1
+▶️ Running plugin: unknown-command
+[delegates to plugin if installed, else error]
+```
+
+## Error Cases
+
+| Error | When | Behavior |
+|-------|------|----------|
+| Unknown command | No matching subcommand or plugin | clap error with suggestions |
+| Plugin not found | External command with no matching plugin | Error with `fledge plugin search` hint |
+
+## Dependencies
+
+All modules are dependencies — main dispatches to every subcommand module. See `depends_on` in frontmatter.
+
+## Invariants
+
+1. All subcommands are defined in the `Commands` enum
+2. Unknown commands are forwarded to `plugin::resolve_plugin_command` for plugin pass-through
+3. Shell completions support bash, zsh, fish, and PowerShell via `--install` flag
+4. The `--version` and `--help` flags are handled by clap
+
+## Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1 | 2026-04-21 | Initial spec |

--- a/specs/main/requirements.md
+++ b/specs/main/requirements.md
@@ -1,0 +1,4 @@
+- Parse CLI arguments via clap derive
+- Dispatch each subcommand to its module's entry function
+- Forward unknown commands to installed plugins
+- Generate shell completions on demand

--- a/specs/main/tasks.md
+++ b/specs/main/tasks.md
@@ -1,0 +1,4 @@
+- [x] Define Cli struct and Commands enum
+- [x] Route all subcommands to module handlers
+- [x] Plugin pass-through via External variant
+- [x] Shell completion generation with --install

--- a/specs/main/testing.md
+++ b/specs/main/testing.md
@@ -1,0 +1,1 @@
+Main is tested indirectly through integration tests (`tests/`) which exercise CLI commands end-to-end.

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -28,6 +28,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `PluginEntry` | Installed plugin metadata: name, source, version, install date, commands |
 | `PluginAction` | Enum of plugin operations: Install, Remove, List, Search, Run |
 | `resolve_plugin_command` | Check if a command name matches an installed plugin |
+| `run_lifecycle_hook` | Run a named lifecycle hook across all installed plugins |
 
 ### Structs & Enums
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -920,6 +920,15 @@ fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
 
     let hook_path = plugin_dir.join(hook);
     let status = if hook_path.exists() {
+        let canonical_hook = hook_path
+            .canonicalize()
+            .with_context(|| format!("canonicalizing hook path '{}'", hook))?;
+        let canonical_plugin_dir = plugin_dir
+            .canonicalize()
+            .unwrap_or_else(|_| plugin_dir.to_path_buf());
+        if !canonical_hook.starts_with(&canonical_plugin_dir) {
+            bail!("Hook path '{}' escapes plugin directory", hook);
+        }
         make_executable(&hook_path)?;
         Command::new(&hook_path)
             .current_dir(plugin_dir)

--- a/src/release.rs
+++ b/src/release.rs
@@ -321,11 +321,16 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
             if dir.join("Cargo.lock").exists() {
                 let lock = std::fs::read_to_string(dir.join("Cargo.lock"))?;
                 if lock.contains(&format!("version = \"{}\"", old)) {
-                    let _ = Command::new("cargo")
+                    let status = Command::new("cargo")
                         .args(["generate-lockfile"])
                         .current_dir(dir)
-                        .output();
-                    bumped.push("Cargo.lock".to_string());
+                        .status()
+                        .with_context(|| "running cargo generate-lockfile")?;
+                    if status.success() {
+                        bumped.push("Cargo.lock".to_string());
+                    } else {
+                        eprintln!("Warning: cargo generate-lockfile failed, Cargo.lock not staged");
+                    }
                 }
             }
         }
@@ -359,20 +364,27 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
     }
 
     if let Ok(content) = std::fs::read_to_string(dir.join("pom.xml")) {
-        let re = Regex::new(r"(<version>)[^<]+(</version>)").unwrap();
-        let updated = re.replace(&content, format!("${{1}}{new_str}${{2}}"));
-        if updated != content {
-            std::fs::write(dir.join("pom.xml"), updated.as_bytes())?;
-            bumped.push("pom.xml".to_string());
+        let re = Regex::new(r"(<version>)([^<]+)(</version>)").unwrap();
+        let old_version_str = old.to_string();
+        if let Some(caps) = re.captures(&content) {
+            if caps
+                .get(2)
+                .map(|m| m.as_str().trim() == old_version_str.as_str())
+                .unwrap_or(false)
+            {
+                let updated = re.replace(&content, format!("${{1}}{new_str}${{3}}"));
+                std::fs::write(dir.join("pom.xml"), updated.as_bytes())?;
+                bumped.push("pom.xml".to_string());
+            }
         }
     }
 
     for name in &["build.gradle", "build.gradle.kts"] {
         let path = dir.join(name);
         if let Ok(content) = std::fs::read_to_string(&path) {
-            let re = Regex::new(r#"(version\s*=\s*["'])[^"']+["']"#).unwrap();
+            let re = Regex::new(r#"(version\s*=\s*)(["'])[^"']+["']"#).unwrap();
             if re.is_match(&content) {
-                let updated = re.replace(&content, format!("${{1}}{new_str}\""));
+                let updated = re.replace(&content, format!("${{1}}${{2}}{new_str}${{2}}"));
                 std::fs::write(&path, updated.as_bytes())?;
                 bumped.push(name.to_string());
             }
@@ -392,6 +404,15 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
                         if !bumped.iter().any(|b| b == file_name) {
                             let path = dir.join(file_name);
                             if path.exists() {
+                                let canonical_path = path
+                                    .canonicalize()
+                                    .with_context(|| format!("canonicalizing '{}'", file_name))?;
+                                let canonical_dir = dir
+                                    .canonicalize()
+                                    .with_context(|| "canonicalizing project dir")?;
+                                if !canonical_path.starts_with(&canonical_dir) {
+                                    bail!("Release file '{}' escapes project directory", file_name);
+                                }
                                 if let Ok(content) = std::fs::read_to_string(&path) {
                                     let re = Regex::new(
                                         r#"(?m)(version\s*[=:]\s*["']?)(\d+\.\d+\.\d+)"#,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -167,6 +167,15 @@ pub fn resolve_template_dir(
             if !template_dir.exists() {
                 bail!("Subpath '{}' not found in {}/{}", sub, owner, repo);
             }
+            let canonical_template = template_dir
+                .canonicalize()
+                .with_context(|| format!("resolving subpath '{}'", sub))?;
+            let canonical_repo = repo_dir
+                .canonicalize()
+                .with_context(|| format!("resolving repo dir '{}'", repo_dir.display()))?;
+            if !canonical_template.starts_with(&canonical_repo) {
+                bail!("Subpath '{}' escapes repository directory", sub);
+            }
             Ok(template_dir)
         }
         None => Ok(repo_dir),


### PR DESCRIPTION
## Summary

Security fixes from Rook's review of issue #153. All blockers and FIX-tier items addressed in one PR.

**Blockers (remote.rs, release.rs):**
- `resolve_template_dir`: canonicalize joined subpath and assert `starts_with(repo_dir)` to block path traversal via `..`
- Gradle version replacement: capture opening quote character and reuse as closing quote; fixes `version = '0.1.0'` → `version = '1.0.0"` corruption

**Fix tier (plugin.rs, release.rs):**
- `run_hook`: canonicalize hook path and assert `starts_with(plugin_dir)` before execution (mirrors `link_commands` pattern)
- Custom version files (`[release] files`): canonicalize each joined path and assert `starts_with(dir)` before read/write
- `pom.xml` version replace: verify first matched `<version>` contains the detected current version before replacing (avoids parent POM clobber)
- `cargo generate-lockfile`: check exit status and emit a warning + skip staging on failure instead of silently swallowing it

## Test plan
- [x] `cargo test` — 144/144 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo run -- spec check` — 30 specs, 0 errors, 0 warnings
- [x] pre-commit hooks (fmt + clippy) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)