### PR TITLE
fix: 1.0 readiness audit — panics, error handling, validation, code quality

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -326,17 +326,27 @@ fn run_post_create_hooks(
             bail!("Empty post-create hook command");
         }
 
-        let status = std::process::Command::new(parts[0])
+        let output = std::process::Command::new(parts[0])
             .args(&parts[1..])
             .current_dir(project_dir)
-            .status()
+            .output()
             .with_context(|| format!("running hook: {}", cmd))?;
 
-        if !status.success() {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let mut detail = String::new();
+            if !stdout.trim().is_empty() {
+                detail.push_str(&format!("\n  stdout: {}", stdout.trim()));
+            }
+            if !stderr.trim().is_empty() {
+                detail.push_str(&format!("\n  stderr: {}", stderr.trim()));
+            }
             bail!(
-                "Post-create hook failed (exit {}): {}",
-                status.code().unwrap_or(-1),
-                cmd
+                "Post-create hook failed (exit {}): {}{}",
+                output.status.code().unwrap_or(-1),
+                cmd,
+                detail
             );
         }
     }
@@ -489,16 +499,17 @@ pub fn init_git_for_tui(dir: &Path) -> Result<()> {
 }
 
 fn init_git(dir: &Path) -> Result<()> {
-    let status = std::process::Command::new("git")
+    let output = std::process::Command::new("git")
         .args(["init"])
         .current_dir(dir)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .stderr(std::process::Stdio::piped())
+        .output()
         .context("running git init")?;
 
-    if !status.success() {
-        bail!("git init failed");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git init failed: {}", stderr.trim());
     }
 
     // Ensure git has a user configured (needed in CI / fresh environments)

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod templates;
 #[cfg(feature = "tui")]
 mod tui;
 mod update;
+mod utils;
 mod validate;
 mod versioning;
 mod work;
@@ -1073,8 +1074,7 @@ fn list_templates() -> Result<()> {
     )?;
 
     if available.is_empty() {
-        println!("No templates found.");
-        return Ok(());
+        anyhow::bail!("No templates found. Add templates to the templates/ directory or configure template_repos in ~/.config/fledge/config.toml.");
     }
 
     println!("{}", style("Available templates:").bold());

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -31,10 +31,23 @@ pub fn prompt_variables(
 
     // Core variables
     ctx.insert("project_name", project_name);
-    ctx.insert("project_name_snake", &to_snake_case(project_name));
-    ctx.insert("project_name_kebab", &to_kebab_case(project_name));
-    ctx.insert("project_name_pascal", &to_pascal_case(project_name));
-    ctx.insert("project_name_camel", &to_camel_case(project_name));
+    crate::utils::validate_project_name(project_name)?;
+    ctx.insert(
+        "project_name_snake",
+        &crate::utils::to_snake_case(project_name),
+    );
+    ctx.insert(
+        "project_name_kebab",
+        &crate::utils::to_kebab_case(project_name),
+    );
+    ctx.insert(
+        "project_name_pascal",
+        &crate::utils::to_pascal_case(project_name),
+    );
+    ctx.insert(
+        "project_name_camel",
+        &crate::utils::to_camel_case(project_name),
+    );
 
     // Date variables
     let now = chrono::Local::now();
@@ -72,6 +85,7 @@ pub fn prompt_variables(
             }
         }
     };
+    crate::utils::validate_github_org(&github_org)?;
     ctx.insert("github_org", &github_org);
 
     // License
@@ -113,62 +127,10 @@ fn render_default(template: &str, ctx: &tera::Context) -> Result<String> {
     Ok(tera.render("__default__", ctx)?)
 }
 
