### PR TITLE
fix: flatten artifact download to prevent same-file copy error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,17 +57,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+          merge-multiple: true
       - name: Generate checksums
         run: |
           cd artifacts
-          for dir in */; do
-            for file in "$dir"*; do
-              filename=$(basename "$file")
-              sha256sum "$file" | sed "s|.*/||" > "${filename}.sha256"
-              cp "$file" "${filename}"
-            done
+          for file in *; do
+            [ -f "$file" ] || continue
+            sha256sum "$file" | sed "s|.*/||" > "${file}.sha256"
           done
-          rm -rf */
           cat *.sha256
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- The `download-artifact@v4` action creates subdirectories named after each artifact (e.g., `fledge-linux-x86_64/fledge-linux-x86_64`), so `cp dir/file dir` fails with "are the same file"
- Fix: use `merge-multiple: true` to download all artifacts flat into a single directory
- Simplifies the checksum generation loop — no more subdirectory traversal needed

Fixes the v0.9.1 release workflow failure: https://github.com/CorvidLabs/fledge/actions/runs/24755940154/job/72429368979

## Test plan
- [ ] Merge and re-tag v0.9.1 to trigger the release workflow
- [ ] Verify checksums are generated correctly for all 4 platform binaries
- [ ] Verify GitHub release is created with binaries + .sha256 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)