### PR TITLE
feat: add --model, --prompt, and --format flags to `fledge review`

### DIFF
--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 3
+version: 4
 status: active
 files:
   - src/review.rs
@@ -22,13 +22,15 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point for the review command |
-| `ReviewOptions` | Options struct with base branch, file filter, and json flag |
+| `ReviewOptions` | Options struct with base branch, file filter, json flag, model, prompt, and format |
+| `ReviewFormat` | Enum for review output format: Summary, Checklist, or Inline |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `ReviewOptions` | `{ base: Option<String>, file: Option<String>, json: bool }` |
+| `ReviewOptions` | `{ base: Option<String>, file: Option<String>, json: bool, model: Option<String>, prompt: Option<String>, format: ReviewFormat }` |
+| `ReviewFormat` | Enum: `Summary` (default, concise markdown), `Checklist` (markdown checklist), `Inline` (file:line comments) |
 
 ### Functions
 
@@ -44,6 +46,9 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 4. Shows diff stats before the AI review output
 5. `--file` flag restricts review to a single file's changes
 6. `--json` outputs structured JSON review results
+7. `--model` overrides the Claude model used for review
+8. `--prompt` appends a custom focus prompt to the default review instructions
+9. `--format` controls output style: `summary` (default), `checklist`, or `inline`
 
 ## Behavioral Examples
 