-fn to_kebab_case(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c == '_' {
-                '-'
-            } else {
-                c.to_ascii_lowercase()
-            }
-        })
-        .collect()
-}
-
-fn to_camel_case(s: &str) -> String {
-    let pascal = to_pascal_case(s);
-    let mut chars = pascal.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first) => {
-            let mut s = first.to_lowercase().to_string();
-            s.extend(chars);
-            s
-        }
-    }
-}
-
-fn to_snake_case(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c == '-' {
-                '_'
-            } else {
-                c.to_ascii_lowercase()
-            }
-        })
-        .collect()
-}
-
-fn to_pascal_case(s: &str) -> String {
-    s.split(['-', '_'])
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => {
-                    let mut s = first.to_uppercase().to_string();
-                    s.extend(chars);
-                    s
-                }
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::*;
 
     #[test]
     fn test_to_snake_case() {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -97,21 +97,29 @@ fn clone_repo(
             .env("GIT_CONFIG_VALUE_0", &header_value);
     }
 
-    let status = cmd.status().context("running git clone")?;
+    let output = cmd.output().context("running git clone")?;
 
-    if !status.success() {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = if stderr.trim().is_empty() {
+            String::new()
+        } else {
+            format!("\n  git: {}", stderr.trim())
+        };
         if let Some(r) = git_ref {
             bail!(
-                "Failed to clone {}/{}@{}. Check the ref exists.",
+                "Failed to clone {}/{}@{}. Check the ref exists.{}",
                 owner,
                 repo,
-                r
+                r,
+                detail
             );
         }
         bail!(
-            "Failed to clone {}/{}. Check the repo exists and you have access.",
+            "Failed to clone {}/{}. Check the repo exists and you have access.{}",
             owner,
-            repo
+            repo,
+            detail
         );
     }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -32,7 +32,6 @@ pub struct TemplateInfo {
     #[serde(default)]
     pub min_fledge_version: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub version: Option<String>,
     #[serde(default)]
     pub requires: Vec<String>,
@@ -79,7 +78,7 @@ pub struct FileRules {
     #[serde(default)]
     pub render: Vec<String>,
     #[serde(default)]
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "tui"), allow(dead_code))]
     pub copy: Vec<String>,
     #[serde(default)]
     pub ignore: Vec<String>,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1012,10 +1012,14 @@ fn handle_input(app: &mut DashboardApp, key: KeyCode) {
             };
         }
         KeyCode::Char(c) => {
-            app.input_fields[app.active_field].value.push(c);
+            if let Some(field) = app.input_fields.get_mut(app.active_field) {
+                field.value.push(c);
+            }
         }
         KeyCode::Backspace => {
-            app.input_fields[app.active_field].value.pop();
+            if let Some(field) = app.input_fields.get_mut(app.active_field) {
+                field.value.pop();
+            }
         }
         KeyCode::Enter => {
             app.submit_input();
@@ -1471,8 +1475,8 @@ impl TemplateBrowserApp {
             match field.key.as_str() {
                 "__project_name__" => {
                     ctx.insert("project_name", &val);
-                    ctx.insert("project_name_snake", &to_snake_case(&val));
-                    ctx.insert("project_name_pascal", &to_pascal_case(&val));
+                    ctx.insert("project_name_snake", &crate::utils::to_snake_case(&val));
+                    ctx.insert("project_name_pascal", &crate::utils::to_pascal_case(&val));
                 }
                 "__author__" => ctx.insert("author", &val),
                 "__github_org__" => ctx.insert("github_org", &val),
@@ -1489,7 +1493,9 @@ impl TemplateBrowserApp {
     }
 
     fn scaffold(&mut self) -> Result<()> {
-        let tpl_idx = self.selected_template.unwrap();
+        let tpl_idx = self
+            .selected_template
+            .ok_or_else(|| anyhow::anyhow!("no template selected"))?;
         let template = &self.templates[tpl_idx];
 
         let project_name = self.project_name.clone();
@@ -1512,34 +1518,6 @@ impl TemplateBrowserApp {
 
         Ok(())
     }
-}
-
-fn to_snake_case(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c == '-' {
-                '_'
-            } else {
-                c.to_ascii_lowercase()
-            }
-        })
-        .collect()
-}
-
-fn to_pascal_case(s: &str) -> String {
-    s.split(['-', '_'])
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => {
-                    let mut s = first.to_uppercase().to_string();
-                    s.extend(chars);
-                    s
-                }
-            }
-        })
-        .collect()
 }
 
 fn run_template_browser(output_dir: PathBuf, no_git: bool) -> Result<()> {
@@ -1704,10 +1682,14 @@ fn handle_input_variables(app: &mut TemplateBrowserApp, key: KeyCode) {
             };
         }
         KeyCode::Char(c) => {
-            app.variables[app.active_field].value.push(c);
+            if let Some(field) = app.variables.get_mut(app.active_field) {
+                field.value.push(c);
+            }
         }
         KeyCode::Backspace => {
-            app.variables[app.active_field].value.pop();
+            if let Some(field) = app.variables.get_mut(app.active_field) {
+                field.value.pop();
+            }
         }
         KeyCode::Enter => {
             let project_name = app.effective_value(&app.variables[0]);
@@ -1831,7 +1813,9 @@ fn draw_template_list(f: &mut Frame, app: &mut TemplateBrowserApp, area: Rect) {
 }
 
 fn draw_variable_form(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
-    let tpl_idx = app.selected_template.unwrap();
+    let Some(tpl_idx) = app.selected_template else {
+        return;
+    };
     let tpl_name = &app.templates[tpl_idx].name;
 
     let block = Block::default()
@@ -1897,7 +1881,9 @@ fn draw_variable_form(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
 }
 
 fn draw_tb_confirm(f: &mut Frame, app: &TemplateBrowserApp, area: Rect) {
-    let tpl_idx = app.selected_template.unwrap();
+    let Some(tpl_idx) = app.selected_template else {
+        return;
+    };
     let tpl = &app.templates[tpl_idx];
 
     let mut lines = vec![

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,209 @@
+pub fn to_kebab_case(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c == '_' {
+                '-'
+            } else {
+                c.to_ascii_lowercase()
+            }
+        })
+        .collect()
+}
+
+pub fn to_camel_case(s: &str) -> String {
+    let pascal = to_pascal_case(s);
+    let mut chars = pascal.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let mut s = first.to_lowercase().to_string();
+            s.extend(chars);
+            s
+        }
+    }
+}
+
+pub fn to_snake_case(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c == '-' {
+                '_'
+            } else {
+                c.to_ascii_lowercase()
+            }
+        })
+        .collect()
+}
+
+pub fn to_pascal_case(s: &str) -> String {
+    s.split(['-', '_'])
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    let mut s = first.to_uppercase().to_string();
+                    s.extend(chars);
+                    s
+                }
+            }
+        })
+        .collect()
+}
+
+pub fn validate_project_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Project name cannot be empty");
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        anyhow::bail!("Project name cannot contain path separators or '..'");
+    }
+    if name.contains('\0') {
+        anyhow::bail!("Project name cannot contain null bytes");
+    }
+    let reserved = [
+        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+    ];
+    if reserved.contains(&name.to_ascii_lowercase().as_str()) {
+        anyhow::bail!("'{}' is a reserved name on Windows", name);
+    }
+    Ok(())
+}
+
+pub fn validate_github_org(org: &str) -> anyhow::Result<()> {
+    if org.is_empty() {
+        anyhow::bail!("GitHub organization cannot be empty");
+    }
+    if org.contains('/') || org.contains('\\') {
+        anyhow::bail!("GitHub organization cannot contain slashes");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_snake_case() {
+        assert_eq!(to_snake_case("my-project"), "my_project");
+        assert_eq!(to_snake_case("MyProject"), "myproject");
+        assert_eq!(to_snake_case("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn test_to_snake_case_multiple_hyphens() {
+        assert_eq!(to_snake_case("my-cool-project"), "my_cool_project");
+    }
+
+    #[test]
+    fn test_to_snake_case_empty() {
+        assert_eq!(to_snake_case(""), "");
+    }
+
+    #[test]
+    fn test_to_snake_case_single_char() {
+        assert_eq!(to_snake_case("A"), "a");
+    }
+
+    #[test]
+    fn test_to_pascal_case() {
+        assert_eq!(to_pascal_case("my-project"), "MyProject");
+        assert_eq!(to_pascal_case("my_project"), "MyProject");
+        assert_eq!(to_pascal_case("single"), "Single");
+    }
+
+    #[test]
+    fn test_to_pascal_case_multiple_segments() {
+        assert_eq!(to_pascal_case("my-cool-project"), "MyCoolProject");
+    }
+
+    #[test]
+    fn test_to_pascal_case_mixed_separators() {
+        assert_eq!(to_pascal_case("my-cool_project"), "MyCoolProject");
+    }
+
+    #[test]
+    fn test_to_pascal_case_empty() {
+        assert_eq!(to_pascal_case(""), "");
+    }
+
+    #[test]
+    fn test_to_pascal_case_single_char() {
+        assert_eq!(to_pascal_case("a"), "A");
+    }
+
+    #[test]
+    fn test_to_kebab_case() {
+        assert_eq!(to_kebab_case("my_project"), "my-project");
+        assert_eq!(to_kebab_case("my-project"), "my-project");
+        assert_eq!(to_kebab_case("MyProject"), "myproject");
+    }
+
+    #[test]
+    fn test_to_kebab_case_empty() {
+        assert_eq!(to_kebab_case(""), "");
+    }
+
+    #[test]
+    fn test_to_camel_case() {
+        assert_eq!(to_camel_case("my-project"), "myProject");
+        assert_eq!(to_camel_case("my_project"), "myProject");
+        assert_eq!(to_camel_case("single"), "single");
+    }
+
+    #[test]
+    fn test_to_camel_case_multiple_segments() {
+        assert_eq!(to_camel_case("my-cool-project"), "myCoolProject");
+    }
+
+    #[test]
+    fn test_to_camel_case_empty() {
+        assert_eq!(to_camel_case(""), "");
+    }
+
+    #[test]
+    fn test_validate_project_name_valid() {
+        assert!(validate_project_name("my-project").is_ok());
+        assert!(validate_project_name("cool_app").is_ok());
+    }
+
+    #[test]
+    fn test_validate_project_name_empty() {
+        assert!(validate_project_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_project_name_path_traversal() {
+        assert!(validate_project_name("../escape").is_err());
+        assert!(validate_project_name("my/project").is_err());
+    }
+
+    #[test]
+    fn test_validate_project_name_reserved() {
+        assert!(validate_project_name("con").is_err());
+        assert!(validate_project_name("NUL").is_err());
+    }
+
+    #[test]
+    fn test_validate_github_org_valid() {
+        assert!(validate_github_org("CorvidLabs").is_ok());
+        assert!(validate_github_org("my-org").is_ok());
+    }
+
+    #[test]
+    fn test_validate_github_org_empty() {
+        assert!(validate_github_org("").is_err());
+    }
+
+    #[test]
+    fn test_validate_github_org_spaces_allowed() {
+        assert!(validate_github_org("my org").is_ok());
+    }
+
+    #[test]
+    fn test_validate_github_org_slashes() {
+        assert!(validate_github_org("my/org").is_err());
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,15 +4,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn cargo_bin() -> String {
-    let output = Command::new("cargo")
-        .args(["build", "--quiet"])
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .status()
-        .expect("cargo build failed");
-    assert!(output.success());
-
-    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/debug/fledge");
-    target_dir.to_string_lossy().to_string()
+    env!("CARGO_BIN_EXE_fledge").to_string()
 }
 
 fn run_fledge(args: &[&str]) -> std::process::Output {


### PR DESCRIPTION
## Summary

Addresses all blocking and high-priority items from issue #154 (1.0 Readiness Audit).

**Critical fixes:**
- 3 TUI `unwrap()` panics on `selected_template` → safe `Option` handling
- 2 TUI field buffer unchecked index accesses → bounds-checked with `get_mut`

**Error handling:**
- Git clone stderr now captured and shown to users (auth failures, 404s, etc.)
- Git init stderr captured instead of generic "git init failed"
- Post-create hook stdout/stderr captured and displayed on failure

**Input validation:**
- Project name: rejects empty, path traversal (`../`), null bytes, Windows reserved names
- GitHub org: rejects empty, slashes

**Code quality:**
- Consolidated duplicated case conversion (prompts.rs + tui.rs) into shared `src/utils.rs`
- Removed misleading `#[allow(dead_code)]` annotations in templates.rs
- Consistent empty-template error (bail with actionable message vs silent Ok)
- Integration tests use `env!("CARGO_BIN_EXE_fledge")` instead of manual cargo build

**Verification:** 144 tests pass, 0 clippy warnings, 30/30 specs valid, fmt clean.

Closes #154

## Test plan
- [x] All 144 existing tests pass
- [x] Zero clippy warnings
- [x] 30/30 specs valid
- [x] `cargo fmt --check` clean
- [x] New validation unit tests in `src/utils.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)