### PR TITLE
fix: spec accuracy audit — 20 files corrected

### DIFF
--- a/specs/ask/ask.spec.md
+++ b/specs/ask/ask.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ask
-version: 1
+version: 2
 status: active
 files:
   - src/ask.rs
@@ -22,13 +22,13 @@ Ask questions about your codebase using AI. Sends the question to Claude CLI whi
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point for the ask command |
-| `AskOptions` | Options struct with the question text |
+| `AskOptions` | Options struct with the question text and json flag |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `AskOptions` | `{ question: String }` |
+| `AskOptions` | `{ question: String, json: bool }` |
 
 ### Functions
 
@@ -41,6 +41,7 @@ Ask questions about your codebase using AI. Sends the question to Claude CLI whi
 1. Requires Claude CLI (`claude`) to be installed and authenticated
 2. Question is joined from multiple args (no quotes required)
 3. Claude CLI runs in the current project directory for context
+4. `--json` outputs structured JSON response
 
 ## Behavioral Examples
 
@@ -74,4 +75,5 @@ error: Please provide a question. Usage: fledge ask <question>
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-21 | Add json field to AskOptions |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/checks/checks.spec.md
+++ b/specs/checks/checks.spec.md
@@ -1,6 +1,6 @@
 ---
 module: checks
-version: 2
+version: 3
 status: active
 files:
   - src/checks.rs
@@ -44,7 +44,8 @@ View CI/CD check run status for a branch using the GitHub Check Runs API. Shows 
 2. Uses GitHub token from config if available
 3. Displays check name, status, and duration for each check run
 4. Shows summary counts (passed/failed/pending)
-5. Supports `--json` for raw API output
+5. Cancelled checks display with 🚫 and count as failed; skipped checks display with ⏭️ and count as passed
+6. Supports `--json` for raw API output
 
 ## Behavioral Examples
 
@@ -55,9 +56,11 @@ $ fledge checks
   ✅ lint          passed      12s
   ✅ test-ubuntu   passed      1m 30s
   ❌ test-windows  failed      45s
+  🚫 deploy        cancelled   20s
+  ⏭️  coverage      skipped     —
   🔄 audit         running     running...
 
-  3 checks: 2 passed, 1 failed, 1 pending
+  6 checks: 3 passed, 2 failed, 1 pending
 
 $ fledge checks --branch main --json
 { ... }
@@ -81,5 +84,6 @@ $ fledge checks --branch main --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-21 | Document cancelled (🚫) and skipped (⏭️) check statuses |
 | 2 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/checks/context.md
+++ b/specs/checks/context.md
@@ -2,14 +2,27 @@
 spec: checks.spec.md
 ---
 
-## Context
+## Key Decisions
 
-TODO: Describe the context and motivation for this module.
+- Uses the GitHub Check Runs API (`/repos/{owner}/{repo}/commits/{branch}/check-runs`) rather than the older Statuses API — Check Runs provide richer data including duration and conclusion
+- Defaults to the current branch via `git rev-parse` — no config needed for the common case
+- Cancelled checks count as failed (not pending) because they represent a definitive non-success outcome
+- Skipped checks count as passed because they indicate an intentionally bypassed (not failing) check
+- `--json` outputs raw API response for scripting — no fledge-specific wrapping
 
-## Related Modules
+## Files to Read First
 
-- TODO
+- `src/checks.rs` — all logic lives here: API call, status mapping, formatting
+- `src/github.rs` — `detect_repo()` and `github_api_get()` shared helpers
+- `specs/checks/checks.spec.md` — formal API and invariants
 
-## Design Decisions
+## Current Status
 
-- TODO
+- Fully implemented: branch detection, check fetching, status display with timing
+- Supports all GitHub Check Run conclusions: success, failure, cancelled, skipped, and in-progress
+- JSON output for scripting
+
+## Notes
+
+- Duration is calculated from `started_at` and `completed_at` timestamps — shows "running..." for in-progress checks
+- The `format_duration` helper formats seconds as "12s" or "1m 30s"

--- a/specs/checks/requirements.md
+++ b/specs/checks/requirements.md
@@ -4,16 +4,26 @@ spec: checks.spec.md
 
 ## User Stories
 
-- As a developer, I want to TODO
+- As a developer, I want to see CI check status for my current branch without leaving the terminal
+- As a developer, I want to check CI status for a specific branch with `--branch`
+- As a developer, I want machine-readable output with `--json` for scripting
 
 ## Acceptance Criteria
 
