### PR TITLE
refactor: rename list/lane/plugin to templates/lanes/plugins

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ enum Commands {
         yes: bool,
     },
     /// List available templates
-    List,
+    #[command(alias = "list")]
+    Templates,
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for (auto-detects if omitted with --install)
@@ -232,7 +233,8 @@ enum Commands {
         lang: Option<String>,
     },
     /// Manage and run composable workflow pipelines
-    Lane {
+    #[command(alias = "lane")]
+    Lanes {
         #[command(subcommand)]
         action: Option<LaneSubcommand>,
     },
@@ -288,7 +290,8 @@ enum Commands {
         json: bool,
     },
     /// Manage plugins (install, remove, list, search)
-    Plugin {
+    #[command(alias = "plugin")]
+    Plugins {
         #[command(subcommand)]
         action: PluginSubcommand,
         /// Output as JSON
@@ -582,7 +585,7 @@ fn run() -> Result<()> {
                 yes,
             })?;
         }
-        Commands::List => {
+        Commands::Templates => {
             list_templates()?;
         }
         Commands::Config { action } => {
@@ -715,7 +718,7 @@ fn run() -> Result<()> {
         Commands::Review { base, file, json } => {
             review::run(review::ReviewOptions { base, file, json })?;
         }
-        Commands::Lane { action } => {
+        Commands::Lanes { action } => {
             let action = match action {
                 Some(LaneSubcommand::Run { name, dry_run }) => {
                     lanes::LaneAction::Run { name, dry_run }
@@ -777,7 +780,7 @@ fn run() -> Result<()> {
                 json,
             })?;
         }
-        Commands::Plugin { action, json } => {
+        Commands::Plugins { action, json } => {
             let action = match action {
                 PluginSubcommand::Install { source, force } => {
                     plugin::PluginAction::Install { source, force }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1025,9 +1025,9 @@ fn cli_help_flag_shows_usage() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("init"));
-    assert!(stdout.contains("list"));
+    assert!(stdout.contains("templates"));
     assert!(stdout.contains("run"));
-    assert!(stdout.contains("lane"));
+    assert!(stdout.contains("lanes"));
     assert!(stdout.contains("doctor"));
     assert!(stdout.contains("metrics"));
 }


### PR DESCRIPTION
## Summary
- Renames `fledge list` → `fledge templates`, `fledge lane` → `fledge lanes`, `fledge plugin` → `fledge plugins`
- Old names kept as aliases for backwards compatibility
- Updated help-text assertions in integration tests

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 144/144 pass
- [x] `fledge templates` and `fledge list` both work
- [x] `fledge lanes list` and `fledge lane list` both work
- [x] `fledge plugins list` and `fledge plugin list` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)