### PR TITLE
feat: add publish commands for plugins and lanes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use console::style;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -112,6 +112,12 @@ pub enum LaneAction {
     Import {
         source: String,
     },
+    Publish {
+        path: PathBuf,
+        org: Option<String>,
+        private: bool,
+        description: Option<String>,
+    },
 }
 
 pub fn run(action: LaneAction) -> Result<()> {
@@ -123,6 +129,12 @@ pub fn run(action: LaneAction) -> Result<()> {
         } => search_lanes(query.as_deref(), author.as_deref(), json),
         LaneAction::Import { source } => import_lanes(&source),
         LaneAction::Init => init_lanes(),
+        LaneAction::Publish {
+            path,
+            org,
+            private,
+            description,
+        } => publish_lanes(&path, org.as_deref(), private, description.as_deref()),
         LaneAction::List { json } => {
             let config = load_lane_config()?;
             list_lanes(&config.lanes, json)
@@ -1009,6 +1021,112 @@ fn base64_decode(input: &str) -> Result<Vec<u8>> {
     }
 
     Ok(output)
+}
+
+fn publish_lanes(
+    path: &Path,
+    org: Option<&str>,
+    private: bool,
+    description: Option<&str>,
+) -> Result<()> {
+    let config = crate::config::Config::load()?;
+    let token = config.github_token().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No GitHub token configured. Run: fledge config set github.token <your-token>"
+        )
+    })?;
+
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", path.display()))?;
+
+    let fledge_toml = path.join("fledge.toml");
+    if !fledge_toml.exists() {
+        bail!(
+            "No fledge.toml found in {}. Lanes must be defined in a fledge.toml file.",
+            path.display()
+        );
+    }
+
+    let content = std::fs::read_to_string(&fledge_toml).context("reading fledge.toml")?;
+    let parsed: FledgeFileWithLanes = toml::from_str(&content).context("parsing fledge.toml")?;
+
+    if parsed.lanes.is_empty() {
+        bail!("No [lanes] defined in fledge.toml. Add lanes before publishing.");
+    }
+
+    let dir_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("fledge-lanes");
+    let repo_name = dir_name.to_string();
+    let desc = description.unwrap_or("Shared fledge lanes");
+
+    let owner = match org {
+        Some(o) => o.to_string(),
+        None => crate::publish::get_authenticated_user(&token)?,
+    };
+
+    let lane_names: Vec<&str> = parsed.lanes.keys().map(|s| s.as_str()).collect();
+    println!(
+        "{} Publishing {} lanes as {}/{}",
+        style("➡️").cyan().bold(),
+        style(lane_names.len()).green(),
+        style(&owner).green(),
+        style(&repo_name).green()
+    );
+    println!("  Lanes: {}", style(lane_names.join(", ")).dim());
+
+    let sp = crate::spinner::Spinner::start("Checking repository:");
+    let repo_exists = crate::publish::check_repo_exists(&owner, &repo_name, &token)?;
+    sp.finish();
+
+    if repo_exists {
+        let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+            .with_prompt(format!(
+                "Repository {}/{} already exists. Push update?",
+                owner, repo_name
+            ))
+            .default(false)
+            .interact()?;
+
+        if !confirm {
+            println!("{} Cancelled.", style("*").cyan().bold());
+            return Ok(());
+        }
+    } else {
+        let sp = crate::spinner::Spinner::start("Creating repository:");
+        crate::publish::create_github_repo(&repo_name, desc, private, Some(&owner), &token)?;
+        sp.finish();
+        println!(
+            "  {} Created repository {}/{}",
+            style("✅").green().bold(),
+            owner,
+            repo_name
+        );
+    }
+
+    let sp = crate::spinner::Spinner::start("Setting repository topics:");
+    crate::publish::set_repo_topic(&owner, &repo_name, "fledge-lane", &token)?;
+    sp.finish();
+    println!(
+        "  {} Set {} topic",
+        style("✅").green().bold(),
+        style("fledge-lane").cyan()
+    );
+
+    let sp = crate::spinner::Spinner::start("Pushing lane files:");
+    crate::publish::push_directory(&path, &owner, &repo_name, &token)?;
+    sp.finish();
+    println!("  {} Pushed lane files", style("✅").green().bold());
+
+    println!(
+        "\n{} Published! Import with:\n\n  {}",
+        style("✅").green().bold(),
+        style(format!("fledge lanes import {}/{}", owner, repo_name)).cyan()
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,21 @@ enum LaneSubcommand {
         /// GitHub repo (owner/repo) or full URL, optionally with @ref
         source: String,
     },
+    /// Publish lanes to GitHub
+    Publish {
+        /// Path to the directory containing fledge.toml with lanes
+        #[arg(default_value = ".")]
+        path: PathBuf,
+        /// Publish under a GitHub organization
+        #[arg(long)]
+        org: Option<String>,
+        /// Create as a private repository
+        #[arg(long)]
+        private: bool,
+        /// Override the repository description
+        #[arg(long)]
+        description: Option<String>,
+    },
     #[command(external_subcommand)]
     External(Vec<String>),
 }
