### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-23
+
+### Added
+
+- Plugin trust tiers and `fledge plugin audit` command — verify plugin provenance (#220)
+- Trust tier badges for templates and lanes — warnings for unverified sources (#221)
+- Non-TTY support for AI agents and CI environments — all interactive prompts gracefully degrade (#222)
+- `uv.lock` support in `fledge deps` for Python projects (#223)
+- Use cases page and enhanced review documentation (#219)
+
+### Fixed
+
+- Proper TOML parsing for `uv.lock` instead of fragile line-based parsing (#224)
+- Plural command names (`lanes`, `plugins`) used consistently across all docs and specs (#216, #217, #218)
+
+### Changed
+
+- CONTRIBUTING.md fully dogfoods fledge — uses `fledge run`, `fledge lanes`, and `fledge work` instead of raw cargo commands (#223, #225, #226)
+
 ## [0.10.0] - 2026-04-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."


### PR DESCRIPTION
## Summary

Prep for v0.11.0 release. Bumps version in Cargo.toml and updates CHANGELOG.md with all changes since v0.10.0.

### Highlights
- **Plugin trust tiers** — `fledge plugin audit` and trust badges across templates, lanes, and plugins (#220, #221)
- **Non-TTY support** — all interactive prompts degrade gracefully for AI agents and CI (#222)
- **uv.lock support** — Python dependency parsing with proper TOML parser (#223, #224)
- **Dogfooding** — CONTRIBUTING.md fully uses fledge commands (#223, #225, #226)
- **Doc fixes** — consistent plural command names across all docs/specs (#216, #217, #218, #219)

## Test plan
- [x] All 144 tests pass
- [x] Clippy clean
- [x] Builds at v0.11.0
- [ ] After merge: `fledge release minor --push` to tag and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)