### PR TITLE
fix: isolate config integration test (fixes CI on main)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1639,15 +1639,35 @@ fn cli_config_unset_unknown_key_fails() {
 
 #[test]
 fn cli_config_add_remove_list_key() {
-    let output = run_fledge(&["config", "add", "templates.paths", "/tmp/e2e-test-path"]);
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("fledge-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let bin = cargo_bin();
+    let output = Command::new(&bin)
+        .args(["config", "add", "templates.paths", "/tmp/e2e-test-path"])
+        .env("FLEDGE_CONFIG_DIR", &config_dir)
+        .output()
+        .unwrap();
     assert!(output.status.success());
 
-    let output = run_fledge(&["config", "get", "templates.paths"]);
+    let output = Command::new(&bin)
+        .args(["config", "get", "templates.paths"])
+        .env("FLEDGE_CONFIG_DIR", &config_dir)
+        .output()
+        .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("/tmp/e2e-test-path"));
+    assert!(
+        stdout.contains("/tmp/e2e-test-path"),
+        "expected /tmp/e2e-test-path in output, got: {stdout}"
+    );
 
-    let output = run_fledge(&["config", "remove", "templates.paths", "/tmp/e2e-test-path"]);
+    let output = Command::new(&bin)
+        .args(["config", "remove", "templates.paths", "/tmp/e2e-test-path"])
+        .env("FLEDGE_CONFIG_DIR", &config_dir)
+        .output()
+        .unwrap();
     assert!(output.status.success());
 }
 


### PR DESCRIPTION
## Summary

- `cli_config_add_remove_list_key` was modifying the real global config file without `FLEDGE_CONFIG_DIR` isolation
- On macOS CI, parallel test execution caused race conditions — the test couldn't find its path in stdout because another test clobbered the config
- Now uses a temp dir with `FLEDGE_CONFIG_DIR`, matching the pattern used by `cli_config_set_and_get_roundtrip`

Fixes the CI failure on main (run 24749965202, macOS only).

## Test plan

- [x] `cargo test cli_config_add_remove_list_key` passes locally
- [x] Pre-commit hooks pass (specs, formatting, clippy)
- [ ] CI passes on all platforms (macOS, Ubuntu, Windows)