-- TODO
+- `fledge checks` shows check name, status icon, and duration for each check run
+- `fledge checks --branch <name>` queries checks for the specified branch
+- Without `--branch`, defaults to the current git branch
+- Shows a summary line with pass/fail/pending counts
+- `--json` outputs the raw GitHub API response
+- Detached HEAD without `--branch` produces a clear error message
 
 ## Constraints
 
-- TODO
+- Requires a GitHub remote (`origin`) to detect owner/repo
+- GitHub token from config is used if available (unauthenticated requests are rate-limited)
 
 ## Out of Scope
 
-- TODO
+- Watching/polling for check completion
+- Triggering re-runs of failed checks
+- GitHub Actions workflow-level status (only check runs)

--- a/specs/checks/testing.md
+++ b/specs/checks/testing.md
@@ -6,8 +6,11 @@ spec: checks.spec.md
 
 ### Unit Tests
 
-- TODO
+- `format_duration` correctly formats seconds into human-readable strings (e.g., 12 → "12s", 90 → "1m 30s")
+- `current_branch` returns an error with guidance when in detached HEAD state
 
 ### Integration Tests
 
-- TODO
+- `fledge checks` in a git repo with a GitHub remote returns a formatted check list or "No CI checks found"
+- `fledge checks --json` outputs valid JSON
+- `fledge checks --branch nonexistent` handles missing branches gracefully

--- a/specs/create_template/tasks.md
+++ b/specs/create_template/tasks.md
@@ -12,7 +12,5 @@ spec: create_template.spec.md
 - [x] Unit tests (5 tests covering scaffold output, manifest validity, error cases)
 - [x] Spec files (spec, context, requirements, tasks, testing)
 
-## Backlog
-
-- [ ] Add `--yes` flag to skip prompts and accept all defaults
-- [ ] Add `fledge validate` command for template validation (issue TBD)
+- [x] Add `--yes` flag to skip prompts and accept all defaults
+- [x] Add `fledge validate` command for template validation

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -1,6 +1,6 @@
 ---
 module: doctor
-version: 1
+version: 2
 status: active
 files:
   - src/doctor.rs
@@ -51,7 +51,7 @@ Diagnoses project environment health by checking toolchain availability, depende
 7. `--json` outputs a structured `DoctorReport`
 8. Exit summary shows count of passed checks and issues found
 9. Tool version is extracted by running `<tool> --version` and parsing first version-like string
-10. Supported project types: rust, node, go, python, ruby, java-gradle, java-maven, generic
+10. Supported project types: rust, node, go, python, ruby, java-gradle, java-maven, swift, generic
 
 ## Behavioral Examples
 
@@ -100,4 +100,5 @@ $ fledge doctor --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-21 | Add swift to supported project types |
 | 1 | 2026-04-20 | Initial spec |

--- a/specs/init/init.spec.md
+++ b/specs/init/init.spec.md
@@ -1,6 +1,6 @@
 ---
 module: init
-version: 6
+version: 7
 status: active
 files:
   - src/init.rs
@@ -9,6 +9,7 @@ db_tables: []
 depends_on:
   - templates
   - run
+  - plugin
 ---
 
 # Init
@@ -31,7 +32,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 
 | Type | Description |
 |------|-------------|
-| `InitOptions` | Options for project creation: name, template, output, no_git, no_install, refresh, dry_run, yes |
+| `InitOptions` | Options for project creation: name, template, output, author, org, no_git, no_install, refresh, dry_run, yes |
 
 ### Traits
 
@@ -120,6 +121,8 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 | `prompts` | `select_template()`, `prompt_variables()` |
 | `update` | `write_project_meta()` for `.fledge.toml` generation |
 | `run` | `detect_project_type()`, `task_defaults()` for generating `fledge.toml` |
+| `plugin` | `run_lifecycle_hook("pre_init")` |
+| `versioning` | `check_fledge_version()` for template minimum version |
 | `console` | `style()` for colored output |
 | `anyhow` | Error handling |
 
@@ -136,4 +139,5 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 | 2026-04-18 | CorvidAgent | Initial spec |
 | 2026-04-18 | CorvidAgent | v2: fill in export descriptions, re-validate against source |
 | 2026-04-18 | CorvidAgent | v3: add remote template support via owner/repo syntax |
+| 2026-04-21 | CorvidAgent | v7: add author/org fields to InitOptions, document plugin pre_init hook and versioning check |
 | 2026-04-19 | CorvidAgent | v5: init now writes `.fledge.toml` with template source, variables, and file hashes for `fledge update` |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 5
+version: 6
 status: active
 files:
   - src/plugin.rs
@@ -26,7 +26,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `run` | Entry point — install, list, remove, or run plugins |
 | `PluginOptions` | Options for the plugin subcommand |
 | `PluginEntry` | Installed plugin metadata: name, source, version, install date, commands |