@@ -563,6 +578,21 @@ enum PluginSubcommand {
         /// Arguments to pass to the plugin
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+    },
+    /// Publish a plugin to GitHub
+    Publish {
+        /// Path to the plugin directory
+        #[arg(default_value = ".")]
+        path: PathBuf,
+        /// Publish under a GitHub organization
+        #[arg(long)]
+        org: Option<String>,
+        /// Create as a private repository
+        #[arg(long)]
+        private: bool,
+        /// Override the repository description
+        #[arg(long)]
+        description: Option<String>,
     },
 }
 
@@ -687,6 +717,17 @@ fn run() -> Result<()> {
                     json,
                 },
                 LaneSubcommand::Import { source } => lanes::LaneAction::Import { source },
+                LaneSubcommand::Publish {
+                    path,
+                    org,
+                    private,
+                    description,
+                } => lanes::LaneAction::Publish {
+                    path,
+                    org,
+                    private,
+                    description,
+                },
                 LaneSubcommand::External(args) => {
                     let name = args.first().cloned().unwrap_or_default();
                     let dry_run = args.iter().any(|a| a == "--dry-run");
@@ -755,6 +796,17 @@ fn run() -> Result<()> {
                     limit,
                 },
                 PluginSubcommand::Run { name, args } => plugin::PluginAction::Run { name, args },
+                PluginSubcommand::Publish {
+                    path,
+                    org,
+                    private,
+                    description,
+                } => plugin::PluginAction::Publish {
+                    path,
+                    org,
+                    private,
+                    description,
+                },
             };
             plugin::run(plugin::PluginOptions { action, json })?;
         }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -85,6 +85,12 @@ pub enum PluginAction {
         name: String,
         args: Vec<String>,
     },
+    Publish {
+        path: PathBuf,
+        org: Option<String>,
+        private: bool,
+        description: Option<String>,
+    },
 }
 
 pub fn run(opts: PluginOptions) -> Result<()> {
@@ -99,6 +105,12 @@ pub fn run(opts: PluginOptions) -> Result<()> {
             limit,
         } => search_plugins(query.as_deref(), author.as_deref(), limit, opts.json),
         PluginAction::Run { name, args } => run_plugin(&name, &args),
+        PluginAction::Publish {
+            path,
+            org,
+            private,
+            description,
+        } => publish_plugin(&path, org.as_deref(), private, description.as_deref()),
     }
 }
 
@@ -1038,6 +1050,104 @@ fn create_symlink(original: &Path, link: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn publish_plugin(
+    path: &Path,
+    org: Option<&str>,
+    private: bool,
+    description: Option<&str>,
+) -> Result<()> {
+    let config = crate::config::Config::load()?;
+    let token = config.github_token().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No GitHub token configured. Run: fledge config set github.token <your-token>"
+        )
+    })?;
+
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", path.display()))?;
+
+    let manifest_path = path.join("plugin.toml");
+    if !manifest_path.exists() {
+        bail!(
+            "No plugin.toml found in {}. A valid plugin requires a plugin.toml manifest.",
+            path.display()
+        );
+    }
+
+    let content = fs::read_to_string(&manifest_path).context("reading plugin.toml")?;
+    let manifest: PluginManifest = toml::from_str(&content).context("Invalid plugin.toml")?;
+
+    let repo_name = &manifest.plugin.name;
+    let desc = description
+        .or(manifest.plugin.description.as_deref())
+        .unwrap_or("A fledge plugin");
+
+    let owner = match org {
+        Some(o) => o.to_string(),
+        None => crate::publish::get_authenticated_user(&token)?,
+    };
+
+    println!(
+        "{} Publishing plugin {} as {}/{}",
+        style("➡️").cyan().bold(),
+        style(path.display()).dim(),
+        style(&owner).green(),
+        style(repo_name).green()
+    );
+
+    let sp = crate::spinner::Spinner::start("Checking repository:");
+    let repo_exists = crate::publish::check_repo_exists(&owner, repo_name, &token)?;
+    sp.finish();
+
+    if repo_exists {
+        let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+            .with_prompt(format!(
+                "Repository {}/{} already exists. Push update?",
+                owner, repo_name
+            ))
+            .default(false)
+            .interact()?;
+
+        if !confirm {
+            println!("{} Cancelled.", style("*").cyan().bold());
+            return Ok(());
+        }
+    } else {
+        let sp = crate::spinner::Spinner::start("Creating repository:");
+        crate::publish::create_github_repo(repo_name, desc, private, Some(&owner), &token)?;
+        sp.finish();
+        println!(
+            "  {} Created repository {}/{}",
+            style("✅").green().bold(),
+            owner,
+            repo_name
+        );
+    }
+
+    let sp = crate::spinner::Spinner::start("Setting repository topics:");
+    crate::publish::set_repo_topic(&owner, repo_name, "fledge-plugin", &token)?;
+    sp.finish();
+    println!(
+        "  {} Set {} topic",
+        style("✅").green().bold(),
+        style("fledge-plugin").cyan()
+    );
+
+    let sp = crate::spinner::Spinner::start("Pushing plugin files:");
+    crate::publish::push_directory(&path, &owner, repo_name, &token)?;
+    sp.finish();
+    println!("  {} Pushed plugin files", style("✅").green().bold());
+
+    println!(
+        "\n{} Published! Install with:\n\n  {}",
+        style("✅").green().bold(),
+        style(format!("fledge plugins install {}/{}", owner, repo_name)).cyan()
+    );
+
     Ok(())
 }
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -91,7 +91,7 @@ pub fn run(options: PublishOptions) -> Result<()> {
     );
 
     let sp = crate::spinner::Spinner::start("Pushing template files:");
