### PR TITLE
fix: resolve bugs and spec issues from templates audit

### DIFF
--- a/specs/publish/publish.spec.md
+++ b/specs/publish/publish.spec.md
@@ -15,7 +15,7 @@ depends_on:
 
 ## Purpose
 
-Publishes a local fledge template, plugin, or lane directory as a GitHub repository with the appropriate discovery topic (`fledge-template`, `fledge-plugin`, or `fledge-lane`), making it discoverable via `fledge search`. Validates the content, creates or updates the GitHub repo, and pushes the files.
+Publishes a local fledge template directory as a GitHub repository with the `fledge-template` discovery topic, making it discoverable via `fledge templates search`. Validates the content, creates or updates the GitHub repo, and pushes the files. Lanes and plugins have their own publish subcommands that reuse shared helpers from this module.
 
 ## Public API
 

--- a/specs/templates/templates.spec.md
+++ b/specs/templates/templates.spec.md
@@ -144,7 +144,7 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | Module | What is used |
 |--------|-------------|
 | `init` | `discover_templates()`, `render_template()` |
-| `main` | `discover_templates()` for `fledge list` |
+| `main` | `discover_templates_with_repos()` for `fledge templates list` |
 | `prompts` | `Template`, `PromptDef` types |
 
 ## Change Log

--- a/specs/update/update.spec.md
+++ b/specs/update/update.spec.md
@@ -37,7 +37,7 @@ Re-applies a template to an existing project that was scaffolded with `fledge in
 
 | Type | Description |
 |------|-------------|
-| `UpdateOptions` | Options: dry_run, refresh, yes |
+| `UpdateOptions` | Options: dry_run, refresh |
 | `ProjectMeta` | Deserialized `.fledge/meta.toml` — source template, variables, file hashes |
 | `SourceInfo` | Template source: name, remote ref, git ref, fledge version |
 | `UpdateAction` | Enum: Add, Update, Skip (user-modified), Remove (template-deleted) |

--- a/specs/validate/validate.spec.md
+++ b/specs/validate/validate.spec.md
@@ -50,7 +50,7 @@ Validates fledge template directories for correctness before publishing or use. 
 ### Scenario: Valid template passes
 ```
 Given a directory with a valid template.toml and matching files
-When the user runs `fledge validate-template ./my-template`
+When the user runs `fledge templates validate ./my-template`
 Then a green checkmark and "valid" are shown
 And exit code is 0
 ```
@@ -58,7 +58,7 @@ And exit code is 0
 ### Scenario: Batch validation
 ```
 Given a directory containing multiple template subdirectories
-When the user runs `fledge validate-template ./templates`
+When the user runs `fledge templates validate ./templates`
 Then each template is validated independently
 And a summary line shows total templates, errors, and warnings
 ```
@@ -66,28 +66,28 @@ And a summary line shows total templates, errors, and warnings
 ### Scenario: Strict mode
 ```
 Given a template with warnings but no errors
-When the user runs `fledge validate-template ./my-template --strict`
+When the user runs `fledge templates validate ./my-template --strict`
 Then exit code is non-zero
 ```
 
 ### Scenario: JSON output
 ```
 Given any template directory
-When the user runs `fledge validate-template ./my-template --json`
+When the user runs `fledge templates validate ./my-template --json`
 Then output is a JSON array of ValidationReport objects
 ```
 
 ### Scenario: Broken Tera syntax
 ```
 Given a template with a file containing `{{ broken unclosed`
-When the user runs `fledge validate-template ./my-template`
+When the user runs `fledge templates validate ./my-template`
 Then the file is reported with a Tera syntax error
 ```
 
 ### Scenario: Undefined variable
 ```
 Given a rendered file using `{{ custom_var }}` with no matching prompt
