### PR TITLE
release: prep v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-04-23
+
+### Added
+
+- `fledge run --json` flag for structured JSON output — improves AI agent usability (#228)
+
 ## [0.11.0] - 2026-04-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."


### PR DESCRIPTION
## Summary

- Bump version to 0.11.1
- Add changelog entry for `--json` flag on `fledge run` (#228)

## Changes since v0.11.0

- `fledge run --json` flag for structured JSON output — improves AI agent usability (#228)

🤖 Generated with [Claude Code](https://claude.com/claude-code)