-    push_template(&path, &owner, repo_name, &token)?;
+    push_directory(&path, &owner, repo_name, &token)?;
     sp.finish();
     println!("  {} Pushed template files", style("✅").green().bold());
 
@@ -130,7 +130,7 @@ pub fn validate_template(path: &Path) -> Result<crate::templates::TemplateManife
     Ok(manifest)
 }
 
-fn get_authenticated_user(token: &str) -> Result<String> {
+pub fn get_authenticated_user(token: &str) -> Result<String> {
     let text = ureq::get("https://api.github.com/user")
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
@@ -150,7 +150,7 @@ fn get_authenticated_user(token: &str) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("Could not determine GitHub username"))
 }
 
-fn check_repo_exists(owner: &str, repo: &str, token: &str) -> Result<bool> {
+pub fn check_repo_exists(owner: &str, repo: &str, token: &str) -> Result<bool> {
     let url = format!("https://api.github.com/repos/{}/{}", owner, repo);
     let result = ureq::get(&url)
         .header("Authorization", &format!("Bearer {}", token))
@@ -206,6 +206,10 @@ pub fn create_github_repo(
 }
 
 pub fn set_repo_topics(owner: &str, repo: &str, token: &str) -> Result<()> {
+    set_repo_topic(owner, repo, "fledge-template", token)
+}
+
+pub fn set_repo_topic(owner: &str, repo: &str, topic: &str, token: &str) -> Result<()> {
     let url = format!("https://api.github.com/repos/{}/{}/topics", owner, repo);
 
     let text = ureq::get(&url)
@@ -230,8 +234,8 @@ pub fn set_repo_topics(owner: &str, repo: &str, token: &str) -> Result<()> {
         })
         .unwrap_or_default();
 
-    if !topics.iter().any(|t| t == "fledge-template") {
-        topics.push("fledge-template".to_string());
+    if !topics.iter().any(|t| t == topic) {
+        topics.push(topic.to_string());
     }
 
     let body = json!({ "names": topics });
@@ -249,7 +253,7 @@ pub fn set_repo_topics(owner: &str, repo: &str, token: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn push_template(path: &Path, owner: &str, repo: &str, token: &str) -> Result<()> {
+pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Result<()> {
     let git_dir = path.join(".git");
     let needs_init = !git_dir.exists();
 
@@ -313,7 +317,7 @@ pub fn push_template(path: &Path, owner: &str, repo: &str, token: &str) -> Resul
     Ok(())
 }
 
-fn run_git(dir: &Path, args: &[&str]) -> Result<()> {
+pub fn run_git(dir: &Path, args: &[&str]) -> Result<()> {
     let status = std::process::Command::new("git")
         .args(args)
         .current_dir(dir)


### PR DESCRIPTION
## Summary
- Adds `fledge plugins publish` and `fledge lanes publish` commands, mirroring the existing `fledge template publish`
- Each command validates manifests (plugin.toml / fledge.toml), creates/updates GitHub repos, auto-sets discovery topics (`fledge-plugin` / `fledge-lane`), and pushes files
- Refactors `publish.rs` to expose shared helpers (`set_repo_topic`, `push_directory`, `check_repo_exists`, `get_authenticated_user`) so all three publish flows share the same GitHub plumbing

## Commands added
| Command | Validates | Topic set |
|---------|-----------|-----------|
| `fledge plugins publish [path]` | `plugin.toml` | `fledge-plugin` |
| `fledge lanes publish [path]` | `fledge.toml` with `[lanes]` | `fledge-lane` |

Both support `--org`, `--private`, and `--description` flags matching `fledge template publish`.

## Test plan
- [x] 144 tests passing
- [x] Zero clippy warnings
- [x] Clean formatting
- [ ] Manual test: `fledge plugins publish` from a plugin directory
- [ ] Manual test: `fledge lanes publish` from a lanes repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)