### PR TITLE
fix: remove static-site fledge.toml

### DIFF
--- a/templates/static-site/fledge.toml
+++ b/templates/static-site/fledge.toml
@@ -1,6 +1,0 @@
-# fledge.toml — project task definitions
-# Docs: https://github.com/CorvidLabs/fledge#task-runner
-
-[tasks]
-# serve = "python3 -m http.server 8080"
-# build = "echo 'add your build command'"


### PR DESCRIPTION
## Summary
- Removes `templates/static-site/fledge.toml` which only contained commented-out tasks
- Static sites have no universal build tool (Hugo, Jekyll, plain HTML, etc.) so a template-shipped fledge.toml is misleading
- `fledge init` will generate appropriate defaults via `detect_project_type` fallback instead

## Test plan
- [ ] `fledge init test --template static-site --yes` works without shipping a fledge.toml
- [ ] Existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)