### PR TITLE
feat: harden release workflow and fix doc inaccuracies

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -194,13 +194,13 @@ fledge run [task] [OPTIONS]
 | Project | Detected by | Default tasks |
 |---------|------------|---------------|
 | Rust | `Cargo.toml` | build, test, clippy, fmt |
-| Node.js | `package.json` | build, test, lint, dev (if scripts exist) |
+| Node.js | `package.json` | test, build, lint, dev (if scripts exist) |
 | Go | `go.mod` | build, test, vet |
-| Python | `pyproject.toml` / `setup.py` | pytest, ruff, mypy |
+| Python | `pyproject.toml` / `setup.py` | test, lint, fmt |
 | Ruby | `Gemfile` | test, lint |
 | Swift | `Package.swift` | build, test |
-| Gradle | `build.gradle` | build, test, lint |
-| Maven | `pom.xml` | build, test, lint |
+| Gradle | `build.gradle` | build, test |
+| Maven | `pom.xml` | build, test |
 
 ```bash
 fledge run test          # works immediately in any detected project

--- a/docs/src/getting-started/existing-projects.md
+++ b/docs/src/getting-started/existing-projects.md
@@ -20,12 +20,12 @@ No `fledge.toml` needed. Fledge looks for marker files (`Cargo.toml`, `package.j
 | Project Type | Detected By | Default Tasks |
 |-------------|------------|---------------|
 | Rust | `Cargo.toml` | build, test, clippy, fmt |
-| Node.js | `package.json` | build, test, lint, dev (if scripts exist) |
+| Node.js | `package.json` | test, build, lint, dev (if scripts exist) |
 | Go | `go.mod` | build, test, vet |
-| Python | `pyproject.toml` / `setup.py` | pytest, ruff, mypy |
-| Ruby | `Gemfile` | rake, rspec |
+| Python | `pyproject.toml` / `setup.py` | test, lint, fmt |
+| Ruby | `Gemfile` | test, lint |
 | Java (Gradle) | `build.gradle` | build, test |
