### PR TITLE
feat: add Kotlin KMP and Ktor API templates

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -859,7 +859,12 @@ ignore = ["template.toml"]
         assert!(names.contains(&"go-cli"), "missing go-cli");
         assert!(names.contains(&"ts-node"), "missing ts-node");
         assert!(names.contains(&"static-site"), "missing static-site");
-        assert_eq!(names.len(), 6, "expected exactly 6 built-in templates");
+        assert!(names.contains(&"kotlin-kmp"), "missing kotlin-kmp");
+        assert!(
+            names.contains(&"kotlin-ktor-api"),
+            "missing kotlin-ktor-api"
+        );
+        assert_eq!(names.len(), 8, "expected exactly 8 built-in templates");
     }
 
     #[test]

--- a/templates/kotlin-kmp/.github/workflows/ci.yml.tera
+++ b/templates/kotlin-kmp/.github/workflows/ci.yml.tera
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew build
+      - run: ./gradlew allTests

--- a/templates/kotlin-kmp/.gitignore
+++ b/templates/kotlin-kmp/.gitignore
@@ -1,0 +1,5 @@
+build/
+.gradle/
+.idea/
+*.iml
+local.properties

--- a/templates/kotlin-kmp/CLAUDE.md.tera
+++ b/templates/kotlin-kmp/CLAUDE.md.tera
@@ -1,0 +1,17 @@
+# {{ project_name }}
+
+{{ description }}
+
+## Build & Test
+
+```bash
+./gradlew build
+./gradlew allTests
+./gradlew detekt
+```
+
+## Architecture
+
+- `shared/src/commonMain/` — shared Kotlin code (expect declarations)
+- `shared/src/jvmMain/` — JVM actual implementations
+- `shared/src/iosMain/` — iOS actual implementations

--- a/templates/kotlin-kmp/LICENSE.tera
+++ b/templates/kotlin-kmp/LICENSE.tera
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{ year }} {{ author }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/kotlin-kmp/README.md.tera
+++ b/templates/kotlin-kmp/README.md.tera
@@ -1,0 +1,24 @@
+# {{ project_name }}
+
+{{ description }}
+
+## Structure
+
+```
+shared/
+  src/
+    commonMain/   — shared business logic
+    jvmMain/      — JVM platform implementation
+    iosMain/      — iOS platform implementation
+```
+
+## Build
+
+```bash
+./gradlew build
+./gradlew allTests
+```
+
+## License
+
+{{ license }}

--- a/templates/kotlin-kmp/build.gradle.kts.tera
+++ b/templates/kotlin-kmp/build.gradle.kts.tera
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+}

--- a/templates/kotlin-kmp/fledge.toml
+++ b/templates/kotlin-kmp/fledge.toml
@@ -1,0 +1,8 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+build = "./gradlew build"
+test = "./gradlew allTests"
+lint = "./gradlew detekt"
+clean = "./gradlew clean"

--- a/templates/kotlin-kmp/gradle.properties
+++ b/templates/kotlin-kmp/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+kotlin.mpp.stability.nowarn=true

--- a/templates/kotlin-kmp/gradle/libs.versions.toml.tera
+++ b/templates/kotlin-kmp/gradle/libs.versions.toml.tera
@@ -1,0 +1,19 @@
+[versions]
+kotlin = "2.1.20"
+kotlinx-coroutines = "1.10.2"
+kotlinx-serialization = "1.8.1"
+kotlinx-datetime = "0.6.2"
+ktor = "3.1.3"
+
+[libraries]
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+
+[plugins]
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/templates/kotlin-kmp/settings.gradle.kts.tera
+++ b/templates/kotlin-kmp/settings.gradle.kts.tera
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolution {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "{{ project_name }}"
+include(":shared")

--- a/templates/kotlin-kmp/shared/build.gradle.kts.tera
+++ b/templates/kotlin-kmp/shared/build.gradle.kts.tera
@@ -1,0 +1,33 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    jvm()
+
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { target ->
+        target.binaries.framework {
+            baseName = "Shared"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(libs.kotlinx.datetime)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.json)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
+    }
+}

