### PR TITLE
chore: fully dogfood fledge in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Documentation lives in `docs/src/` and is built with [mdBook](https://rust-lang.
 cargo install mdbook
 
 # Serve locally
-cd docs && mdbook serve
+cargo run -- run docs-serve
 ```
 
 ## Code Guidelines
@@ -130,8 +130,8 @@ cd docs && mdbook serve
 
 ### Style
 
-- Run `cargo fmt` before committing
-- Run `cargo clippy -- -D warnings` and fix all warnings
+- Run `cargo run -- run fmt-fix` before committing (or `fledge run fmt-fix` if installed)
+- Run `cargo run -- run lint` and fix all warnings
 - No `unsafe` code without discussion
 - Prefer standard library types over external crates when practical
 
@@ -142,6 +142,15 @@ Every module has a spec in `specs/<module>/`. The spec is the source of truth fo
 1. Read its spec
 2. If your change alters behavior, update the spec first
 3. Run `cargo run -- spec check` to verify alignment
+
+### Dependencies
+
+Check dependency health with:
+
+```bash
+cargo run -- deps              # list all dependencies
+cargo run -- deps --outdated   # check for outdated deps
+```
 
 ## Release Process
 

--- a/fledge.toml
+++ b/fledge.toml
@@ -41,14 +41,6 @@ steps = ["docs-build"]
 [lanes.release]
 description = "Pre-release validation"
 steps = ["fmt", "lint", "test", "build", "spec-check", "validate-templates", "docs-build"]
-[tasks.deps]
-cmd = "cargo run -- deps"
-description = "List project dependencies"
-
-[tasks.deps-outdated]
-cmd = "cargo run -- deps --outdated"
-description = "Check for outdated dependencies"
-
 [tasks.audit]
 cmd = "cargo audit"
 description = "Check dependencies for known vulnerabilities"


### PR DESCRIPTION
## Summary

- Replace raw `cargo fmt` / `cargo clippy` in Style section with `cargo run -- run fmt-fix` / `cargo run -- run lint`
- Replace `cd docs && mdbook serve` with `cargo run -- run docs-serve`
- Add Dependencies section documenting `fledge deps` / `fledge deps --outdated`
- Remove redundant `deps` and `deps-outdated` tasks from fledge.toml — `fledge deps` is a built-in command, no need to wrap it as a task

## Test plan

- [x] All 144 integration tests pass
- [x] Pre-commit hooks pass (specs, fmt, clippy)
- [ ] Verify `cargo run -- run docs-serve` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)