### PR TITLE
fix: release workflow checksum step fails on mv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             for file in "$dir"*; do
               filename=$(basename "$file")
               sha256sum "$file" | sed "s|.*/||" > "${filename}.sha256"
-              mv "$file" .
+              cp "$file" "${filename}"
             done
           done
           rm -rf */


### PR DESCRIPTION
## Summary
- The release action triggered by `v0.9.0` failed at the "Generate checksums" step
- `download-artifact@v4` creates subdirectories named after each artifact (e.g., `artifacts/fledge-linux-x86_64/fledge-linux-x86_64`)
- `mv "$file" .` fails because the destination path collides with the existing directory name
- Fix: use `cp` to copy files out, then `rm -rf */` cleans up the directories as before

## Test plan
- [ ] Merge and re-tag (or manually trigger) to verify the release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)