-When the user runs `fledge validate-template ./my-template`
+When the user runs `fledge templates validate ./my-template`
 Then a warning is shown: "uses undefined variable 'custom_var'"
 ```
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -123,12 +123,7 @@ pub fn run(opts: InitOptions) -> Result<()> {
 
     // Post-create hooks (local templates are trusted); skip if required tools missing
     if !opts.no_install && reqs_ok {
-        run_post_create_hooks(
-            &template.manifest.hooks.post_create,
-            &target_dir,
-            false,
-            opts.yes,
-        )?;
+        run_post_create_hooks(&template.manifest.hooks.post_create, &target_dir, opts.yes)?;
     }
 
     // Print summary
@@ -253,12 +248,7 @@ fn run_remote(
 
     // Remote templates require confirmation before running hooks; skip if required tools missing
     if !opts.no_install && reqs_ok {
-        run_post_create_hooks(
-            &template.manifest.hooks.post_create,
-            &target_dir,
-            true,
-            opts.yes,
-        )?;
+        run_post_create_hooks(&template.manifest.hooks.post_create, &target_dir, opts.yes)?;
     }
 
     print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
@@ -287,12 +277,7 @@ fn print_summary(name: &str, target_dir: &Path, created_files: &[PathBuf], no_gi
     println!("  cd {} && get started!", style(name).cyan());
 }
 
-fn run_post_create_hooks(
-    hooks: &[String],
-    project_dir: &Path,
-    _is_remote: bool,
-    auto_yes: bool,
-) -> Result<()> {
+fn run_post_create_hooks(hooks: &[String], project_dir: &Path, auto_yes: bool) -> Result<()> {
     if hooks.is_empty() {
         return Ok(());
     }
@@ -327,13 +312,15 @@ fn run_post_create_hooks(
     for cmd in hooks {
         println!("  {} {}", style("$").dim(), style(cmd).dim());
 
-        let parts: Vec<&str> = cmd.split_whitespace().collect();
-        if parts.is_empty() {
+        if cmd.trim().is_empty() {
             bail!("Empty post-create hook command");
         }
 
-        let output = std::process::Command::new(parts[0])
-            .args(&parts[1..])
+        let shell = if cfg!(windows) { "cmd" } else { "sh" };
+        let flag = if cfg!(windows) { "/C" } else { "-c" };
+
+        let output = std::process::Command::new(shell)
+            .args([flag, cmd])
             .current_dir(project_dir)
             .output()
             .with_context(|| format!("running hook: {}", cmd))?;
@@ -689,7 +676,7 @@ ignore = ["template.toml"]
         fs::create_dir(&dir).unwrap();
 
         let hooks = vec!["touch hook-ran.txt".to_string()];
-        run_post_create_hooks(&hooks, &dir, false, true).unwrap();
+        run_post_create_hooks(&hooks, &dir, true).unwrap();
 
         assert!(dir.join("hook-ran.txt").exists());
     }
@@ -697,7 +684,7 @@ ignore = ["template.toml"]
     #[test]
     fn run_post_create_hooks_empty_is_noop() {
         let tmp = TempDir::new().unwrap();
-        let result = run_post_create_hooks(&[], tmp.path(), false, true);
+        let result = run_post_create_hooks(&[], tmp.path(), true);
         assert!(result.is_ok());
     }
 
@@ -705,7 +692,7 @@ ignore = ["template.toml"]
     fn run_post_create_hooks_failing_command_errors() {
         let tmp = TempDir::new().unwrap();
         let hooks = vec!["false".to_string()];
-        let result = run_post_create_hooks(&hooks, tmp.path(), false, true);
+        let result = run_post_create_hooks(&hooks, tmp.path(), true);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -720,7 +707,7 @@ ignore = ["template.toml"]
         fs::create_dir(&dir).unwrap();
 
         let hooks = vec!["touch hook-ran.txt".to_string()];
-        run_post_create_hooks(&hooks, &dir, true, true).unwrap();
+        run_post_create_hooks(&hooks, &dir, true).unwrap();
 
         assert!(dir.join("hook-ran.txt").exists());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1239,7 +1239,7 @@ fn list_templates() -> Result<()> {
     )?;
 
     if available.is_empty() {
-        anyhow::bail!("No templates found. Add templates to the templates/ directory or configure template_repos in ~/.config/fledge/config.toml.");
+        anyhow::bail!("No templates found. Configure template sources via `fledge config set template_repos`, add templates to the templates/ directory, or set extra_template_paths in ~/.config/fledge/config.toml.");
     }
 
     println!("{}", style("Available templates:").bold());

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -301,6 +301,12 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
+    println!(
+        "{} Force-pushing to {}/{}...",
+        style("*").cyan().bold(),
+        owner,
+        repo
+    );
     let status = std::process::Command::new("git")
         .args(["push", "-u", "origin", "main", "--force"])
         .current_dir(path)

--- a/src/search.rs
+++ b/src/search.rs
@@ -204,7 +204,7 @@ pub fn urlencod(s: &str) -> String {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
                 String::from(b as char)
             }
-            b' ' => "+".to_string(),
+            b' ' => "%20".to_string(),
             _ => format!("%{:02X}", b),
         })
         .collect()
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn urlencod_basic() {
-        assert_eq!(urlencod("hello world"), "hello+world");
+        assert_eq!(urlencod("hello world"), "hello%20world");
         assert_eq!(urlencod("topic:fledge-template"), "topic%3Afledge-template");
         assert_eq!(urlencod("rust"), "rust");
     }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -78,9 +78,6 @@ pub struct FileRules {
     #[serde(default)]
     pub render: Vec<String>,
     #[serde(default)]
-    #[allow(dead_code)]
-    pub copy: Vec<String>,
-    #[serde(default)]
     pub ignore: Vec<String>,
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -125,7 +125,6 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
     let ignore_set: Vec<&str> = manifest.files.ignore.iter().map(|s| s.as_str()).collect();
 
     let mut file_count = 0;
-    let mut tera_count = 0;
 
     for entry in WalkDir::new(path).min_depth(1) {
         let entry = match entry {
@@ -163,7 +162,6 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
                 .any(|g| matches_glob_pub(g, &rel_string));
 
         if should_render {
-            tera_count += 1;
             let file_content = match std::fs::read_to_string(entry.path()) {
                 Ok(c) => c,
                 Err(_) => continue,
@@ -248,10 +246,6 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
         );
     }
 
-    if !opts_summary(file_count, tera_count).is_empty() {
-        // summary is printed elsewhere
-    }
-
     Ok(report)
 }
 
@@ -269,10 +263,6 @@ fn extract_variables(content: &str) -> HashSet<String> {
         })
         .map(|cap| cap.get(1).unwrap().as_str().to_string())
         .collect()
-}
-
-fn opts_summary(files: usize, tera: usize) -> String {
-    format!("{files} files, {tera} rendered")
 }
 
 fn print_report(report: &ValidationReport, strict: bool, json: bool) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes all code bugs and spec inaccuracies found during the command-by-command audit of the 7 `templates` subcommands.

### Code fixes
- **Hook command parsing** — use `sh -c` instead of `split_whitespace()`, which broke commands with quoted arguments
- **Dead code removal** — `_is_remote` parameter, `FileRules.copy` field, `opts_summary()` function, `tera_count` variable
- **URL encoding** — use `%20` instead of `+` for spaces (correct RFC 3986 percent-encoding)
- **Force-push visibility** — add status message before force-pushing in `publish`
- **Error message** — mention all template sources in no-templates-found error

### Spec fixes
- `validate.spec.md` — `fledge validate-template` → `fledge templates validate`
- `templates.spec.md` — wrong function name and command for `list`
- `update.spec.md` — remove phantom `yes` field from `UpdateOptions`
- `publish.spec.md` — narrow scope to templates only (lanes/plugins have their own publish)

Documentation gaps tracked separately in #205.

## Test plan
- [x] All 144 tests pass
- [x] Clippy clean (no warnings)
- [x] `cargo fmt --check` clean
- [x] `fledge spec check` — 30 specs, 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6