-| `PluginAction` | Enum of plugin operations: Install, Remove, List, Search, Run |
+| `PluginAction` | Enum of plugin operations: Install, Remove, Update, List, Search, Run |
 | `resolve_plugin_command` | Check if a command name matches an installed plugin |
 | `run_lifecycle_hook` | Run a named lifecycle hook across all installed plugins |
 
@@ -211,6 +211,7 @@ $ fledge plugin update fledge-deploy
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 6 | 2026-04-21 | Fix: add missing Update variant to exported functions table |
 | 5 | 2026-04-21 | Add lifecycle hooks: pre_init, post_work_start, pre_pr — run across all installed plugins |
 | 4 | 2026-04-21 | Add version pinning with @ref syntax, pinned_ref in registry, smart update for pinned plugins |
 | 3 | 2026-04-21 | Add build hook, auto-detect build systems, plugin update command, improved error messages |

--- a/specs/prompts/prompts.spec.md
+++ b/specs/prompts/prompts.spec.md
@@ -1,6 +1,6 @@
 ---
 module: prompts
-version: 2
+version: 3
 status: active
 files:
   - src/prompts.rs
@@ -40,13 +40,13 @@ Interactive user prompts using dialoguer. Handles template selection and variabl
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `select_template` | `(&[Template]) -> Result<usize>` | Interactive template selection menu |
-| `prompt_variables` | `(&Template, &str, &Config, bool) -> Result<tera::Context>` | Collects all template variables via prompts; bool is `yes` flag to skip interactive prompts |
+| `prompt_variables` | `(&Template, &str, &Config, bool, Option<&str>, Option<&str>) -> Result<tera::Context>` | Collects all template variables via prompts; bool is `yes` flag, last two are `author_override` and `org_override` from CLI flags |
 
 ## Invariants
 
 1. Core variables (project_name, snake/pascal variants, year, date) are always set without prompting
-2. Author uses config/git before falling back to interactive prompt
-3. GitHub org defaults to "CorvidLabs" if not in config
+2. Author uses CLI override → config → git, falling back to interactive prompt
+3. GitHub org uses CLI override → config, defaulting to "CorvidLabs"
 4. License is always read from config (no interactive prompt)
 5. Template-specific prompts support Tera expressions in default values
 6. Template-specific prompts are processed in manifest iteration order; earlier prompt values are available as Tera context for later prompt defaults
@@ -107,4 +107,5 @@ Interactive user prompts using dialoguer. Handles template selection and variabl
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-18 | CorvidAgent | Initial spec |
+| 2026-04-21 | CorvidAgent | v3: add author_override and org_override params to prompt_variables signature |
 | 2026-04-18 | CorvidAgent | v2: fill API descriptions, add license invariant, add prompt ordering invariant, add Tera/plain default scenarios |

--- a/specs/publish/tasks.md
+++ b/specs/publish/tasks.md
@@ -2,7 +2,10 @@
 
 - [x] Write publish spec
 - [x] Implement `publish.rs` with validate, create, topics, push
-- [ ] Add CLI subcommand to main.rs
-- [ ] Add unit tests
-- [ ] Register spec in spec-sync registry
-- [ ] Run full verification (clippy, fmt, tests, spec-check)
+- [x] Add CLI subcommand to main.rs
+- [x] Register spec in spec-sync registry
+- [x] Run full verification (clippy, fmt, tests, spec-check)
+
+## Gaps
+
+- No unit tests for publish.rs (relies on integration testing against GitHub)

--- a/specs/release/tasks.md
+++ b/specs/release/tasks.md
@@ -11,4 +11,7 @@
 - [x] Pre-release lane support
 - [x] Custom version files via [release] config
 - [x] 32 unit tests covering all paths
-- [ ] Add [lanes.release] to built-in templates
+
+## Gaps
+
+- No `[lanes.release]` in built-in templates yet (users must define their own)

--- a/specs/remote/tasks.md
+++ b/specs/remote/tasks.md
@@ -8,8 +8,9 @@
 - [x] Add unit tests for all public functions
 - [x] Integrate with init and templates modules
 
+- [x] Add `--refresh` flag to force re-clone cached repos
+
 ## Future
 
-- [ ] Add `--refresh` flag to force re-clone cached repos
 - [ ] Support non-GitHub git hosts (GitLab, Bitbucket)
 - [ ] Template registry / index for discoverability

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 1
+version: 2
 status: active
 files:
   - src/review.rs
