### PR TITLE
fix: address Rook's security review findings

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -182,9 +182,13 @@ fn apply_git_auth(cmd: &mut Command) {
         let credentials = format!("x-access-token:{}", t);
         let encoded = base64::engine::general_purpose::STANDARD.encode(&credentials);
         let header_value = format!("Authorization: Basic {}", encoded);
-        cmd.env("GIT_CONFIG_COUNT", "1")
-            .env("GIT_CONFIG_KEY_0", "http.extraheader")
-            .env("GIT_CONFIG_VALUE_0", &header_value);
+        let existing: usize = std::env::var("GIT_CONFIG_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        cmd.env("GIT_CONFIG_COUNT", (existing + 1).to_string())
+            .env(format!("GIT_CONFIG_KEY_{existing}"), "http.extraheader")
+            .env(format!("GIT_CONFIG_VALUE_{existing}"), &header_value);
     }
 }
 
@@ -544,7 +548,12 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
             );
         }
         println!();
-        if !force {
+        if force {
+            eprintln!(
+                "  {} Capabilities auto-granted via --force",
+                style("WARN").yellow()
+            );
+        } else {
             let confirm =
                 dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
                     .with_prompt("Grant these capabilities?")

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -286,11 +286,14 @@ fn run_message_loop(
             }
             OutboundMessage::Store { key, value } => {
                 if !capabilities.store {
-                    eprintln!(
-                        "  {} [{}] store blocked — capability not granted",
+                    let msg = format!(
+                        "  {} [{}] store blocked — capability not granted (key: {})",
                         style("WARN").yellow(),
-                        style(plugin_name).dim()
+                        style(plugin_name).dim(),
+                        key,
                     );
+                    eprintln!("{msg}");
+                    handle_log(plugin_name, "error", "store capability not granted");
                     continue;
                 }
                 handle_store(plugin_dir, &key, &value)?;
@@ -589,13 +592,13 @@ fn handle_store(plugin_dir: &Path, key: &str, value: &str) -> Result<()> {
     } else {
         HashMap::new()
     };
-    state.insert(key.to_string(), value.to_string());
-    if state.len() > MAX_STORE_KEY_COUNT {
+    if !state.contains_key(key) && state.len() >= MAX_STORE_KEY_COUNT {
         bail!(
             "plugin state exceeds maximum of {} keys",
             MAX_STORE_KEY_COUNT
         );
     }
+    state.insert(key.to_string(), value.to_string());
     let json = serde_json::to_string_pretty(&state).context("serializing state")?;
     if json.len() > MAX_STORE_TOTAL_SIZE {
         bail!(

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -297,12 +297,16 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
     let encoded = base64::engine::general_purpose::STANDARD.encode(&credentials);
     let header_value = format!("Authorization: Basic {}", encoded);
 
+    let existing: usize = std::env::var("GIT_CONFIG_COUNT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
     let status = std::process::Command::new("git")
         .args(["push", "-u", "origin", "main", "--force"])
         .current_dir(path)
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "http.extraheader")
-        .env("GIT_CONFIG_VALUE_0", &header_value)
+        .env("GIT_CONFIG_COUNT", (existing + 1).to_string())
+        .env(format!("GIT_CONFIG_KEY_{existing}"), "http.extraheader")
+        .env(format!("GIT_CONFIG_VALUE_{existing}"), &header_value)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .status()


### PR DESCRIPTION
## Summary
- **Store key count**: check moved before insert — previously allowed MAX+1 keys
- **GIT_CONFIG_COUNT**: now appends to existing git config env vars instead of overwriting with `"1"`
- **--force install**: prints a warning when capabilities are auto-granted without user consent
- **Store blocked**: logs the key name and emits an error log for debuggability

## Test plan
- [x] All 144 tests pass
- [x] Clippy clean, fmt clean, spec check clean
- [ ] Manual: install a plugin with `--force` and verify warning appears
- [ ] Manual: verify store block warning shows key name

🤖 Generated with [Claude Code](https://claude.com/claude-code)