--- a/templates/kotlin-kmp/shared/src/commonMain/kotlin/Greeting.kt.tera
+++ b/templates/kotlin-kmp/shared/src/commonMain/kotlin/Greeting.kt.tera
@@ -1,0 +1,7 @@
+package {{ group_id }}.{{ project_name_snake }}.shared
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String = "Hello from {{ project_name }} on ${platform.name}!"
+}

--- a/templates/kotlin-kmp/shared/src/commonMain/kotlin/Platform.kt.tera
+++ b/templates/kotlin-kmp/shared/src/commonMain/kotlin/Platform.kt.tera
@@ -1,0 +1,7 @@
+package {{ group_id }}.{{ project_name_snake }}.shared
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/templates/kotlin-kmp/shared/src/iosMain/kotlin/Platform.ios.kt.tera
+++ b/templates/kotlin-kmp/shared/src/iosMain/kotlin/Platform.ios.kt.tera
@@ -1,0 +1,9 @@
+package {{ group_id }}.{{ project_name_snake }}.shared
+
+import platform.UIKit.UIDevice
+
+class IosPlatform : Platform {
+    override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+}
+
+actual fun getPlatform(): Platform = IosPlatform()

--- a/templates/kotlin-kmp/shared/src/jvmMain/kotlin/Platform.jvm.kt.tera
+++ b/templates/kotlin-kmp/shared/src/jvmMain/kotlin/Platform.jvm.kt.tera
@@ -1,0 +1,7 @@
+package {{ group_id }}.{{ project_name_snake }}.shared
+
+class JvmPlatform : Platform {
+    override val name: String = "JVM ${System.getProperty("java.version")}"
+}
+
+actual fun getPlatform(): Platform = JvmPlatform()

--- a/templates/kotlin-kmp/template.toml
+++ b/templates/kotlin-kmp/template.toml
@@ -1,0 +1,13 @@
+[template]
+name = "kotlin-kmp"
+description = "Kotlin Multiplatform project with shared module and JVM/iOS targets"
+min_fledge_version = "0.1.0"
+
+[prompts]
+description = { message = "Project description", default = "A Kotlin Multiplatform project" }
+group_id = { message = "Group ID (e.g. com.example)", default = "com.example" }
+
+[files]
+render = ["**/*.kt", "**/*.kts", "**/*.md", "**/*.yml", "**/*.toml", "**/*.properties"]
+copy = []
+ignore = ["template.toml"]

--- a/templates/kotlin-ktor-api/.github/workflows/ci.yml.tera
+++ b/templates/kotlin-ktor-api/.github/workflows/ci.yml.tera
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew build
+      - run: ./gradlew test

--- a/templates/kotlin-ktor-api/.gitignore
+++ b/templates/kotlin-ktor-api/.gitignore
@@ -1,0 +1,5 @@
+build/
+.gradle/
+.idea/
+*.iml
+local.properties

--- a/templates/kotlin-ktor-api/CLAUDE.md.tera
+++ b/templates/kotlin-ktor-api/CLAUDE.md.tera
@@ -1,0 +1,18 @@
+# {{ project_name }}
+
+{{ description }}
+
+## Build & Test
+
+```bash
+./gradlew build
+./gradlew test
+./gradlew run
+```
+
+## Architecture
+
+- `src/main/kotlin/com/Application.kt` — entry point, module wiring
+- `src/main/kotlin/com/Routing.kt` — REST routes and data models
+- `src/main/kotlin/com/Database.kt` — Exposed table definitions
+- `src/main/kotlin/com/Serialization.kt` — JSON content negotiation