@@ -22,13 +22,13 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point for the review command |
-| `ReviewOptions` | Options struct with base branch and file filter |
+| `ReviewOptions` | Options struct with base branch, file filter, and json flag |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `ReviewOptions` | `{ base: Option<String>, file: Option<String> }` |
+| `ReviewOptions` | `{ base: Option<String>, file: Option<String>, json: bool }` |
 
 ### Functions
 
@@ -43,6 +43,7 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 3. Empty diffs bail with a clear message
 4. Shows diff stats before the AI review output
 5. `--file` flag restricts review to a single file's changes
+6. `--json` outputs structured JSON review results
 
 ## Behavioral Examples
 
@@ -87,4 +88,5 @@ $ fledge review --file src/github.rs
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-21 | Add json field to ReviewOptions |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/run/context.md
+++ b/specs/run/context.md
@@ -2,14 +2,29 @@
 spec: run.spec.md
 ---
 
-## Context
+## Key Decisions
 
-TODO: Describe the context and motivation for this module.
+- Tasks are defined in `fledge.toml` under `[tasks]` — either short form (`build = "cargo build"`) or full form with deps, env, dir, and description
+- Task dependencies form a DAG — circular deps are detected before execution and produce a clear error
+- `detect_project_type()` is public because it's used by `init` (to generate default `fledge.toml`) and `doctor` (for toolchain checks)
+- `task_defaults()` returns sensible default tasks per language (build, test, lint, fmt) so new projects work out of the box
+- `--list` shows available tasks with descriptions — useful for discoverability
+- `--init` generates a starter `fledge.toml` based on detected project type
 
-## Related Modules
+## Files to Read First
 
-- TODO
+- `src/run.rs` — task parsing, dependency resolution, execution
+- `fledge.toml` (in any project) — the task definition format
+- `specs/run/run.spec.md` — formal API and invariants
 
-## Design Decisions
+## Current Status
 
-- TODO
+- Fully implemented: task parsing, dep resolution, execution with env/dir support
+- Auto-detection covers: rust, node, go, python, ruby, java-gradle, java-maven, swift, generic
+- `task_defaults()` provides starter tasks for each detected project type
+
+## Notes
+
+- Tasks run via `sh -c` on Unix — command strings are shell expressions
+- Dep resolution uses topological sort with cycle detection
+- The `generic` project type is the fallback when no language markers are found

--- a/specs/run/requirements.md
+++ b/specs/run/requirements.md
@@ -4,16 +4,28 @@ spec: run.spec.md
 
 ## User Stories
 
-- As a developer, I want to TODO
+- As a developer, I want to run project tasks with `fledge run <task>` instead of remembering tool-specific commands
+- As a developer, I want tasks to automatically run their dependencies first
+- As a developer, I want to see all available tasks with `fledge run --list`
+- As a developer, I want `fledge run --init` to generate a starter task file for my project type
 
 ## Acceptance Criteria
 
-- TODO
+- `fledge run <task>` executes the named task from `fledge.toml`
+- Task dependencies run in topological order before the requested task
+- Circular dependencies produce an error listing the cycle
+- `fledge run --list` shows task names and descriptions
+- `fledge run --init` generates `fledge.toml` with defaults for the detected project type
+- Unknown task names produce an error listing available tasks
+- Tasks support environment variables and working directory overrides
 
 ## Constraints
 
-- TODO
+- Tasks execute via `sh -c` — must work on macOS and Linux
+- `fledge.toml` must be present in the current directory (or `--init` to create one)
 
 ## Out of Scope
 
-- TODO
+- Parallel task execution
+- Task caching or incremental builds
+- Watch mode / file-change triggers

--- a/specs/run/testing.md
+++ b/specs/run/testing.md
@@ -6,8 +6,15 @@ spec: run.spec.md
 
 ### Unit Tests
 
-- TODO
+- `detect_project_type` correctly identifies rust, node, go, python, ruby, java-gradle, java-maven, swift, and generic projects
+- `task_defaults` returns non-empty task maps for each supported project type
+- Circular dependency detection catches direct cycles (A→B→A) and indirect cycles (A→B→C→A)
+- Short-form task (`"cargo build"`) and full-form task (with deps, env, dir) both parse correctly
 
 ### Integration Tests
 
-- TODO
+- `fledge run build` in a Rust project executes `cargo build`
+- `fledge run --list` displays task names and descriptions from `fledge.toml`
+- `fledge run --init` in a Rust project generates a valid `fledge.toml` with rust-specific tasks
+- `fledge run nonexistent` fails with available task names listed
+- Task with dependencies runs deps first in correct order

--- a/specs/update/tasks.md
+++ b/specs/update/tasks.md
@@ -5,14 +5,14 @@ spec: update.spec.md
 ## Tasks
 
 - [x] Write spec files for update module