@@ -70,6 +75,16 @@ $ fledge review --base develop
 $ fledge review --file src/github.rs
 ```
 
+### review — with custom model and format
+```
+$ fledge review --model opus --format checklist
+```
+
+### review — with custom prompt
+```
+$ fledge review --prompt "Focus on security vulnerabilities"
+```
+
 ## Error Cases
 
 | Error | When | Behavior |
@@ -78,6 +93,7 @@ $ fledge review --file src/github.rs
 | Not a git repo | Outside a git repository | Bail with message |
 | No changes | Empty diff against base | Bail with message |
 | Claude CLI error | Non-zero exit from claude | Bail with error |
+| Invalid format | Unknown `--format` value | Bail with error listing valid formats |
 
 ## Dependencies
 
@@ -88,6 +104,7 @@ $ fledge review --file src/github.rs
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-23 | Add ReviewFormat enum, model/prompt/format fields to ReviewOptions |
 | 3 | 2026-04-22 | Document default branch fallback algorithm (symbolic-ref → main → master → fallback main) |
 | 2 | 2026-04-21 | Add json field to ReviewOptions |
 | 1 | 2026-04-19 | Initial spec |

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,15 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Claude model to use (e.g. sonnet, opus, haiku)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Custom review focus prompt (appended to default instructions)
+        #[arg(short, long)]
+        prompt: Option<String>,
+        /// Output format: summary (default), checklist, inline
+        #[arg(long, default_value = "summary")]
+        format: String,
     },
     /// View CI/CD check status for a branch
     Checks {
@@ -763,8 +772,24 @@ fn run() -> Result<()> {
                 json,
             })?;
         }
-        Commands::Review { base, file, json } => {
-            review::run(review::ReviewOptions { base, file, json })?;
+        Commands::Review {
+            base,
+            file,
+            json,
+            model,
+            prompt,
+            format,
+        } => {
+            let format: review::ReviewFormat =
+                format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+            review::run(review::ReviewOptions {
+                base,
+                file,
+                json,
+                model,
+                prompt,
+                format,
+            })?;
         }
         Commands::Lanes { action } => {
             let action = match action {

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,11 +1,48 @@
 use anyhow::{bail, Result};
 use console::style;
+use std::fmt;
 use std::process::Command;
+
+#[derive(Debug, Clone, Default)]
+pub enum ReviewFormat {
+    #[default]
+    Summary,
+    Checklist,
+    Inline,
+}
+
+impl fmt::Display for ReviewFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReviewFormat::Summary => write!(f, "summary"),
+            ReviewFormat::Checklist => write!(f, "checklist"),
+            ReviewFormat::Inline => write!(f, "inline"),
+        }
+    }
+}
+
+impl std::str::FromStr for ReviewFormat {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "summary" => Ok(ReviewFormat::Summary),
+            "checklist" => Ok(ReviewFormat::Checklist),
+            "inline" => Ok(ReviewFormat::Inline),
+            other => Err(format!(
+                "unknown review format '{}' (expected: summary, checklist, inline)",
+                other
+            )),
+        }
+    }
+}
 
 pub struct ReviewOptions {
     pub base: Option<String>,
     pub file: Option<String>,
     pub json: bool,
+    pub model: Option<String>,
+    pub prompt: Option<String>,
+    pub format: ReviewFormat,
 }
 
 pub fn run(options: ReviewOptions) -> Result<()> {
@@ -29,11 +66,19 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         println!("{}\n", style(&diff_stats).dim());
     }
 
-    let prompt = build_prompt(&diff);
+    let prompt = build_prompt(&diff, &options.format, options.prompt.as_deref());
 
     let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}:", &base));
 
-    let output = Command::new("claude").args(["--print", &prompt]).output()?;
+    let mut args = Vec::new();
+    if let Some(ref model) = options.model {
+        args.push("--model".to_string());
+        args.push(model.clone());
+    }
+    args.push("--print".to_string());
+    args.push(prompt);
+
+    let output = Command::new("claude").args(&args).output()?;
 
     sp.finish();
     println!();
@@ -63,7 +108,28 @@ pub fn run(options: ReviewOptions) -> Result<()> {
     Ok(())
 }
 
-fn build_prompt(diff: &str) -> String {
+fn build_prompt(diff: &str, format: &ReviewFormat, custom_prompt: Option<&str>) -> String {
+    let format_instruction = match format {
+        ReviewFormat::Summary => {
+            "Be concise. Use markdown formatting. Only comment on things worth changing.\n\
+             If the code looks good, say so briefly."
+                .to_string()
+        }
+        ReviewFormat::Checklist => {
+            "Format your review as a markdown checklist with - [ ] for issues found and - [x] for areas that look good."
+                .to_string()
+        }
+        ReviewFormat::Inline => {
+            "For each file in the diff, provide inline comments in the format: `file:line - comment`. Group by file."
+                .to_string()
+        }
+    };
+
+    let custom_section = match custom_prompt {
+        Some(p) => format!("\n\nAdditional review focus: {p}"),
+        None => String::new(),
+    };
+
     format!(
         "You are a senior code reviewer. Review the following git diff and provide actionable feedback.\n\
         Focus on:\n\
@@ -72,8 +138,7 @@ fn build_prompt(diff: &str) -> String {
         - Performance concerns\n\
         - Code clarity and maintainability\n\
         \n\
-        Be concise. Use markdown formatting. Only comment on things worth changing.\n\
-        If the code looks good, say so briefly.\n\
+        {format_instruction}{custom_section}\n\
         \n\
         ```diff\n{diff}\n```"
     )
@@ -139,7 +204,7 @@ mod tests {
 
     #[test]
     fn build_prompt_contains_diff() {
-        let prompt = build_prompt("+ added line\n- removed line");
+        let prompt = build_prompt("+ added line\n- removed line", &ReviewFormat::Summary, None);
         assert!(prompt.contains("+ added line"));
         assert!(prompt.contains("- removed line"));
         assert!(prompt.contains("```diff"));