--- a/templates/kotlin-ktor-api/Dockerfile.tera
+++ b/templates/kotlin-ktor-api/Dockerfile.tera
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21 AS build
+WORKDIR /app
+COPY . .
+RUN gradle build --no-daemon -x test
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/build/libs/*-all.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/templates/kotlin-ktor-api/LICENSE.tera
+++ b/templates/kotlin-ktor-api/LICENSE.tera
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{ year }} {{ author }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/kotlin-ktor-api/README.md.tera
+++ b/templates/kotlin-ktor-api/README.md.tera
@@ -1,0 +1,32 @@
+# {{ project_name }}
+
+{{ description }}
+
+## Run
+
+```bash
+./gradlew run
+```
+
+Server starts at http://localhost:8080
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /health | Health check |
+| GET | /items | List all items |
+| GET | /items/{id} | Get item by ID |
+| POST | /items | Create item |
+| DELETE | /items/{id} | Delete item |
+
+## Build & Test
+
+```bash
+./gradlew build
+./gradlew test
+```
+
+## License
+
+{{ license }}

--- a/templates/kotlin-ktor-api/build.gradle.kts.tera
+++ b/templates/kotlin-ktor-api/build.gradle.kts.tera
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ktor)
+}
+
+application {
+    mainClass.set("{{ group_id }}.{{ project_name_snake }}.ApplicationKt")
+}
+
+dependencies {
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.serialization.json)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.dao)
+    implementation(libs.h2)
+    implementation(libs.logback)
+    testImplementation(libs.ktor.server.test)
+    testImplementation(libs.kotlin.test)
+}

--- a/templates/kotlin-ktor-api/fledge.toml
+++ b/templates/kotlin-ktor-api/fledge.toml
@@ -1,0 +1,9 @@
+# fledge.toml — project task definitions
+# Docs: https://github.com/CorvidLabs/fledge#task-runner
+
+[tasks]
+build = "./gradlew build"
+test = "./gradlew test"
+run = "./gradlew run"
+lint = "./gradlew detekt"
+clean = "./gradlew clean"

--- a/templates/kotlin-ktor-api/gradle.properties
+++ b/templates/kotlin-ktor-api/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/templates/kotlin-ktor-api/gradle/libs.versions.toml.tera
+++ b/templates/kotlin-ktor-api/gradle/libs.versions.toml.tera
@@ -1,0 +1,25 @@
+[versions]
+kotlin = "2.1.20"
+ktor = "3.1.3"
+exposed = "0.61.0"
+logback = "1.5.18"
+h2 = "2.3.232"
+
+[libraries]
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-test = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ktor = { id = "io.ktor.plugin", version.ref = "ktor" }

--- a/templates/kotlin-ktor-api/settings.gradle.kts.tera
+++ b/templates/kotlin-ktor-api/settings.gradle.kts.tera
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolution {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "{{ project_name }}"

--- a/templates/kotlin-ktor-api/src/main/kotlin/com/Application.kt.tera
+++ b/templates/kotlin-ktor-api/src/main/kotlin/com/Application.kt.tera
@@ -1,0 +1,15 @@
+package {{ group_id }}.{{ project_name_snake }}
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+
+fun main() {
+    embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
+}
+
+fun Application.module() {
+    configureSerialization()
+    configureDatabase()
+    configureRouting()
+}

--- a/templates/kotlin-ktor-api/src/main/kotlin/com/Database.kt.tera
+++ b/templates/kotlin-ktor-api/src/main/kotlin/com/Database.kt.tera
@@ -1,0 +1,19 @@
+package {{ group_id }}.{{ project_name_snake }}
+
+import io.ktor.server.application.*
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+object Items : Table() {
+    val id = integer("id").autoIncrement()
+    val name = varchar("name", 255)
+    val description = varchar("description", 1024).nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+fun Application.configureDatabase() {
+    Database.connect("jdbc:h2:mem:{{ project_name_snake }};DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    transaction {
+        SchemaUtils.create(Items)
+    }
+}

--- a/templates/kotlin-ktor-api/src/main/kotlin/com/Routing.kt.tera
+++ b/templates/kotlin-ktor-api/src/main/kotlin/com/Routing.kt.tera
@@ -1,0 +1,67 @@
+package {{ group_id }}.{{ project_name_snake }}
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Serializable
+data class ItemRequest(val name: String, val description: String? = null)
+
+@Serializable
+data class ItemResponse(val id: Int, val name: String, val description: String?)
+
+fun Application.configureRouting() {
+    routing {
+        get("/health") {
+            call.respond(mapOf("status" to "ok"))
+        }
+
+        route("/items") {
+            get {
+                val items = transaction {
+                    Items.selectAll().map {
+                        ItemResponse(it[Items.id], it[Items.name], it[Items.description])
+                    }
+                }
+                call.respond(items)
+            }
+
+            get("/{id}") {
+                val id = call.parameters["id"]?.toIntOrNull()
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid ID"))
+                val item = transaction {
+                    Items.selectAll().where { Items.id eq id }.singleOrNull()?.let {
+                        ItemResponse(it[Items.id], it[Items.name], it[Items.description])
+                    }
+                }
+                if (item != null) call.respond(item)
+                else call.respond(HttpStatusCode.NotFound, mapOf("error" to "Not found"))
+            }
+
+            post {
+                val req = call.receive<ItemRequest>()
+                val id = transaction {
+                    Items.insert {
+                        it[name] = req.name
+                        it[description] = req.description
+                    } get Items.id
+                }
+                call.respond(HttpStatusCode.Created, ItemResponse(id, req.name, req.description))
+            }
+
+            delete("/{id}") {
+                val id = call.parameters["id"]?.toIntOrNull()
+                    ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid ID"))
+                val deleted = transaction { Items.deleteWhere { Items.id eq id } }
+                if (deleted > 0) call.respond(HttpStatusCode.NoContent)
+                else call.respond(HttpStatusCode.NotFound, mapOf("error" to "Not found"))
+            }
+        }
+    }
+}

--- a/templates/kotlin-ktor-api/src/main/kotlin/com/Serialization.kt.tera
+++ b/templates/kotlin-ktor-api/src/main/kotlin/com/Serialization.kt.tera
@@ -1,0 +1,16 @@
+package {{ group_id }}.{{ project_name_snake }}
+
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
+import kotlinx.serialization.json.Json
+
+fun Application.configureSerialization() {
+    install(ContentNegotiation) {
+        json(Json {
+            prettyPrint = true
+            isLenient = true
+            ignoreUnknownKeys = true
+        })
+    }
+}

--- a/templates/kotlin-ktor-api/src/main/resources/logback.xml
+++ b/templates/kotlin-ktor-api/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/templates/kotlin-ktor-api/template.toml
+++ b/templates/kotlin-ktor-api/template.toml
@@ -1,0 +1,13 @@
+[template]
+name = "kotlin-ktor-api"
+description = "Ktor REST API server with serialization, routing, and database"
+min_fledge_version = "0.1.0"
+
+[prompts]
+description = { message = "Project description", default = "A Ktor REST API" }
+group_id = { message = "Group ID (e.g. com.example)", default = "com.example" }
+
+[files]
+render = ["**/*.kt", "**/*.kts", "**/*.md", "**/*.yml", "**/*.toml", "**/*.conf", "**/*.properties"]
+copy = []
+ignore = ["template.toml"]


### PR DESCRIPTION
## Summary
- Adds **kotlin-kmp** template: Kotlin Multiplatform starter with shared module, JVM/iOS targets, Gradle version catalog, coroutines, kotlinx-serialization, Ktor client, and expect/actual pattern
- Adds **kotlin-ktor-api** template: Ktor REST API server with Exposed ORM, H2 database, CRUD routing, content negotiation, Dockerfile, and health check endpoint
- Both include CI workflows, fledge.toml tasks, CLAUDE.md, and LICENSE

Brings fledge's built-in template count from 6 to 8.

## Test plan
- [x] All 144 tests pass (including updated template discovery test)
- [x] Clippy clean
- [x] Pre-commit hooks pass (specs, fmt, clippy)
- [ ] `fledge init` with kotlin-kmp and kotlin-ktor-api templates
- [ ] Generated Gradle projects build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)