### PR TITLE
Dogfood fledge in CONTRIBUTING.md, add uv.lock deps support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,14 @@ cargo build
 cargo test
 ```
 
-### Run from Source
+Once built, use fledge itself for development (we dogfood our own CLI):
 
 ```bash
-cargo run -- init my-test --template rust-cli
+cargo run -- run build
 cargo run -- run test
 ```
+
+See `fledge.toml` at the repo root for all available tasks and lanes.
 
 ## Development Workflow
 
@@ -35,10 +37,8 @@ Check [existing issues](https://github.com/CorvidLabs/fledge/issues) first. If y
 ### 2. Create a Branch
 
 ```bash
-# Use fledge itself for branch management
+# Use fledge for branch management
 cargo run -- work start my-feature
-# Or manually
-git checkout -b feat/my-feature
 ```
 
 Branch naming convention: `{type}/{description}` where type is `feat`, `fix`, `chore`, `docs`, `refactor`, or `hotfix`.
@@ -53,21 +53,22 @@ Branch naming convention: `{type}/{description}` where type is `feat`, `fix`, `c
 ### 4. Verify
 
 ```bash
-cargo build                        # compiles
-cargo test                         # all tests pass
-cargo clippy -- -D warnings        # no lint warnings
-cargo fmt --check                  # formatting is correct
+# Run the full pre-commit lane (fmt, lint, test, spec check)
+cargo run -- lanes run pre-commit
+
+# Or check individual steps
+cargo run -- run fmt               # formatting is correct
+cargo run -- run lint              # no lint warnings
+cargo run -- run test              # all tests pass
 cargo run -- spec check            # specs are in sync
 ```
 
-All four checks must pass before submitting a PR.
+All checks in the `pre-commit` lane must pass before submitting a PR.
 
 ### 5. Submit a Pull Request
 
 ```bash
-# Use fledge
 cargo run -- work pr --title "Add my feature"
-# Or use gh/GitHub
 ```
 
 In your PR description:

--- a/fledge.toml
+++ b/fledge.toml
@@ -41,6 +41,14 @@ steps = ["docs-build"]
 [lanes.release]
 description = "Pre-release validation"
 steps = ["fmt", "lint", "test", "build", "spec-check", "validate-templates", "docs-build"]
+[tasks.deps]
+cmd = "cargo run -- deps"
+description = "List project dependencies"
+
+[tasks.deps-outdated]
+cmd = "cargo run -- deps --outdated"
+description = "Check for outdated dependencies"
+
 [tasks.audit]
 cmd = "cargo audit"
 description = "Check dependencies for known vulnerabilities"

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -357,13 +357,18 @@ fn parse_python_deps(dir: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
         return parse_pipfile_lock(&pipfile_lock);
     }
 
+    let uv_lock = dir.join("uv.lock");
+    if uv_lock.exists() {
+        return parse_uv_lock(&uv_lock);
+    }
+
     let poetry_lock = dir.join("poetry.lock");
     if poetry_lock.exists() {
         return parse_poetry_lock(&poetry_lock);
     }
 
     bail!(
-        "No Python lock/requirements file found (requirements.txt, Pipfile.lock, or poetry.lock)."
+        "No Python lock/requirements file found (requirements.txt, Pipfile.lock, uv.lock, or poetry.lock)."
     );
 }
 
@@ -445,6 +450,28 @@ fn parse_poetry_lock(path: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
     Ok((Some(path.to_path_buf()), deps))
 }
 
+fn parse_uv_lock(path: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
+    let content = std::fs::read_to_string(path).context("reading uv.lock")?;
+    let mut deps = Vec::new();
+    let mut current_name: Option<String> = None;
+
+    for line in content.lines() {
+        if line.starts_with("name = ") {
+            current_name = Some(unquote(line.trim_start_matches("name = ")));
+        } else if line.starts_with("version = ") {
+            if let Some(name) = current_name.take() {
+                let version = unquote(line.trim_start_matches("version = "));
+                deps.push(Dep { name, version });
+            }
+        } else if line == "[[package]]" {
+            current_name = None;
+        }
+    }
+
+    deps.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok((Some(path.to_path_buf()), deps))
+}
+
 fn parse_gemfile_lock(dir: &Path) -> Result<(Option<PathBuf>, Vec<Dep>)> {
     let lock_path = dir.join("Gemfile.lock");
     if !lock_path.exists() {
@@ -488,7 +515,13 @@ fn run_outdated(project_type: &str, dir: &Path) -> Result<()> {
         "rust" => ("cargo", vec!["outdated"], "cargo-outdated"),
         "node" => ("npm", vec!["outdated"], "npm"),
         "go" => ("go", vec!["list", "-m", "-u", "all"], "go"),
-        "python" => ("pip", vec!["list", "--outdated"], "pip"),
+        "python" => {
+            if dir.join("uv.lock").exists() {
+                ("uv", vec!["pip", "list", "--outdated"], "uv")
+            } else {
+                ("pip", vec!["list", "--outdated"], "pip")
+            }
+        }
         "ruby" => ("bundle", vec!["outdated"], "bundler"),
         _ => bail!("Outdated check not supported for {}", project_type),
     };
@@ -695,6 +728,37 @@ version = "4.5.0"
         assert_eq!(deps.len(), 2);
         assert_eq!(deps[0].name, "flask");
         assert_eq!(deps[0].version, "2.3.0");
+    }
+
+    #[test]
+    fn parse_uv_lock_basic() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("uv.lock");
+        std::fs::write(
+            &lock_path,
+            r#"version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "fastapi"
+version = "0.111.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "pydantic"
+version = "2.7.4"
+source = { registry = "https://pypi.org/simple" }
+"#,
+        )
+        .unwrap();
+
+        let (lock, deps) = parse_uv_lock(&lock_path).unwrap();
+        assert!(lock.is_some());
+        assert_eq!(deps.len(), 2);
+        assert_eq!(deps[0].name, "fastapi");
+        assert_eq!(deps[0].version, "0.111.0");
+        assert_eq!(deps[1].name, "pydantic");
+        assert_eq!(deps[1].version, "2.7.4");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: Replace raw `cargo` commands with fledge equivalents (`fledge run`, `fledge lanes run pre-commit`, `fledge work`) — eat our own dog food
- **deps**: Add `uv.lock` parsing for Python projects (uv is the fast Python package manager gaining adoption)
- **deps**: Use `uv pip list --outdated` when a `uv.lock` is detected
- **fledge.toml**: Add `deps` and `deps-outdated` tasks

## Test plan
- [x] All 144 tests pass
- [x] Clippy clean, fmt clean, spec check passes
- [x] New `parse_uv_lock_basic` test verifies uv.lock parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)