### PR TITLE
fix: generate fledge.toml during init

### DIFF
--- a/specs/init/init.spec.md
+++ b/specs/init/init.spec.md
@@ -1,6 +1,6 @@
 ---
 module: init
-version: 5
+version: 6
 status: active
 files:
   - src/init.rs
@@ -8,6 +8,7 @@ files:
 db_tables: []
 depends_on:
   - templates
+  - run
 ---
 
 # Init
@@ -50,6 +51,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 3. Git init creates an initial commit with all scaffolded files
 4. Directory is created before template rendering begins
 5. `.fledge.toml` is written after rendering, before git init, recording template source and file hashes
+6. If the template does not include a `fledge.toml`, one is generated from auto-detected project type defaults
 
 ## Behavioral Examples
 
@@ -117,6 +119,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 | `remote` | `is_remote_ref()`, `parse_remote_ref()`, `resolve_template_dir()` |
 | `prompts` | `select_template()`, `prompt_variables()` |
 | `update` | `write_project_meta()` for `.fledge.toml` generation |
+| `run` | `detect_project_type()`, `task_defaults()` for generating `fledge.toml` |
 | `console` | `style()` for colored output |
 | `anyhow` | Error handling |
 

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -24,6 +24,7 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 | `run` | Entry point — lists or executes tasks |
 | `RunOptions` | Options: `task`, `init`, `list` |
 | `detect_project_type` | Detects project ecosystem from directory contents |
+| `task_defaults` | Returns default task definitions for a given project type |
 
 ### Structs & Enums
 
@@ -37,6 +38,7 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 |----------|-----------|-------------|
 | `run` | `(RunOptions) -> Result<()>` | Main entry — dispatch to init/list/execute |
 | `detect_project_type` | `(&Path) -> &'static str` | Detect project ecosystem (rust, node, go, python, etc.) from marker files |
