### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/.fledge/meta.toml
+++ b/.fledge/meta.toml
@@ -1,6 +1,6 @@
 [source]
 template = "rust-cli"
-fledge_version = "0.8.0"
+fledge_version = "0.9.1"
 created = "2026-04-21"
 
 [variables]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-21
+
+### Fixed
+
+- Release workflow: use `cp` instead of `mv` in checksum step to fix artifact packaging with `download-artifact@v4` (#173)
+
 ## [0.9.0] - 2026-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."


### PR DESCRIPTION
## Summary
- Bump version in Cargo.toml from 0.9.0 to 0.9.1
- Once merged, tag `v0.9.1` will be created to trigger the release workflow and test the checksum fix from #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)