### PR TITLE
fix: resolve audit round 2 bugs and doc inaccuracies

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,13 +25,15 @@ fledge follows [Conventional Commits](https://www.conventionalcommits.org/). The
 | Type | Section |
 |------|---------|
 | `feat` | Features |
-| `fix` | Bug Fixes |
+| `fix` | Fixes |
 | `docs` | Documentation |
-| `chore` | Maintenance |
+| `style` | Style |
 | `refactor` | Refactoring |
 | `perf` | Performance |
 | `test` | Tests |
-| `ci` | CI/CD |
+| `build` | Build |
+| `ci` | CI |
+| `chore` | Chores |
 
 Commits that don't match any type are grouped under "Other".
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -42,7 +42,7 @@ fledge templates init <name> [OPTIONS]
 - If the template specifies `requires` (tool dependencies), fledge checks they're on PATH and warns about missing ones.
 - If the template doesn't include a `fledge.toml`, one is auto-generated from detected project type defaults.
 - If no git user is configured, defaults to `user.name=fledge` and `user.email=fledge@localhost`.
-- Plugin `pre_init` lifecycle hooks run before template rendering (if any plugins define them).
+- Plugin `pre_init` lifecycle hooks run before config loading (if any plugins define them).
 
 **Examples:**
 
@@ -183,7 +183,7 @@ fledge run [task] [OPTIONS]
 **Options:**
 - `--init` - Generate `fledge.toml` with detected defaults
 - `-l, --list` - List available tasks
-- `--lang <LANG>` - Override detected project language (swift, python, rust, node, go)
+- `--lang <LANG>` - Override detected project language (swift, python, rust, node, go, ruby, java-gradle, java-maven)
 
 **Zero-config mode** (no `fledge.toml`): Fledge detects your project type from marker files and provides default tasks automatically. For Node.js projects, it also detects your package manager (npm, bun, yarn, pnpm) from lockfiles.
 
@@ -346,7 +346,7 @@ fledge work <start|pr|status> [OPTIONS]
 
 **Options for `work start`:**
 
-- `-t, --branch-type <TYPE>` - Branch type: `feat`, `fix`, `chore`, `docs`, `hotfix`, `refactor` [default: `feat`]
+- `-t, --branch-type <TYPE>` - Branch type: `feat`, `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, `refactor` [default: `feat`]
 - `-i, --issue <NUMBER>` - Link to GitHub issue (prefixes branch name with issue number)
 - `--prefix <PREFIX>` - Override branch prefix entirely (e.g. `user/leif`)
 - `--base <BRANCH>` - Base branch [default: `main`]
@@ -645,7 +645,7 @@ fledge plugins validate --json
 
 ### fledge completions `[shell]`
 
-Shell completions for bash, zsh, fish, powershell.
+Shell completions for bash, zsh, fish.
 
 ```
 fledge completions [shell] [OPTIONS]

--- a/docs/src/develop.md
+++ b/docs/src/develop.md
@@ -26,7 +26,7 @@ fledge work pr --title "Add auth middleware"
 This creates a branch using your configured format (default: `{author}/{type}/{name}`), and `fledge work pr` opens a pull request against your base branch with sensible defaults.
 
 **Options for `work start`:**
-- `-t, --branch-type <TYPE>` - Branch type: `feat`, `fix`, `chore`, `docs`, `hotfix`, `refactor` [default: `feat`]
+- `-t, --branch-type <TYPE>` - Branch type: `feat`, `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, `refactor` [default: `feat`]
 - `-i, --issue <NUMBER>` - Link to GitHub issue (prefixes branch name with issue number)
 - `--prefix <PREFIX>` - Override branch prefix entirely (e.g. `user/leif`)
 - `--base <branch>` - Base branch (defaults to `main`)

--- a/docs/src/doctor.md
+++ b/docs/src/doctor.md
@@ -11,24 +11,33 @@ fledge doctor --json
 
 ## What It Checks
 
-| Check | What it looks for |
-|-------|-------------------|
-| **Rust toolchain** | `cargo`, `rustc`, `clippy`, `rustfmt` |
-| **Node.js** | `node`, `npm`, `bun`, `yarn`, `pnpm` |
-| **Go** | `go` |
-| **Python** | `python3`, `pip`, `ruff` |
-| **Git** | `git`, configured user name and email |
-| **GitHub** | Token present (`GITHUB_TOKEN` or config) |
-| **Config** | Valid `~/.config/fledge/config.toml` |
-| **Templates** | Configured template paths and repos are accessible |
+Doctor auto-detects your project type and checks relevant tools:
+
+**Toolchain** (project-type-specific):
+
+| Project type | What it checks |
+|--------------|----------------|
+| Rust | `rustc`, `cargo`, `cargo-clippy`, `rustfmt` |
+| Node.js | `node`, `npm` or `yarn` |
+| Go | `go` |
+| Python | `python3` or `python`, `pip` |
+| Ruby | `ruby`, `gem`, `bundler` |
+| Java (Gradle) | `java`, `gradle` |
+| Java (Maven) | `java`, `mvn` |
+| Swift | `swift`, `swiftlint` (optional) |
+
+**Dependencies** — checks for lockfiles and build artifacts (e.g. `Cargo.lock`, `node_modules/`, `go.sum`).
+
+**Git** — `git` installed, repository initialized, remote configured, working tree status.
+
+**AI** — `claude` CLI installed (enables `fledge review` and `fledge ask`).
 
 ## Output
 
-Doctor reports each check as passing, warning, or failing:
+Doctor reports each check as passing or failing:
 
-- **Pass**: tool is installed and working
-- **Warn**: tool is missing but only needed for specific features
-- **Fail**: something is broken that will cause errors
+- **Pass** (✅): tool is installed and working, with version info
+- **Fail** (❌): tool is missing or errored, with a suggested fix command
 
 ## When to Run It
 

--- a/docs/src/github-integration.md
+++ b/docs/src/github-integration.md
@@ -41,7 +41,7 @@ fledge work start my-feature --prefix user/leif
 # → creates user/leif/my-feature (custom prefix, overrides format)
 ```
 
-Branch names get sanitized automatically (spaces → hyphens, special chars removed). The default type is `feat`, but you can use `fix`, `chore`, `docs`, `hotfix`, or `refactor` via `--branch-type` (or `-t` for short). The branch format is configurable in `fledge.toml`.
+Branch names get sanitized automatically (spaces → hyphens, special chars removed). The default type is `feat`, but you can use `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, or `refactor` via `--branch-type` (or `-t` for short). The branch format is configurable in `fledge.toml`.
 
 ### Open a PR
 

--- a/specs/init/init.spec.md
+++ b/specs/init/init.spec.md
@@ -50,7 +50,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 2. At least one template must be available
 3. Git init creates an initial commit with all scaffolded files
 4. Directory is created before template rendering begins
-5. `.fledge.toml` is written after rendering, before git init, recording template source and file hashes
+5. `.fledge/meta.toml` is written after rendering, before git init, recording template source and file hashes for future `fledge update`
 6. If the template does not include a `fledge.toml`, one is generated from auto-detected project type defaults
 
 ## Behavioral Examples

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -60,12 +60,12 @@ Available tasks:
 
 # Run a task
 $ fledge run build
-▸ Running task: build
+▶️ Running task: build
 
 # Run a task with dependencies
 $ fledge run ci
-▸ Running task: lint
-▸ Running task: ci
+▶️ Running task: lint
+▶️ Running task: ci
 
 # Init a new fledge.toml
 $ fledge run --init

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -108,7 +108,7 @@ pub fn run(opts: ChecksOptions) -> Result<()> {
         let duration = match (check["started_at"].as_str(), check["completed_at"].as_str()) {
             (Some(start), Some(end)) => format_duration(start, end),
             (Some(_), None) => "running...".to_string(),
-            _ => String::new(),
+            _ => "\u{2014}".to_string(),
         };
 
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ enum Commands {
         /// List available tasks
         #[arg(short, long)]
         list: bool,
-        /// Override detected project language (e.g. swift, python, rust, node, go)
+        /// Override detected project language (e.g. rust, node, go, python, swift, ruby, java-gradle, java-maven)
         #[arg(long)]
         lang: Option<String>,
     },

--- a/src/prs.rs
+++ b/src/prs.rs
@@ -177,6 +177,7 @@ fn print_pr_line(pr: &serde_json::Value) {
     let draft = pr["draft"].as_bool().unwrap_or(false);
     let updated = pr["updated_at"].as_str().unwrap_or("");
     let head = pr["head"]["ref"].as_str().unwrap_or("?");
+    let base = pr["base"]["ref"].as_str().unwrap_or("?");
 
     let state_icon = if draft {
         style("📝").dim()
@@ -194,7 +195,7 @@ fn print_pr_line(pr: &serde_json::Value) {
         style(format!("#{:<5}", number)).cyan(),
         title,
         style(head).dim(),
-        style("base").dim(),
+        style(base).dim(),
         style(github::format_relative_time(updated)).dim()
     );
 }


### PR DESCRIPTION
## Summary

Fixes the 2 code bugs and 10 doc/spec inaccuracies found in the full command audit.

### Bug fixes
- **prs**: show actual base branch name instead of hardcoded `"base"` string (`src/prs.rs:197`)
- **checks**: show em-dash (`—`) for skipped check duration instead of empty string (`src/checks.rs:111`)

### Doc/spec corrections
- **init spec**: `.fledge.toml` → `.fledge/meta.toml` (matches code)
- **init docs**: plugin hook runs before config loading, not template rendering
- **completions**: remove false powershell claim (only bash/zsh/fish supported)
- **work**: add missing branch types (`feature`, `bug`, `task`) across cli-reference, develop, github-integration docs
- **changelog**: fix section names (Fixes not Bug Fixes, Chores not Maintenance, CI not CI/CD) and add missing `build`/`style` types
- **run**: add `ruby`, `java-gradle`, `java-maven` to `--lang` docs and CLI help text
- **run spec**: fix arrow character to match code (`▶️` not `▸`)
- **doctor**: rewrite to match actual implementation (Toolchain/Dependencies/Git/AI sections, not fictional GitHub/Config/Templates checks)

## Test plan
- [x] All 144 tests pass
- [x] Clippy clean
- [x] Spec check passes (30/30)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6