+| `task_defaults` | `(&str, &Path) -> String` | Return default task TOML entries for a given project type and directory |
 
 ## Invariants
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -100,7 +100,10 @@ pub fn run(opts: InitOptions) -> Result<()> {
 
     // Render template
     println!("{} Scaffolding project...", style("*").cyan().bold());
-    let created_files = templates::render_template(template, &target_dir, &variables)?;
+    let mut created_files = templates::render_template(template, &target_dir, &variables)?;
+
+    // Generate fledge.toml if the template didn't include one
+    generate_fledge_toml_if_missing(&target_dir, &mut created_files)?;
 
     // Write .fledge.toml for future `fledge update`
     update::write_project_meta(
@@ -228,7 +231,10 @@ fn run_remote(
         .with_context(|| format!("creating directory {}", target_dir.display()))?;
 
     println!("{} Scaffolding project...", style("*").cyan().bold());
-    let created_files = templates::render_template(template, &target_dir, &variables)?;
+    let mut created_files = templates::render_template(template, &target_dir, &variables)?;
+
+    // Generate fledge.toml if the template didn't include one
+    generate_fledge_toml_if_missing(&target_dir, &mut created_files)?;
 
     // Write .fledge.toml for future `fledge update`
     update::write_project_meta(
@@ -555,6 +561,32 @@ fn init_git(dir: &Path) -> Result<()> {
         .status()
         .context("running git commit")?;
 
+    Ok(())
+}
+
+fn generate_fledge_toml_if_missing(
+    target_dir: &Path,
+    created_files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let fledge_toml = target_dir.join("fledge.toml");
+    if fledge_toml.exists() {
+        return Ok(());
+    }
+
+    let project_type = crate::run::detect_project_type(target_dir);
+    let defaults = crate::run::task_defaults(project_type, target_dir);
+
+    let content = format!(
+        r#"# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+{defaults}
+"#
+    );
+
+    std::fs::write(&fledge_toml, content).context("writing fledge.toml")?;
+    created_files.push(PathBuf::from("fledge.toml"));
     Ok(())
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -233,7 +233,7 @@ pub fn detect_project_type(dir: &Path) -> &'static str {
     }
 }
 
-fn task_defaults(project_type: &str, dir: &Path) -> String {
+pub fn task_defaults(project_type: &str, dir: &Path) -> String {
     match project_type {
         "rust" => r#"build = "cargo build"
 test = "cargo test"

--- a/templates/go-cli/fledge.toml
+++ b/templates/go-cli/fledge.toml
@@ -1,0 +1,8 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+build = "go build ./..."
+test = "go test ./..."
+lint = "go vet ./..."
+fmt = "gofmt -l ."

--- a/templates/python-cli/fledge.toml
+++ b/templates/python-cli/fledge.toml
@@ -1,0 +1,7 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+test = "pytest"
+lint = "ruff check ."
+fmt = "ruff format --check ."

--- a/templates/rust-cli/fledge.toml
+++ b/templates/rust-cli/fledge.toml
@@ -1,0 +1,8 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+build = "cargo build"
+test = "cargo test"
+lint = "cargo clippy -- -D warnings"
+fmt = "cargo fmt --check"

--- a/templates/static-site/fledge.toml
+++ b/templates/static-site/fledge.toml
@@ -1,0 +1,6 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+# serve = "python3 -m http.server 8080"
+# build = "echo 'add your build command'"

--- a/templates/ts-bun/fledge.toml
+++ b/templates/ts-bun/fledge.toml
@@ -1,0 +1,8 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+dev = "bun run dev"
+test = "bun test"
+lint = "bun run lint"
+build = "bun run build"

--- a/templates/ts-node/fledge.toml
+++ b/templates/ts-node/fledge.toml
@@ -1,0 +1,8 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+dev = "npm run dev"
+test = "npm test"
+lint = "npm run lint"
+build = "npm run build"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1248,13 +1248,7 @@ fn e2e_rust_project_lifecycle() {
     let project = tmp.path().join("e2e-test");
     assert!(project.join("Cargo.toml").exists());
 
-    // Step 2: Generate task runner config
-    let output = run_fledge_in(&project, &["run", "--init"]);
-    assert!(
-        output.status.success(),
-        "run --init failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    // Step 2: Verify fledge.toml was created by init
     assert!(project.join("fledge.toml").exists());
     let fledge_toml = fs::read_to_string(project.join("fledge.toml")).unwrap();
     assert!(fledge_toml.contains("[tasks]"));
@@ -1330,9 +1324,11 @@ fn e2e_tsbun_project_lifecycle() {
     let project = tmp.path().join("e2e-ts");
     assert!(project.join("package.json").exists());
 
-    // Step 2: Generate task runner config
-    let output = run_fledge_in(&project, &["run", "--init"]);
-    assert!(output.status.success());
+    // Step 2: Verify fledge.toml was created by init
+    assert!(project.join("fledge.toml").exists());
+    let fledge_toml = fs::read_to_string(project.join("fledge.toml")).unwrap();
+    assert!(fledge_toml.contains("[tasks]"));
+    assert!(fledge_toml.contains("bun"));
 
     // Step 3: Doctor
     let output = run_fledge_in(&project, &["doctor"]);


### PR DESCRIPTION
## Summary
- All built-in templates now ship with a `fledge.toml` containing language-appropriate tasks (rust-cli, ts-bun, ts-node, python-cli, go-cli, static-site)
- `fledge init` auto-generates a `fledge.toml` as a fallback if the template doesn't include one, using `detect_project_type` from the task runner
- Previously only `.fledge.toml` (hidden metadata for `fledge update`) was created, so `fledge run` failed immediately after init

Fixes the issue where users saw `.fledge.toml` and thought it was the task config with a wrong filename.

## Test plan
- [x] All 491 unit tests pass
- [x] All 144 integration tests pass (e2e tests updated to verify fledge.toml from init)
- [x] Clippy clean, fmt clean
- [ ] Manual: `fledge init myapp --template rust-cli --yes` → verify `fledge.toml` exists with cargo tasks
- [ ] Manual: `fledge run --list` works immediately after init

🤖 Generated with [Claude Code](https://claude.com/claude-code)