### PR TITLE
docs: fill documentation and spec gaps from audits

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -33,15 +33,15 @@ fledge follows [Conventional Commits](https://www.conventionalcommits.org/). The
 | `test` | Tests |
 | `ci` | CI/CD |
 
-Breaking changes use `!` after the type (`feat!: ...`) or a `BREAKING CHANGE:` footer. They get their own section at the top.
+Commits that don't match any type are grouped under "Other".
 
 **Examples:**
 
 ```
 feat: add dark mode toggle
 fix(auth): handle expired tokens
-feat!: remove legacy config format
 chore: bump dependencies
+refactor: simplify config loader
 ```
 
 ## Versioning
@@ -51,13 +51,6 @@ fledge reads git tags that follow semver (`v1.2.3`). Each tag becomes a changelo
 ## Config
 
 No config required. fledge reads your git history directly.
-
-Optional `fledge.toml` settings:
-
-```toml
-[changelog]
-types = ["feat", "fix", "perf"]   # only include these types
-```
 
 ## Full Changelog
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -36,6 +36,14 @@ fledge templates init <name> [OPTIONS]
 - `--dry-run` - Preview without writing anything
 - `-y, --yes` - Accept all defaults, skip prompts
 
+**Behavior:**
+
+- If the template specifies `min_fledge_version`, fledge checks compatibility before proceeding.
+- If the template specifies `requires` (tool dependencies), fledge checks they're on PATH and warns about missing ones.
+- If the template doesn't include a `fledge.toml`, one is auto-generated from detected project type defaults.
+- If no git user is configured, defaults to `user.name=fledge` and `user.email=fledge@localhost`.
+- Plugin `pre_init` lifecycle hooks run before template rendering (if any plugins define them).
+
 **Examples:**
 
 ```bash
@@ -71,8 +79,8 @@ fledge templates create <name> [OPTIONS]
 - `-o, --output <OUTPUT>` - Parent directory [default: `.`]
 - `-d, --description <DESC>` - Template description (bypasses prompt)
 - `--render-patterns <PATTERNS>` - Comma-separated file patterns to render through Tera (bypasses prompt)
-- `--hooks` - Include post-create hooks scaffold (bypasses prompt)
-- `--prompts` - Include custom prompts scaffold (bypasses prompt)
+- `--hooks [BOOL]` - Include post-create hooks scaffold (bypasses prompt; accepts optional `true`/`false`, defaults to `true`)
+- `--prompts [BOOL]` - Include custom prompts scaffold (bypasses prompt; accepts optional `true`/`false`, defaults to `true`)
 - `-y, --yes` - Skip all interactive prompts (accept defaults)
 
 **Examples:**
@@ -86,7 +94,7 @@ fledge templates create my-template -d "FastAPI starter" --render-patterns "**/*
 
 ### fledge templates validate `[path]`
 
-Check a template for issues: manifest parsing, Tera syntax, undefined variables, glob coverage.
+Check a template for issues: manifest parsing, Tera syntax, undefined variables, glob coverage. GitHub Actions `${{ }}` syntax is automatically filtered out so it isn't flagged as Tera.
 
 ```
 fledge templates validate [path] [OPTIONS]
@@ -120,8 +128,10 @@ fledge templates search [query] [OPTIONS]
 
 **Options:**
 - `-a, --author <OWNER>` - Filter by author/owner
-- `-l, --limit <N>` - Max results [default: `20`]
+- `-l, --limit <N>` - Max results [default: `20`, max: `100`]
 - `--json` - JSON output
+
+**Output format:** Results show repo name, star count (abbreviated with "k" suffix for 1000+), and description (truncated to 60 characters). Topics are shown below each result.
 
 ---
 
@@ -136,7 +146,13 @@ fledge templates publish [path] [OPTIONS]
 **Options:**
 - `--org <ORG>` - Publish under an org
 - `--private` - Private repo
-- `--description <DESC>` - Override repo description
+- `--description <DESC>` - Override repo description (falls back to description in `template.toml`)
+
+**Behavior:**
+
+- If the repo already exists on GitHub, prompts for confirmation before updating.
+- Auto-initializes git (`.git`) if the template directory doesn't have one.
+- Cleans up embedded tokens from the remote URL after push.
 
 ---
 
@@ -182,6 +198,7 @@ fledge run [task] [OPTIONS]
 | Go | `go.mod` | build, test, vet |
 | Python | `pyproject.toml` / `setup.py` | pytest, ruff, mypy |
 | Ruby | `Gemfile` | rake, rspec |
+| Swift | `Package.swift` | build, test |
 | Gradle | `build.gradle` | build, test |
 | Maven | `pom.xml` | compile, test |
 
@@ -384,6 +401,8 @@ fledge review [OPTIONS]
 - `-b, --base <BRANCH>` - Base branch [default: auto-detect]
 - `-f, --file <FILE>` - Review a single file
 - `--json` - JSON output
+
+**Default branch detection:** When `--base` is not specified, fledge tries `git symbolic-ref refs/remotes/origin/HEAD`, then checks for `main` and `master` branches. Falls back to `main` if none exist.
 
 ---
 

--- a/docs/src/template-authoring.md
+++ b/docs/src/template-authoring.md
@@ -54,7 +54,9 @@ post_create = ["cargo fmt", "npm install"]
 |-----|------|----------|-------|
 | `name` | string | Yes | What you pass to `--template` |
 | `description` | string | No | Shows up in `fledge templates list` |
-| `min_fledge_version` | string | No | Minimum fledge version needed |
+| `version` | string | No | Template version (informational, shown in init summary) |
+| `min_fledge_version` | string | No | Minimum fledge version needed (checked before rendering) |
+| `requires` | string[] | No | Tools that must be on PATH (e.g. `["node", "npm"]`) |
 
 ### [prompts] section
 
@@ -172,6 +174,17 @@ cd {{ project_name_snake }}
 cargo build
 ```
 ````
+
+## Quick Start with `fledge templates create`
+
+The fastest way to start a new template:
+
+```bash
+fledge templates create my-template
+fledge templates create my-template --hooks --prompts --yes
+```
+
+This scaffolds a ready-to-edit template directory with `template.toml` and example files. See the [CLI reference](./cli-reference.md#fledge-templates-create-name) for all options.
 
 ## Building a Template from Scratch
 

--- a/docs/src/templates.md
+++ b/docs/src/templates.md
@@ -97,6 +97,24 @@ fledge templates search --author CorvidLabs
 fledge templates list    # built-in + configured repos + local paths
 ```
 
+## Updating Projects
+
+When a template gets updated, you can re-apply it to an existing project:
+
+```bash
+fledge templates update              # re-apply source template
+fledge templates update --dry-run    # preview what would change
+fledge templates update --refresh    # force re-clone remote template
+```
+
+fledge tracks file hashes in `.fledge/meta.toml` to detect changes:
+- **New files** from the template are always added.
+- **User-modified files** are skipped with a warning (your changes are preserved).
+- **Unmodified files** are updated to the latest template version.
+- **Removed files** in the new template version trigger a warning.
+
+Projects created with older fledge versions using `.fledge.toml` are automatically migrated to `.fledge/meta.toml` on the first update.
+
 ## Publishing Your Own
 
 ```bash

--- a/specs/changelog/changelog.spec.md
+++ b/specs/changelog/changelog.spec.md
@@ -1,6 +1,6 @@
 ---
 module: changelog
-version: 1
+version: 2
 status: active
 files:
   - src/changelog.rs
@@ -47,6 +47,7 @@ Generate changelogs from git tags and conventional commit messages. Groups commi
 7. `--tag` shows a single release
 8. `--json` outputs structured JSON
 9. Merge commits are excluded via `--no-merges`
+10. Breaking change indicators (`!` after type, `BREAKING CHANGE:` footer) are not parsed separately — commits with `!` are classified by their base type (e.g. `feat!:` → Features)
 
 ## Behavioral Examples
 
@@ -97,4 +98,5 @@ None (uses only git CLI and standard library)
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-22 | Document that breaking changes are not parsed separately; note no types filter config |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/checks/checks.spec.md
+++ b/specs/checks/checks.spec.md
@@ -1,6 +1,6 @@
 ---
 module: checks
-version: 3
+version: 4
 status: active
 files:
   - src/checks.rs
@@ -44,7 +44,7 @@ View CI/CD check run status for a branch using the GitHub Check Runs API. Shows 
 2. Uses GitHub token from config if available
 3. Displays check name, status, and duration for each check run
 4. Shows summary counts (passed/failed/pending)
-5. Cancelled checks display with 🚫 and count as failed; skipped checks display with ⏭️ and count as passed
+5. Cancelled checks display with 🚫 and count as failed; skipped checks display with ⏭️, show "—" for duration, and count as passed
 6. Supports `--json` for raw API output
 
 ## Behavioral Examples
@@ -84,6 +84,7 @@ $ fledge checks --branch main --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-22 | Clarify skipped check duration displays "—" |
 | 3 | 2026-04-21 | Document cancelled (🚫) and skipped (⏭️) check statuses |
 | 2 | 2026-04-20 | Update behavioral examples to use emojis instead of ASCII/Unicode symbols |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -100,7 +100,7 @@ steps = ["deps-audit", "license-check", "security-scan"]
 1. Lanes are loaded from `fledge.toml` and merged with any `.fledge/lanes/*.toml` files; `fledge.toml` definitions take precedence
 2. Each step in a lane is either a task reference (string), inline command (`{ run = "..." }`), or parallel group (`{ parallel = [...] }`) — parallel groups accept both task references and inline commands
 3. Task references must resolve to tasks defined in `[tasks]` — unknown references produce an error before execution
-4. Parallel groups spawn threads and collect results; if any thread fails and `fail_fast` is true, remaining steps are skipped
+4. Parallel groups spawn threads and collect results; if any thread fails and `fail_fast` is true, remaining steps are skipped. If a thread panics, it is treated as a failure.
 5. Steps execute sequentially by default; only `{ parallel = [...] }` groups run concurrently
 6. `fail_fast` defaults to `true` — first failure stops the lane
 7. `--init` appends language-aware default lanes to an existing `fledge.toml`

--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -45,6 +45,7 @@ Provides a unified release workflow: version bumping across language ecosystems,
 7. Tags are annotated (`git tag -a`) with message `Release vX.Y.Z`
 8. Custom version files can be specified in `[release]` section of `fledge.toml`
 9. All git commands use explicit `current_dir` for correctness in any working directory context
+10. Release has its own `classify_for_changelog()` function that mirrors `changelog::classify_commit()` — same type labels but independent implementations
 
 ## Behavioral Examples
 

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 2
+version: 3
 status: active
 files:
   - src/review.rs
@@ -39,7 +39,7 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 ## Invariants
 
 1. Requires Claude CLI (`claude`) to be installed and authenticated
-2. Base branch defaults to auto-detected default (main/master)
+2. Base branch defaults to auto-detected default: tries `git symbolic-ref refs/remotes/origin/HEAD`, then checks `main` and `master` via `git rev-parse --verify`, falls back to `main`
 3. Empty diffs bail with a clear message
 4. Shows diff stats before the AI review output
 5. `--file` flag restricts review to a single file's changes
@@ -88,5 +88,6 @@ $ fledge review --file src/github.rs
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-22 | Document default branch fallback algorithm (symbolic-ref → main → master → fallback main) |
 | 2 | 2026-04-21 | Add json field to ReviewOptions |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/templates/templates.spec.md
+++ b/specs/templates/templates.spec.md
@@ -40,7 +40,7 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 |------|-------------|
 | `Template` | A discovered template with name, description, path, and manifest |
 | `TemplateManifest` | Parsed `template.toml` with info, prompts, and file rules |
-| `TemplateInfo` | Template name, description, and min version |
+| `TemplateInfo` | Template name, description, version, min_fledge_version, and requires (tool dependencies) |
 | `PromptDef` | Custom prompt definition with message and optional default |
 | `FileRules` | Glob patterns for render, copy, and ignore |
 | `Hooks` | Post-create lifecycle hooks (e.g., `npm install`, `bun install`) |

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 4
+version: 5
 status: active
 files:
   - src/work.rs
@@ -69,6 +69,8 @@ Provides opinionated git workflow commands for feature branch development. `fled
 10. `--prefix` bypasses type validation and format template, using raw `prefix/name`
 11. `--issue N` prepends the issue number to the branch name segment: `N-name`
 12. `generate_title_from_branch` strips any valid branch type prefix (feat/, feature/, fix/, bug/, chore/, task/, docs/, hotfix/, refactor/)
+13. Plugin lifecycle hook `post_work_start` runs after branch creation (errors silently ignored via `.ok()`)
+14. Plugin lifecycle hook `pre_pr` runs before PR creation (errors propagate and abort the PR)
 
 ## Behavioral Examples
 
@@ -168,5 +170,6 @@ $ fledge work status
 |---------|------|---------|
 | 1 | 2026-04-19 | Initial spec for fledge work |
 | 2 | 2026-04-20 | Flexible branch types, configurable format, `{author}` support, `--type`/`--issue`/`--prefix` flags |
+| 5 | 2026-04-22 | Document lifecycle hooks: post_work_start (silent) and pre_pr (propagating) |
 | 4 | 2026-04-21 | Correct load_work_config as internal (not exported) |
 | 3 | 2026-04-20 | Added `feature`, `bug`, `task` as valid branch types |


### PR DESCRIPTION
## Summary

Fills all documentation and spec gaps identified in issues #205 and #207.

**Issue #205 — Templates subcommand docs:**
- `templates init`: document `template.requires`, `min_fledge_version` check, `pre_init` hook, auto-generated fledge.toml, git defaults
- `templates create`: fix `--hooks`/`--prompts` to show optional bool values
- `templates search`: document 100-result cap and output formatting
- `templates publish`: document existing repo prompt, auto git init, token cleanup, description fallback
- `templates validate`: note GitHub Actions `${{ }}` filtering
- `templates update`: add full section to templates user guide
- Template authoring guide: add `version` and `requires` fields, mention `fledge templates create`

**Issue #207 — Dev loop docs:**
- `run`: add Swift to auto-detection table
- `review`: document default branch fallback algorithm
- `changelog`: fix inaccurate breaking changes claim, remove undocumented `[changelog].types` config
- `work` spec: document `post_work_start` and `pre_pr` lifecycle hooks
- `release` spec: note independent `classify_for_changelog()` function
- `lanes` spec: add thread panic behavior note
- `checks` spec: clarify skipped check duration shows "—"

Closes #205, closes #207.

## Test plan

- [x] `cargo run -- spec check` — 30 specs, 0 errors
- [x] Pre-commit hooks (specs, fmt, clippy) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)