@@ -147,11 +212,88 @@ mod tests {
 
     #[test]
     fn build_prompt_includes_review_criteria() {
-        let prompt = build_prompt("some diff");
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
         assert!(prompt.contains("Bugs and logic errors"));
         assert!(prompt.contains("Security issues"));
         assert!(prompt.contains("Performance concerns"));
         assert!(prompt.contains("Code clarity"));
+    }
+
+    #[test]
+    fn build_prompt_summary_format() {
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
+        assert!(prompt.contains("Be concise"));
+        assert!(prompt.contains("Use markdown formatting"));
+    }
+
+    #[test]
+    fn build_prompt_checklist_format() {
+        let prompt = build_prompt("some diff", &ReviewFormat::Checklist, None);
+        assert!(prompt.contains("markdown checklist"));
+        assert!(prompt.contains("- [ ]"));
+        assert!(prompt.contains("- [x]"));
+    }
+
+    #[test]
+    fn build_prompt_inline_format() {
+        let prompt = build_prompt("some diff", &ReviewFormat::Inline, None);
+        assert!(prompt.contains("file:line - comment"));
+        assert!(prompt.contains("Group by file"));
+    }
+
+    #[test]
+    fn build_prompt_with_custom_prompt() {
+        let prompt = build_prompt(
+            "some diff",
+            &ReviewFormat::Summary,
+            Some("Focus on security vulnerabilities"),
+        );
+        assert!(prompt.contains("Additional review focus: Focus on security vulnerabilities"));
+    }
+
+    #[test]
+    fn build_prompt_without_custom_prompt() {
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
+        assert!(!prompt.contains("Additional review focus"));
+    }
+
+    #[test]
+    fn build_prompt_custom_prompt_with_checklist_format() {
+        let prompt = build_prompt(
+            "some diff",
+            &ReviewFormat::Checklist,
+            Some("Check for performance issues"),
+        );
+        assert!(prompt.contains("markdown checklist"));
+        assert!(prompt.contains("Additional review focus: Check for performance issues"));
+    }
+
+    #[test]
+    fn review_format_from_str() {
+        assert!(matches!(
+            "summary".parse::<ReviewFormat>().unwrap(),
+            ReviewFormat::Summary
+        ));
+        assert!(matches!(
+            "checklist".parse::<ReviewFormat>().unwrap(),
+            ReviewFormat::Checklist
+        ));
+        assert!(matches!(
+            "inline".parse::<ReviewFormat>().unwrap(),
+            ReviewFormat::Inline
+        ));
+        assert!(matches!(
+            "SUMMARY".parse::<ReviewFormat>().unwrap(),
+            ReviewFormat::Summary
+        ));
+        assert!("unknown".parse::<ReviewFormat>().is_err());
+    }
+
+    #[test]
+    fn review_format_display() {
+        assert_eq!(ReviewFormat::Summary.to_string(), "summary");
+        assert_eq!(ReviewFormat::Checklist.to_string(), "checklist");
+        assert_eq!(ReviewFormat::Inline.to_string(), "inline");
     }
 
     #[test]
@@ -160,10 +302,16 @@ mod tests {
             base: None,
             file: None,
             json: false,
+            model: None,
+            prompt: None,
+            format: ReviewFormat::Summary,
         };
         assert!(opts.base.is_none());
         assert!(opts.file.is_none());
         assert!(!opts.json);
+        assert!(opts.model.is_none());
+        assert!(opts.prompt.is_none());
+        assert!(matches!(opts.format, ReviewFormat::Summary));
     }
 
     #[test]
@@ -172,6 +320,9 @@ mod tests {
             base: Some("develop".to_string()),
             file: None,
             json: true,
+            model: None,
+            prompt: None,
+            format: ReviewFormat::Summary,
         };
         assert_eq!(opts.base.unwrap(), "develop");
         assert!(opts.json);
@@ -183,7 +334,25 @@ mod tests {
             base: None,
             file: Some("src/main.rs".to_string()),
             json: false,
+            model: None,
+            prompt: None,
+            format: ReviewFormat::Summary,
         };
         assert_eq!(opts.file.unwrap(), "src/main.rs");
+    }
+
+    #[test]
+    fn review_options_with_all_new_fields() {
+        let opts = ReviewOptions {
+            base: None,
+            file: None,
+            json: false,
+            model: Some("opus".to_string()),
+            prompt: Some("Focus on security".to_string()),
+            format: ReviewFormat::Checklist,
+        };
+        assert_eq!(opts.model.unwrap(), "opus");
+        assert_eq!(opts.prompt.unwrap(), "Focus on security");
+        assert!(matches!(opts.format, ReviewFormat::Checklist));
     }
 }


### PR DESCRIPTION
## Summary
- **`--model`** (`-m`) — specify Claude model: `fledge review --model sonnet`
- **`--prompt`** (`-p`) — custom review focus: `fledge review --prompt "Focus on security"`
- **`--format`** — output style: `summary` (default), `checklist`, `inline`
- All flags composable, backward compatible (no flags = identical behavior)
- 9 new tests

## Test plan
- [x] `cargo test` — 629 unit + 144 integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `fledge review --format checklist` on a branch with changes
- [ ] Manual: `fledge review --model haiku --prompt "security only"`