### PR TITLE
fix: correct .fledge/meta.toml created date

### DIFF
--- a/.fledge/meta.toml
+++ b/.fledge/meta.toml
@@ -1,7 +1,7 @@
 [source]
 template = "rust-cli"
 fledge_version = "0.8.0"
-created = "2026-04-22"
+created = "2026-04-21"
 
 [variables]
 project_name = "fledge"


### PR DESCRIPTION
## Summary
- Fixes the `created` date in `.fledge/meta.toml` from `2026-04-22` to `2026-04-21` (actual date the `.fledge/` directory was introduced)

## Test plan
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)