### PR TITLE
fix: use plural command names in docs tables

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -13,11 +13,11 @@ I kept setting up the same boilerplate across projects. CI workflows, linters, t
 | Pillar | Tagline | Commands |
 |--------|---------|----------|
 | **Start** | Scaffold and discover | `templates init`, `templates list`, `templates search`, `templates create`, `templates publish`, `templates validate`, `templates update` |
-| **Build** | Configure and run | `run`, `lane`, `config`, `doctor` |
+| **Build** | Configure and run | `run`, `lanes`, `config`, `doctor` |
 | **Develop** | Branch and spec | `work`, `spec` |
 | **Review** | Quality and insight | `review`, `ask`, `metrics`, `deps` |
 | **Ship** | Track and release | `issues`, `prs`, `checks`, `changelog`, `release` |
-| **Extend** | Grow the tool | `plugin`, `completions` |
+| **Extend** | Grow the tool | `plugins`, `completions` |
 
 Start a project, build your tasks and config, develop features on branches, review quality before merging, ship releases. Extend runs alongside everything with plugins and completions.
 

--- a/docs/src/pillars.md
+++ b/docs/src/pillars.md
@@ -18,7 +18,7 @@ Get a project off the ground. Pick a template (built-in, remote, or your own), s
 
 Define your tasks, wire them into pipelines, set your defaults, and make sure your environment is ready. This is where `fledge.toml` lives.
 
-**Commands:** `run`, `lane`, `config`, `doctor`
+**Commands:** `run`, `lanes`, `config`, `doctor`
 
 ## Develop: Branch and spec
 
@@ -42,4 +42,4 @@ Manage issues, review PRs, check CI status, generate changelogs, and cut release
 
 Install community plugins, write your own, and set up shell completions.
 
-**Commands:** `plugin`, `completions`
+**Commands:** `plugins`, `completions`


### PR DESCRIPTION
## Summary
- Fixed command tables in `introduction.md` and `pillars.md` that listed `lane` and `plugin` (singular alias forms) instead of the primary `lanes` and `plugins` command names
- This was causing the docs site to show the old singular naming in the pillar overview tables

## Test plan
- [x] All 144 tests pass
- [x] Docs will auto-deploy via GitHub Pages when merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)