### PR TITLE
feat: enhance search with topics, author filter, and broader matching

### DIFF
--- a/specs/search/search.spec.md
+++ b/specs/search/search.spec.md
@@ -26,8 +26,8 @@ Discovers fledge-compatible templates on GitHub by searching for repositories ta
 | `SearchResult` | A single matching repository with metadata |
 | `run` | Entry point that queries GitHub and displays matching templates |
 | `full_name` | Method on `SearchResult` returning `owner/repo` string |
-| `build_search_query` | Constructs GitHub search query string with `fledge-template` topic |
-| `search_github` | Executes GitHub search API call and parses results |
+| `build_search_query_ex` | Constructs GitHub search query string with topic, optional author filter |
+| `search_github_ex` | Executes GitHub search API call with extended options and parses results |
 | `parse_search_response` | Parses GitHub API JSON response into `Vec<SearchResult>` |
 | `format_stars` | Formats star count with `k` suffix for thousands |
 | `urlencod` | URL-encodes a string for use in query parameters |
@@ -50,8 +50,8 @@ Discovers fledge-compatible templates on GitHub by searching for repositories ta
 |----------|-----------|-------------|
 | `run` | `(SearchOptions) -> Result<()>` | Search GitHub API for fledge-template repos, display results |
 | `full_name` | `(&self) -> String` | Returns `owner/repo` format string for a `SearchResult` |
