### PR TITLE
fix: address 6 crash and security findings from codebase audit

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -39,7 +39,19 @@ fn parse_repo_url(url: &str) -> Result<(String, String)> {
         }
     }
 
-    bail!("Could not parse GitHub owner/repo from remote URL: {}", url);
+    let sanitized = if let Some(at_pos) = url.find('@') {
+        if let Some(scheme_end) = url.find("://") {
+            format!("{}://<redacted>{}", &url[..scheme_end], &url[at_pos..])
+        } else {
+            url.to_string()
+        }
+    } else {
+        url.to_string()
+    };
+    bail!(
+        "Could not parse GitHub owner/repo from remote URL: {}",
+        sanitized
+    );
 }
 
 pub fn github_api_get(

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -771,8 +771,9 @@ fn search_lanes(keyword: Option<&str>, author: Option<&str>, json: bool) -> Resu
         .unwrap_or(0);
     for r in &results {
         let stars = crate::search::format_stars(r.stars);
-        let desc = if r.description.len() > 60 {
-            format!("{}...", &r.description[..57])
+        let desc = if r.description.chars().count() > 60 {
+            let truncated: String = r.description.chars().take(57).collect();
+            format!("{truncated}...")
         } else {
             r.description.clone()
         };
@@ -873,7 +874,8 @@ fn import_lanes(source: &str) -> Result<()> {
             continue;
         }
         let cmd = task_def.cmd();
-        import_content.push_str(&format!("[tasks.{task_name}]\ncmd = \"{cmd}\"\n\n"));
+        let escaped_cmd = cmd.replace('\\', "\\\\").replace('"', "\\\"");
+        import_content.push_str(&format!("[tasks.{task_name}]\ncmd = \"{escaped_cmd}\"\n\n"));
     }
 
     for (lane_name, lane) in &remote_config.lanes {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -182,9 +182,13 @@ fn apply_git_auth(cmd: &mut Command) {
         let credentials = format!("x-access-token:{}", t);
         let encoded = base64::engine::general_purpose::STANDARD.encode(&credentials);
         let header_value = format!("Authorization: Basic {}", encoded);
-        cmd.env("GIT_CONFIG_COUNT", "1")
-            .env("GIT_CONFIG_KEY_0", "http.extraheader")
-            .env("GIT_CONFIG_VALUE_0", &header_value);
+        let existing: usize = std::env::var("GIT_CONFIG_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        cmd.env("GIT_CONFIG_COUNT", (existing + 1).to_string())
+            .env(format!("GIT_CONFIG_KEY_{existing}"), "http.extraheader")
+            .env(format!("GIT_CONFIG_VALUE_{existing}"), &header_value);
     }
 }
 
@@ -544,7 +548,12 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
             );
         }
         println!();
-        if !force {
+        if force {
+            eprintln!(
+                "  {} Capabilities auto-granted via --force",
+                style("WARN").yellow()
+            );
+        } else {
             let confirm =
                 dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
                     .with_prompt("Grant these capabilities?")

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -286,11 +286,14 @@ fn run_message_loop(
             }
             OutboundMessage::Store { key, value } => {
                 if !capabilities.store {
-                    eprintln!(
-                        "  {} [{}] store blocked — capability not granted",
+                    let msg = format!(
+                        "  {} [{}] store blocked — capability not granted (key: {})",
                         style("WARN").yellow(),
-                        style(plugin_name).dim()
+                        style(plugin_name).dim(),
+                        key,
                     );
+                    eprintln!("{msg}");
+                    handle_log(plugin_name, "error", "store capability not granted");
                     continue;
                 }
                 handle_store(plugin_dir, &key, &value)?;
@@ -589,13 +592,13 @@ fn handle_store(plugin_dir: &Path, key: &str, value: &str) -> Result<()> {
     } else {
         HashMap::new()
     };
-    state.insert(key.to_string(), value.to_string());
-    if state.len() > MAX_STORE_KEY_COUNT {
+    if !state.contains_key(key) && state.len() >= MAX_STORE_KEY_COUNT {
         bail!(
             "plugin state exceeds maximum of {} keys",
             MAX_STORE_KEY_COUNT
         );
     }
+    state.insert(key.to_string(), value.to_string());
     let json = serde_json::to_string_pretty(&state).context("serializing state")?;
     if json.len() > MAX_STORE_TOTAL_SIZE {
         bail!(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -758,13 +758,14 @@ fn handle_metadata(keys: &[String]) -> Result<serde_json::Value> {
             }
             "git_tags" => {
                 let tags: Vec<String> = Command::new("git")
-                    .args(["tag", "--sort=-v:refname"])
+                    .args(["tag", "--sort=-v:refname", "--no-column"])
                     .output()
                     .ok()
                     .filter(|o| o.status.success())
                     .map(|o| {
                         String::from_utf8_lossy(&o.stdout)
                             .lines()
+                            .take(100)
                             .map(String::from)
                             .collect()
                     })
@@ -946,7 +947,23 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<std::proces
                 }
                 let status = child
                     .wait()
-                    .unwrap_or_else(|_| std::process::Command::new("true").status().unwrap());
+                    .or_else(|_| std::process::Command::new("true").status())
+                    .unwrap_or_else(|_| {
+                        // Both wait() and `true` failed — synthesize a failed status
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::process::ExitStatusExt;
+                            std::process::ExitStatus::from_raw(1)
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            // On non-unix, run cmd /C exit 1 as last resort
+                            std::process::Command::new("cmd")
+                                .args(["/C", "exit", "1"])
+                                .status()
+                                .expect("cannot create exit status")
+                        }
+                    });
                 return Ok(std::process::Output {
                     status,
                     stdout,

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -297,12 +297,16 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
     let encoded = base64::engine::general_purpose::STANDARD.encode(&credentials);
     let header_value = format!("Authorization: Basic {}", encoded);
 
+    let existing: usize = std::env::var("GIT_CONFIG_COUNT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
     let status = std::process::Command::new("git")
         .args(["push", "-u", "origin", "main", "--force"])
         .current_dir(path)
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "http.extraheader")
-        .env("GIT_CONFIG_VALUE_0", &header_value)
+        .env("GIT_CONFIG_COUNT", (existing + 1).to_string())
+        .env(format!("GIT_CONFIG_KEY_{existing}"), "http.extraheader")
+        .env(format!("GIT_CONFIG_VALUE_{existing}"), &header_value)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .status()

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,8 +54,9 @@ pub fn run(options: SearchOptions) -> Result<()> {
         println!("{}\n", style("Fledge templates on GitHub:").bold());
         for r in &results {
             let stars = format_stars(r.stars);
-            let desc = if r.description.len() > 60 {
-                format!("{}...", &r.description[..57])
+            let desc = if r.description.chars().count() > 60 {
+                let truncated: String = r.description.chars().take(57).collect();
+                format!("{truncated}...")
             } else {
                 r.description.clone()
             };

--- a/src/update.rs
+++ b/src/update.rs
@@ -393,8 +393,21 @@ fn compute_actions(
 
     for rel_path in meta.files.keys() {
         if !new_files.contains_key(rel_path) {
+            if rel_path.contains("..") || Path::new(rel_path).is_absolute() {
+                continue;
+            }
             let full_path = project_dir.join(rel_path);
             if full_path.exists() {
+                let canon_dir = project_dir
+                    .canonicalize()
+                    .unwrap_or_else(|_| project_dir.to_path_buf());
+                let canon_file = match full_path.canonicalize() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                if !canon_file.starts_with(&canon_dir) {
+                    continue;
+                }
                 actions.push(UpdateAction::Remove(PathBuf::from(rel_path)));
             }
         }


### PR DESCRIPTION
## Summary
- **UTF-8 string slicing panic** — `search.rs` and `lanes.rs` used byte indexing on descriptions, which panics on multi-byte chars (emoji, CJK). Now uses `chars().take(57)`.
- **Fallback panic** — `protocol.rs` panicked if `true` binary was missing. Now synthesizes a failed exit status instead.
- **Token leakage** — `github.rs` printed the full URL (including embedded tokens) in error messages. Now redacts credentials.
- **Unbounded git tags** — `protocol.rs` loaded all tags into memory. Now limited to 100.
- **TOML injection** — `lanes.rs` lane import didn't escape `"` or `\` in commands. Now escapes both.
- **Path traversal** — `update.rs` didn't validate `rel_path` from metadata. Now rejects `..` components, absolute paths, and verifies canonical path stays within project dir.

## Test plan
- [x] All 144 tests pass (including existing `compute_actions_removed_from_template` test)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)