-- [ ] Add `.fledge.toml` generation to `fledge init`
-- [ ] Implement `ProjectMeta` struct and parsing
-- [ ] Implement file hash computation (SHA-256)
-- [ ] Implement diff logic (compare old hashes vs new template vs current files)
-- [ ] Implement `fledge update` command with dry-run support
-- [ ] Wire up CLI subcommand in `main.rs`
-- [ ] Unit tests for meta parsing, hashing, diff logic
-- [ ] Integration: init → modify → update cycle
+- [x] Add `.fledge.toml` generation to `fledge init`
+- [x] Implement `ProjectMeta` struct and parsing
+- [x] Implement file hash computation (SHA-256)
+- [x] Implement diff logic (compare old hashes vs new template vs current files)
+- [x] Implement `fledge update` command with dry-run support
+- [x] Wire up CLI subcommand in `main.rs`
+- [x] Unit tests for meta parsing, hashing, diff logic
+- [x] Integration: init → modify → update cycle
 
 ## Gaps
 

--- a/specs/versioning/tasks.md
+++ b/specs/versioning/tasks.md
@@ -2,7 +2,10 @@
 
 - [x] Write versioning spec
 - [x] Implement versioning.rs with Version struct and comparison
-- [ ] Integrate check into init.rs lane
-- [ ] Add version pinning to remote.rs
-- [ ] Add template_version field to TemplateInfo
-- [ ] Register spec and run full verification
+- [x] Integrate check into init.rs (min_fledge_version enforcement)
+- [x] Register spec and run full verification
+
+## Gaps
+
+- Version pinning for remote templates is handled in `remote.rs` via `@ref` syntax, not in versioning module
+- No `template_version` field in TemplateInfo (template versioning is tracked via git refs instead)

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 2
+version: 4
 status: active
 files:
   - src/work.rs
@@ -50,8 +50,10 @@ Provides opinionated git workflow commands for feature branch development. `fled
 | `status` | `() -> Result<()>` | Shows current branch, commits ahead, and PR status |
 | `sanitize_branch_name` | `(&str) -> String` | Lowercase, replace special chars with hyphens, collapse consecutive hyphens |
 | `generate_title_from_branch` | `(&str) -> String` | Strip type prefix, convert hyphens to spaces, title-case |
-| `load_work_config` | `() -> WorkConfig` | Reads `[work]` section from `fledge.toml`, falls back to defaults |
 | `build_branch_name` | `(name, branch_type, issue, prefix, config) -> String` | Apply format template with `{author}`, `{type}`, `{name}`, `{issue}` substitution |
+
+**Internal (not exported):**
+- `load_work_config() -> WorkConfig` — Reads `[work]` section from `fledge.toml`, falls back to defaults
 
 ## Invariants
 
@@ -166,4 +168,5 @@ $ fledge work status
 |---------|------|---------|
 | 1 | 2026-04-19 | Initial spec for fledge work |
 | 2 | 2026-04-20 | Flexible branch types, configurable format, `{author}` support, `--type`/`--issue`/`--prefix` flags |
+| 4 | 2026-04-21 | Correct load_work_config as internal (not exported) |
 | 3 | 2026-04-20 | Added `feature`, `bug`, `task` as valid branch types |


### PR DESCRIPTION
## Summary

Full audit of all 30 specs against actual source code. Found and fixed every discrepancy.

**Spec-vs-code mismatches fixed (8):**
- **checks** — document cancelled (🚫) and skipped (⏭️) check statuses
- **init** — add missing `author`/`org` fields to InitOptions, document plugin/versioning deps
- **work** — correct `load_work_config` as internal (not exported)
- **plugin** — add missing `Update` variant to exported functions table
- **review** — add undocumented `json` field to ReviewOptions
- **ask** — add undocumented `json` field to AskOptions
- **doctor** — add missing `swift` project type
- **prompts** — add `author_override`/`org_override` params to `prompt_variables` signature

**Companion files filled in (were TODO placeholders, 6 files):**
- checks: context.md, requirements.md, testing.md
- run: context.md, requirements.md, testing.md

**Stale task checkboxes marked complete (6 files):**
- publish, update, versioning, release, remote, create_template tasks.md

## Verification

- `cargo run -- spec check` → 30/30 pass, 0 errors, 0 warnings
- Zero TODO placeholders remaining in specs
- Pre-commit hooks pass (specs, formatting, clippy)

## Test plan

- [x] `cargo run -- spec check` passes
- [x] No remaining TODOs in spec companion files
- [x] No stale unchecked boxes for implemented features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6