-| `build_search_query` | `(keyword: Option<&str>) -> String` | Constructs GitHub search query with `fledge-template` topic filter |
-| `search_github` | `(keyword: Option<&str>, token: Option<&str>, limit: usize) -> Result<Vec<SearchResult>>` | Execute GitHub search API call and parse results |
+| `build_search_query_ex` | `(keyword: Option<&str>, author: Option<&str>, topic: &str) -> String` | Constructs GitHub search query with topic filter and optional author |
+| `search_github_ex` | `(keyword: Option<&str>, author: Option<&str>, token: Option<&str>, limit: usize, topic: &str) -> Result<Vec<SearchResult>>` | Execute GitHub search API call with extended options and parse results |
 | `parse_search_response` | `(body: &serde_json::Value) -> Result<Vec<SearchResult>>` | Parse GitHub API JSON into search results |
 | `format_stars` | `(count: u64) -> String` | Format star count with `k` suffix for thousands |
 | `urlencod` | `(s: &str) -> String` | URL-encode a string for use in query parameters |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -96,16 +96,31 @@ enum ParallelItem {
 }
 
 pub enum LaneAction {
-    Run { name: String, dry_run: bool },
-    List { json: bool },
+    Run {
+        name: String,
+        dry_run: bool,
+    },
+    List {
+        json: bool,
+    },
     Init,
-    Search { query: Option<String>, json: bool },
-    Import { source: String },
+    Search {
+        query: Option<String>,
+        author: Option<String>,
+        json: bool,
+    },
+    Import {
+        source: String,
+    },
 }
 
 pub fn run(action: LaneAction) -> Result<()> {
     match action {
-        LaneAction::Search { query, json } => search_lanes(query.as_deref(), json),
+        LaneAction::Search {
+            query,
+            author,
+            json,
+        } => search_lanes(query.as_deref(), author.as_deref(), json),
         LaneAction::Import { source } => import_lanes(&source),
         LaneAction::Init => init_lanes(),
         LaneAction::List { json } => {
@@ -675,14 +690,11 @@ fn init_lanes() -> Result<()> {
     Ok(())
 }
 
-fn search_lanes(keyword: Option<&str>, json: bool) -> Result<()> {
+fn search_lanes(keyword: Option<&str>, author: Option<&str>, json: bool) -> Result<()> {
     let config = crate::config::Config::load()?;
     let token = config.github_token();
 
-    let query = match keyword {
-        Some(kw) => format!("{} topic:fledge-lane", kw),
-        None => "topic:fledge-lane".to_string(),
-    };
+    let query = crate::search::build_search_query_ex(keyword, author, "fledge-lane");
 
     let sp = crate::spinner::Spinner::start("Searching GitHub for community lanes:");
 
@@ -730,11 +742,17 @@ fn search_lanes(keyword: Option<&str>, json: bool) -> Result<()> {
         } else {
             r.description.clone()
         };
+        let topic_str = if r.topics.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", r.topics.join(", "))
+        };
         println!(
-            "  {:<width$}  {}  {}",
+            "  {:<width$}  {}  {}{}",
             style(&r.full_name()).green(),
             style(format!("(⭐ {})", stars)).dim(),
             style(&desc).dim(),
+            style(&topic_str).cyan(),
             width = max_name,
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,9 @@ enum TemplatesSubcommand {
     Search {
         /// Keyword to filter results
         query: Option<String>,
+        /// Filter by author/owner
+        #[arg(short, long)]
+        author: Option<String>,
         /// Maximum number of results
         #[arg(short, long, default_value = "20")]
         limit: usize,
@@ -504,6 +507,9 @@ enum LaneSubcommand {
     Search {
         /// Keyword to filter results
         query: Option<String>,
+        /// Filter by author/owner
+        #[arg(short, long)]
+        author: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -543,6 +549,9 @@ enum PluginSubcommand {
     Search {
         /// Search query
         query: Option<String>,
+        /// Filter by author/owner
+        #[arg(short, long)]
+        author: Option<String>,
         /// Maximum results
         #[arg(short, long, default_value = "20")]
         limit: usize,
@@ -668,7 +677,15 @@ fn run() -> Result<()> {
                 LaneSubcommand::Run { name, dry_run } => lanes::LaneAction::Run { name, dry_run },
                 LaneSubcommand::List { json } => lanes::LaneAction::List { json },
                 LaneSubcommand::Init => lanes::LaneAction::Init,
-                LaneSubcommand::Search { query, json } => lanes::LaneAction::Search { query, json },
+                LaneSubcommand::Search {
+                    query,
+                    author,
+                    json,
+                } => lanes::LaneAction::Search {
+                    query,
+                    author,
+                    json,
+                },
                 LaneSubcommand::Import { source } => lanes::LaneAction::Import { source },
                 LaneSubcommand::External(args) => {
                     let name = args.first().cloned().unwrap_or_default();
@@ -728,9 +745,15 @@ fn run() -> Result<()> {
                 PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },
                 PluginSubcommand::Update { name } => plugin::PluginAction::Update { name },
                 PluginSubcommand::List => plugin::PluginAction::List,
-                PluginSubcommand::Search { query, limit } => {
-                    plugin::PluginAction::Search { query, limit }
-                }
+                PluginSubcommand::Search {
+                    query,
+                    author,
+                    limit,
+                } => plugin::PluginAction::Search {
+                    query,
+                    author,
+                    limit,
+                },
                 PluginSubcommand::Run { name, args } => plugin::PluginAction::Run { name, args },
             };
             plugin::run(plugin::PluginOptions { action, json })?;
@@ -859,8 +882,18 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
                 yes,
             })?;
         }
-        TemplatesSubcommand::Search { query, limit, json } => {
-            search::run(search::SearchOptions { query, limit, json })?;
+        TemplatesSubcommand::Search {
+            query,
+            author,
+            limit,
+            json,
+        } => {
+            search::run(search::SearchOptions {
+                query,
+                author,
+                limit,
+                json,
+            })?;
         }
         TemplatesSubcommand::Update { dry_run, refresh } => {
             update::run(update::UpdateOptions { dry_run, refresh })?;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -65,12 +65,26 @@ pub struct PluginOptions {
 }
 
 pub enum PluginAction {
-    Install { source: String, force: bool },
-    Remove { name: String },
-    Update { name: Option<String> },
+    Install {
+        source: String,
+        force: bool,
+    },
+    Remove {
+        name: String,
+    },
+    Update {
+        name: Option<String>,
+    },
     List,
-    Search { query: Option<String>, limit: usize },
-    Run { name: String, args: Vec<String> },
+    Search {
+        query: Option<String>,
+        author: Option<String>,
+        limit: usize,
+    },
+    Run {
+        name: String,
+        args: Vec<String>,
+    },
 }
 
 pub fn run(opts: PluginOptions) -> Result<()> {
@@ -79,7 +93,11 @@ pub fn run(opts: PluginOptions) -> Result<()> {
         PluginAction::Remove { name } => remove_plugin(&name),
         PluginAction::Update { name } => update_plugins(name.as_deref()),
         PluginAction::List => list_plugins(opts.json),
-        PluginAction::Search { query, limit } => search_plugins(query.as_deref(), limit, opts.json),
+        PluginAction::Search {
+            query,
+            author,
+            limit,
+        } => search_plugins(query.as_deref(), author.as_deref(), limit, opts.json),
         PluginAction::Run { name, args } => run_plugin(&name, &args),
     }
 }
@@ -790,18 +808,18 @@ fn list_plugins(json: bool) -> Result<()> {
     Ok(())
 }
 
-fn search_plugins(query: Option<&str>, limit: usize, json: bool) -> Result<()> {
-    let search_query = match query {
-        Some(q) => format!("fledge-plugin {q}"),
-        None => "fledge-plugin".to_string(),
-    };
-
+fn search_plugins(
+    query: Option<&str>,
+    author: Option<&str>,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
     let sp = crate::spinner::Spinner::start("Searching GitHub for plugins:");
 
     let config = crate::config::Config::load().ok();
     let token = config.as_ref().and_then(|c| c.github_token());
 
-    let query_str = format!("{search_query} topic:fledge-plugin");
+    let query_str = crate::search::build_search_query_ex(query, author, "fledge-plugin");
     let limit_str = limit.to_string();
     let body = crate::github::github_api_get(
         "/search/repositories",

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug)]
 pub struct SearchOptions {
     pub query: Option<String>,
+    pub author: Option<String>,
     pub limit: usize,
     pub json: bool,
 }
@@ -16,6 +17,8 @@ pub struct SearchResult {
     pub description: String,
     pub stars: u64,
     pub url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub topics: Vec<String>,
 }
 
 impl SearchResult {
@@ -29,7 +32,13 @@ pub fn run(options: SearchOptions) -> Result<()> {
     let token = config.github_token();
 
     let sp = crate::spinner::Spinner::start("Searching GitHub for templates:");
-    let results = search_github(options.query.as_deref(), token.as_deref(), options.limit);
+    let results = search_github_ex(
+        options.query.as_deref(),
+        options.author.as_deref(),
+        "fledge-template",
+        token.as_deref(),
+        options.limit,
+    );
     sp.finish();
     let results = results?;
 
@@ -50,11 +59,17 @@ pub fn run(options: SearchOptions) -> Result<()> {
             } else {
                 r.description.clone()
             };
+            let topic_str = if r.topics.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", r.topics.join(", "))
+            };
             println!(
-                "  {} {} {}",
+                "  {} {} {}{}",
                 style(&r.full_name()).green(),
                 style(format!("({})", stars)).dim(),
-                style(&desc).dim()
+                style(&desc).dim(),
+                style(&topic_str).cyan(),
             );
         }
         println!(
@@ -66,19 +81,26 @@ pub fn run(options: SearchOptions) -> Result<()> {
     Ok(())
 }
 
-pub fn build_search_query(keyword: Option<&str>) -> String {
-    match keyword {
-        Some(kw) => format!("{} topic:fledge-template", kw),
-        None => "topic:fledge-template".to_string(),
+pub fn build_search_query_ex(keyword: Option<&str>, author: Option<&str>, topic: &str) -> String {
+    let mut parts = Vec::new();
+    if let Some(kw) = keyword {
+        parts.push(format!("{kw} in:name,description,topics"));
     }
+    parts.push(format!("topic:{topic}"));
+    if let Some(a) = author {
+        parts.push(format!("user:{a}"));
+    }
+    parts.join(" ")
 }
 
-pub fn search_github(
+pub fn search_github_ex(
     keyword: Option<&str>,
+    author: Option<&str>,
+    topic: &str,
     token: Option<&str>,
     limit: usize,
 ) -> Result<Vec<SearchResult>> {
-    let query = build_search_query(keyword);
+    let query = build_search_query_ex(keyword, author, topic);
     let per_page = limit.min(100);
     let url = format!(
         "https://api.github.com/search/repositories?q={}&sort=stars&order=desc&per_page={}",
@@ -138,6 +160,15 @@ pub fn parse_search_response(body: &serde_json::Value) -> Result<Vec<SearchResul
                 .and_then(|s| s.as_u64())
                 .unwrap_or(0);
             let url = item.get("html_url").and_then(|u| u.as_str()).unwrap_or("");
+            let topics = item
+                .get("topics")
+                .and_then(|t| t.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
 
             Some(SearchResult {
                 owner: owner.to_string(),
@@ -145,6 +176,7 @@ pub fn parse_search_response(body: &serde_json::Value) -> Result<Vec<SearchResul
                 description: description.to_string(),
                 stars,
                 url: url.to_string(),
+                topics,
             })
         })
         .collect();
@@ -251,14 +283,29 @@ mod tests {
 
     #[test]
     fn build_search_query_no_keyword() {
-        let q = build_search_query(None);
+        let q = build_search_query_ex(None, None, "fledge-template");
         assert_eq!(q, "topic:fledge-template");
     }
 
     #[test]
     fn build_search_query_with_keyword() {
-        let q = build_search_query(Some("rust"));
-        assert_eq!(q, "rust topic:fledge-template");
+        let q = build_search_query_ex(Some("rust"), None, "fledge-template");
+        assert_eq!(q, "rust in:name,description,topics topic:fledge-template");
+    }
+
+    #[test]
+    fn build_search_query_ex_with_author() {
+        let q = build_search_query_ex(Some("rust"), Some("corvidlabs"), "fledge-template");
+        assert_eq!(
+            q,
+            "rust in:name,description,topics topic:fledge-template user:corvidlabs"
+        );
+    }
+
+    #[test]
+    fn build_search_query_ex_author_only() {
+        let q = build_search_query_ex(None, Some("corvidlabs"), "fledge-plugin");
+        assert_eq!(q, "topic:fledge-plugin user:corvidlabs");
     }
 
     #[test]
@@ -290,6 +337,7 @@ mod tests {
             description: "Templates".to_string(),
             stars: 10,
             url: "https://github.com/CorvidLabs/fledge-templates".to_string(),
+            topics: vec![],
         };
         assert_eq!(r.full_name(), "CorvidLabs/fledge-templates");
     }
@@ -302,6 +350,7 @@ mod tests {
             description: "A template".to_string(),
             stars: 5,
             url: "https://github.com/test/tpl".to_string(),
+            topics: vec!["fledge-template".to_string()],
         }];
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&results).unwrap()).unwrap();
@@ -337,10 +386,30 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    #[test]
+    fn parse_search_response_extracts_topics() {
+        let json = serde_json::json!({
+            "total_count": 1,
+            "items": [
+                {
+                    "name": "fledge-rust-template",
+                    "owner": { "login": "CorvidLabs" },
+                    "description": "A Rust template",
+                    "stargazers_count": 5,
+                    "html_url": "https://github.com/CorvidLabs/fledge-rust-template",
+                    "topics": ["fledge-template", "rust", "cli"]
+                }
+            ]
+        });
+
+        let results = parse_search_response(&json).unwrap();
+        assert_eq!(results[0].topics, vec!["fledge-template", "rust", "cli"]);
+    }
+
     #[ignore]
     #[test]
     fn live_search_returns_results() {
-        let results = search_github(None, None, 5).unwrap();
+        let results = search_github_ex(None, None, "fledge-template", None, 5).unwrap();
         // May be empty if no repos have the topic yet — just ensure no error
         let _ = results;
     }


### PR DESCRIPTION
## Summary

- **Broader search** — keywords now match against repo name, description, AND topics via GitHub's `in:name,description,topics` qualifier
- **`--author` flag** — filters results by GitHub user/org across all three search commands
- **Topics displayed** — search results show repo topics in cyan brackets
- **Shared query builder** — all three commands (`templates search`, `plugins search`, `lanes search`) use `build_search_query_ex()` for consistent behavior

## Usage

```
fledge templates search rust
fledge templates search --author corvidlabs
fledge plugins search --author corvidlabs cache
fledge lanes search ci --author someorg
```

## Test plan

- [x] All 638 unit tests pass (494 unit + 144 integration)
- [x] Clippy clean, no warnings
- [x] Pre-commit hooks pass (specs, fmt, clippy)
- [x] New test for topics parsing in `parse_search_response`
- [x] Updated all existing search tests for new `SearchResult` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6