-| Java (Maven) | `pom.xml` | compile, test |
+| Java (Maven) | `pom.xml` | build, test |
 
 For Node.js projects, fledge also detects your package manager (npm, bun, yarn, pnpm) from lockfiles and uses the right one.
 

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -208,7 +208,7 @@ steps = [
 | Rust | `Cargo.toml` | `ci` (fmt, lint, test, build), `check` (parallel fmt+lint, test) |
 | Node.js | `package.json` | `ci` (lint, test, build), `check` (parallel lint+test) |
 | Go | `go.mod` | `ci` (fmt, lint, test, build), `check` (parallel fmt+lint, test) |
-| Python | `pyproject.toml` | `ci` (fmt, lint, typecheck, test), `check` (parallel fmt+lint, test) |
+| Python | `pyproject.toml` | `ci` (fmt, lint, test), `check` (parallel fmt+lint, test) |
 
 ## CLI
 

--- a/docs/src/pillars.md
+++ b/docs/src/pillars.md
@@ -36,7 +36,7 @@ Check your code before it ships. AI review, codebase Q&A, code metrics, and depe
 
 Manage issues, review PRs, check CI status, generate changelogs, and cut releases. Everything you need to get code out the door.
 
-**Commands:** `issues`, `prs`, `checks`, `changelog`, `release`, `release`
+**Commands:** `issues`, `prs`, `checks`, `changelog`, `release`
 
 ## Extend: Grow the tool
 

--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -42,7 +42,7 @@ Provides a unified release workflow: version bumping across language ecosystems,
 4. `--dry-run` never modifies any files or creates commits/tags
 5. Changelog entries are inserted before existing entries (newest first)
 6. The release commit message follows conventional commit format: `chore: release vX.Y.Z`
-7. Tags are annotated (`git tag -a`) with message `Release vX.Y.Z`
+7. Tags are annotated (`git tag -a`) with message `Release vX.Y.Z`; creating a tag that already exists is rejected with a clear error
 8. Custom version files can be specified in `[release]` section of `fledge.toml`
 9. All git commands use explicit `current_dir` for correctness in any working directory context
 10. Release has its own `classify_for_changelog()` function that mirrors `changelog::classify_commit()` — same type labels but independent implementations
@@ -104,6 +104,7 @@ Then version.txt is bumped alongside auto-detected files
 | No version found | No version file and no git tags |
 | Invalid version string | Explicit version doesn't match semver format |
 | Pre-lane failure | The specified pre-release lane fails |
+| Tag already exists | Target version tag already exists in the repo |
 | Git operations fail | Tag creation, commit, or push fails |
 
 ## Dependencies

--- a/src/release.rs
+++ b/src/release.rs
@@ -613,6 +613,20 @@ fn create_release_commit(
 
 fn create_tag(dir: &Path, version: &Version) -> Result<()> {
     let tag = format!("v{version}");
+
+    let check = Command::new("git")
+        .args(["tag", "-l", &tag])
+        .current_dir(dir)
+        .output()
+        .context("checking existing tags")?;
+    if !String::from_utf8_lossy(&check.stdout).trim().is_empty() {
+        bail!(
+            "Tag '{}' already exists. Delete it first with: git tag -d {}",
+            tag,
+            tag
+        );
+    }
+
     let output = Command::new("git")
         .args(["tag", "-a", &tag, "-m", &format!("Release {tag}")])
         .current_dir(dir)
@@ -1198,5 +1212,205 @@ files = ["version.txt"]
 
         let content = fs::read_to_string(tmp.path().join("version.txt")).unwrap();
         assert!(content.contains("0.2.0"));
+    }
+
+    #[test]
+    fn read_gemspec_version_test() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("my_gem.gemspec"),
+            r#"
+Gem::Specification.new do |s|
+  s.name = "my_gem"
+  s.version = "1.4.2"
+  s.summary = "A test gem"
+end
+"#,
+        )
+        .unwrap();
+        assert_eq!(read_gemspec_version(tmp.path()).unwrap(), "1.4.2");
+    }
+
+    #[test]
+    fn read_gemspec_version_single_quotes() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("my_gem.gemspec"),
+            "Gem::Specification.new do |s|\n  s.version = '2.0.1'\nend\n",
+        )
+        .unwrap();
+        assert_eq!(read_gemspec_version(tmp.path()).unwrap(), "2.0.1");
+    }
+
+    #[test]
+    fn read_python_version_from_setup_cfg() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("setup.cfg"),
+            "[metadata]\nname = my_pkg\nversion = 3.1.0\n",
+        )
+        .unwrap();
+        assert_eq!(read_python_version(tmp.path()).unwrap(), "3.1.0");
+    }
+
+    #[test]
+    fn read_python_version_pyproject_takes_priority() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("pyproject.toml"),
+            "[project]\nname = \"test\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("setup.cfg"),
+            "[metadata]\nversion = 2.0.0\n",
+        )
+        .unwrap();
+        assert_eq!(read_python_version(tmp.path()).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn duplicate_tag_prevented() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(tmp.path(), "test.txt", "hello");
+
+        Command::new("git")
+            .args(["tag", "-a", "v1.0.0", "-m", "v1.0.0"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+
+        let version = parse_version("1.0.0").unwrap();
+        let result = create_tag(tmp.path(), &version);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("already exists"),
+            "expected 'already exists' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn bump_setup_cfg() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(
+            tmp.path(),
+            "setup.cfg",
+            "[metadata]\nname = test\nversion = 0.5.0\n",
+        );
+        commit_file(tmp.path(), "pyproject.toml", "[build-system]\n");
+
+        let new_ver = parse_version("0.6.0").unwrap();
+        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
+        assert!(result.files_bumped.contains(&"setup.cfg".to_string()));
+        let content = fs::read_to_string(tmp.path().join("setup.cfg")).unwrap();
+        assert!(content.contains("0.6.0"));
+    }
+
+    #[test]
+    fn bump_pom_xml() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0.0</version>
+</project>"#;
+        commit_file(tmp.path(), "pom.xml", pom);
+
+        let new_ver = parse_version("1.1.0").unwrap();
+        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
+        assert!(result.files_bumped.contains(&"pom.xml".to_string()));
+        let content = fs::read_to_string(tmp.path().join("pom.xml")).unwrap();
+        assert!(content.contains("<version>1.1.0</version>"));
+    }
+
+    #[test]
+    fn bump_gradle() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(
+            tmp.path(),
+            "build.gradle.kts",
+            "plugins { id(\"java\") }\nversion = \"0.3.0\"\n",
+        );
+
+        let new_ver = parse_version("0.4.0").unwrap();
+        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
+        assert!(result
+            .files_bumped
+            .contains(&"build.gradle.kts".to_string()));
+        let content = fs::read_to_string(tmp.path().join("build.gradle.kts")).unwrap();
+        assert!(content.contains("\"0.4.0\""));
+    }
+
+    #[test]
+    fn changelog_created_fresh() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(tmp.path(), "a.txt", "a");
+
+        let tmp_path = tmp.path().to_path_buf();
+        let version = parse_version("0.1.0").unwrap();
+        with_cwd(&tmp_path, || {
+            generate_changelog_entry(&tmp_path, &version).unwrap();
+        });
+
+        let changelog = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
+        assert!(changelog.starts_with("# Changelog"));
+        assert!(changelog.contains("[v0.1.0]"));
+    }
+
+    #[test]
+    fn release_with_no_tag_flag() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(
+            tmp.path(),
+            "Cargo.toml",
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        );
+
+        Command::new("git")
+            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+
+        commit_file(tmp.path(), "src.rs", "fn main() {}");
+
+        let tmp_path = tmp.path().to_path_buf();
+        let result = with_cwd(&tmp_path, || {
+            run(ReleaseOptions {
+                bump: "patch".to_string(),
+                dry_run: false,
+                no_tag: true,
+                no_changelog: true,
+                push: false,
+                pre_lane: None,
+                allow_dirty: false,
+            })
+        });
+
+        assert!(result.is_ok());
+
+        let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
+        assert!(content.contains("version = \"0.1.1\""));
+
+        let tag_output = Command::new("git")
+            .args(["tag", "-l", "v0.1.1"])
+            .current_dir(&tmp_path)
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&tag_output.stdout)
+                .trim()
+                .is_empty(),
+            "no tag should be created with --no-tag"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Release hardening**: Added duplicate tag pre-check (prevents confusing git errors), 10 new tests covering previously untested paths (gemspec version reading, setup.cfg fallback, pyproject priority, pom.xml/gradle/setup.cfg bumping, fresh changelog creation, --no-tag flag, duplicate tag detection), and updated release spec with tag-exists error case
- **Doc fixes**: Fixed 7 inaccuracies found during full docs audit — incorrect default tasks for Python/Ruby/Gradle/Maven, duplicate command in pillars.md, and wrong Python lane definition in lanes.md

## Test plan

- [x] All 574 unit tests pass (was 564, +10 new release tests)
- [x] All 144 integration tests pass
- [x] Clippy clean, fmt clean
- [x] All 30 specs pass
- [x] New `duplicate_tag_prevented` test verifies the pre-check works
- [x] Doc claims verified against actual `auto_tasks()` and `lane_defaults()` code

🤖 Generated with [Claude Code](https://claude.com/claude-code)