### PR TITLE
chore: alphabetize CLI commands and add --json to lane run

### DIFF
--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 8
+version: 9
 status: active
 files:
   - src/lanes.rs
@@ -33,7 +33,7 @@ Composable workflow pipelines defined in `fledge.toml` and `.fledge/lanes/`. Lan
 
 | Type | Description |
 |------|-------------|
-| `LaneAction` | Action enum for the lane subcommand (Run, List, Init, Search, Import, Publish, Create, Validate) |
+| `LaneAction` | Action enum for the lane subcommand (Run with json/dry_run, List, Init, Search, Import, Publish, Create, Validate) |
 | `LaneDef` | A named lane with description, steps, and fail_fast flag |
 | `Step` | A single step: task reference, inline command, or parallel group |
 | `ParallelItem` | An item within a parallel group: task reference or inline command |
@@ -187,6 +187,10 @@ Validation failed
 $ fledge laness publish
 ✅ . — valid (2 lanes)
 ➡️ Publishing 2 lanes as owner/my-lanes
+
+# Run a lane with JSON output
+$ fledge lanes run ci --json
+{"lane": "ci", "description": "Full CI pipeline", "total_steps": 3, "success": true, "duration_ms": 4733, "fail_fast": true, "steps": [...], "failures": []}
 ```
 
 ## Error Cases
@@ -221,6 +225,7 @@ $ fledge laness publish
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 9 | 2026-04-23 | Add `--json` flag to `lane run` for structured JSON output |
 | 8 | 2026-04-22 | Add `create` and `validate` subcommands; `publish` now validates before pushing |
 | 7 | 2026-04-21 | Imported lanes stored in `.fledge/lanes/` instead of appending to fledge.toml; lane loading merges both sources |
 | 6 | 2026-04-21 | Add step timing — each step prints elapsed time, lane summary includes total |

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,6 +1,6 @@
 ---
 module: main
-version: 1
+version: 2
 status: active
 files:
   - src/main.rs
@@ -34,6 +34,7 @@ depends_on:
   - update
   - validate
   - versioning
+  - watch
   - work
 ---
 
@@ -89,4 +90,5 @@ All modules are dependencies — main dispatches to every subcommand module. See
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-23 | Add `watch` to depends_on |
 | 1 | 2026-04-21 | Initial spec |

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -1,6 +1,6 @@
 ---
 module: run
-version: 1
+version: 2
 status: active
 files:
   - src/run.rs
@@ -31,7 +31,7 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 
 | Type | Description |
 |------|-------------|
-| `RunOptions` | Options: `task`, `init`, `list` |
+| `RunOptions` | Options: `task`, `init`, `list`, `lang`, `json` |
 
 ### Functions
 
@@ -39,6 +39,7 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 |----------|-----------|-------------|
 | `run` | `(RunOptions) -> Result<()>` | Main entry — dispatch to init/list/execute |
 | `detect_project_type` | `(&Path) -> &'static str` | Detect project ecosystem (rust, node, go, python, etc.) from marker files |
+| `detect_node_runner` | `(&Path) -> &'static str` | Detect Node.js package manager (npm, bun, pnpm, yarn) |
 | `task_defaults` | `(&str, &Path) -> String` | Return default task TOML entries for a given project type and directory |
 | `detect_node_runner` | `(&Path) -> &'static str` | Detect node package manager (bun, yarn, pnpm, npm) from lock files in directory |
 
@@ -50,6 +51,8 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 4. Circular dependencies are detected and produce an error
 5. `--init` creates a starter `fledge.toml` if none exists
 6. When auto-detecting, the task list header indicates tasks are auto-detected and suggests creating `fledge.toml` to customize
+7. `--json` outputs structured JSON for both task listing and task execution
+8. `--lang` overrides auto-detected project type (e.g. `rust`, `node`, `go`, `python`, `swift`, `ruby`, `java-gradle`, `java-maven`)
 
 ## Behavioral Examples
 
@@ -72,6 +75,20 @@ $ fledge run ci
 # Init a new fledge.toml
 $ fledge run --init
 ✓ Created fledge.toml
+
+# List tasks as JSON
+$ fledge run --json
+{"auto_detected": false, "tasks": [...]}
+
+# Run a task with JSON output
+$ fledge run test --json
+{"task": "test", "command": "cargo test", "exit_code": 0, "success": true, "stdout": "...", "stderr": "..."}
+
+# Override project type
+$ fledge run --lang node
+Available tasks:
+  build  npm run build
+  test   npm test
 ```
 
 ## Error Cases
@@ -93,4 +110,5 @@ $ fledge run --init
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-23 | Add `--json` flag (list + execute), `--lang` override, `detect_node_runner` |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/watch/context.md
+++ b/specs/watch/context.md
@@ -1,0 +1,9 @@
+---
+spec: watch.spec.md
+---
+
+## Context
+
+The watch module was added in v0.11.0 to turn fledge from a manually-invoked CLI into a persistent development companion. It uses the `notify` crate for cross-platform filesystem event monitoring and supports both tasks and lanes as re-run targets.
+
+The debounce implementation extends the deadline on each new event rather than using a fixed window, which handles rapid save bursts (e.g., formatter running after save) without triggering multiple runs. Default debounce was increased from 200ms to 500ms based on real-world testing.

--- a/specs/watch/requirements.md
+++ b/specs/watch/requirements.md
@@ -1,0 +1,14 @@
+---
+spec: watch.spec.md
+---
+
+## Requirements
+
+- Watch a directory recursively for filesystem changes
+- Re-run a specified task or lane when relevant files change
+- Filter events by file extension (optional)
+- Ignore common non-source directories (.git, target, node_modules, .fledge, __pycache__)
+- Configurable debounce interval with deadline extension on new events
+- Perform an initial run before entering the watch loop
+- Optional terminal clear before each re-run
+- Graceful error handling — target failures don't stop the watcher

--- a/specs/watch/tasks.md
+++ b/specs/watch/tasks.md
@@ -1,0 +1,16 @@
+---
+spec: watch.spec.md
+---
+
+## Tasks
+
+- [x] Write spec files for watch module
+- [x] Implement WatchOptions struct
+- [x] Implement file watching with notify crate
+- [x] Implement debounce with deadline extension
+- [x] Implement extension filtering
+- [x] Implement path ignore patterns
+- [x] Implement task and lane re-run
+- [x] Add --clear flag for terminal clearing
+- [x] Wire up CLI subcommand in main.rs
+- [x] Add unit tests for ignore, extension, and parse functions

--- a/specs/watch/testing.md
+++ b/specs/watch/testing.md
@@ -1,0 +1,30 @@
+---
+spec: watch.spec.md
+---
+
+## Testing
+
+### Unit Tests
+
+- `ignore_git_directory` — .git paths are ignored
+- `ignore_target_directory` — target paths are ignored
+- `ignore_node_modules` — node_modules paths are ignored
+- `ignore_fledge_directory` — .fledge paths are ignored
+- `ignore_pycache` — __pycache__ paths are ignored
+- `do_not_ignore_regular_path` — source files are not ignored
+- `do_not_ignore_similar_names` — similar but different names (target_dir, .github) not ignored
+- `extension_filter_matches_rs` — extension matching works for .rs and .toml
+- `extension_filter_empty_matches_all` — empty filter matches everything
+- `extension_filter_no_ext_file` — files without extensions don't match a filter
+- `parse_extensions_basic` — comma-separated parsing
+- `parse_extensions_with_dots` — dot-prefixed extensions stripped
+- `parse_extensions_with_spaces` — whitespace trimmed
+- `parse_extensions_empty` — empty string returns empty vec
+- `parse_extensions_single` — single extension
+- `format_duration_millis` — sub-second formatting
+- `format_duration_seconds` — seconds formatting
+- `format_duration_minutes` — minutes formatting
+- `format_duration_zero` — zero duration
+- `ignore_dirs_list_is_complete` — all expected dirs present
+- `watch_options_defaults` — struct construction
+- `combined_ignore_and_extension_filter` — combined filtering logic

--- a/specs/watch/watch.spec.md
+++ b/specs/watch/watch.spec.md
@@ -1,0 +1,111 @@
+---
+module: watch
+version: 1
+status: active
+files:
+  - src/watch.rs
+
+db_tables: []
+depends_on:
+  - run
+  - lanes
+---
+
+# Watch
+
+## Purpose
+
+File watcher that monitors a directory for changes and automatically re-runs a specified task or lane. Uses the `notify` crate for cross-platform filesystem events with configurable debouncing, extension filtering, and path ignore patterns.
+
+## Public API
+
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `run` | Entry point — starts watching and re-running |
+| `WatchOptions` | Options: `name`, `lane`, `path`, `extensions`, `debounce_ms`, `clear` |
+| `should_ignore_path` | Check if a path falls under an ignored directory |
+| `matches_extensions` | Check if a path matches the extension filter |
+| `parse_extensions` | Parse comma-separated extension string into a list |
+
+### Structs & Enums
+
+| Type | Description |
+|------|-------------|
+| `WatchOptions` | Configuration: target name, lane mode, watch path, extension filter, debounce interval, clear flag |
+
+### Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `run` | `(WatchOptions) -> Result<()>` | Main entry — watch directory and re-run target on changes |
+| `should_ignore_path` | `(&Path) -> bool` | Returns true if path is under an ignored directory (.git, target, node_modules, .fledge, __pycache__) |
+| `matches_extensions` | `(&Path, &[String]) -> bool` | Returns true if path matches extension filter (empty filter matches all) |
+| `parse_extensions` | `(&str) -> Vec<String>` | Parses comma-separated extension string, strips dots and whitespace |
+
+## Invariants
+
+1. Watches recursively from the specified path (or cwd if none given)
+2. Ignores events from `.git`, `target`, `node_modules`, `.fledge`, and `__pycache__` directories
+3. Only triggers on Create, Modify, and Remove events
+4. Extension filter is optional — empty filter matches all files
+5. Debounce window defaults to 500ms; each new relevant event extends the deadline
+6. Performs an initial run before entering the watch loop
+7. `--clear` clears the terminal before each re-run
+8. `--lane` flag switches from task mode to lane mode
+9. Errors during target execution are printed but do not stop the watcher
+
+## Behavioral Examples
+
+```
+# Watch and re-run a task
+$ fledge watch test
+* Watching for changes to re-run task test
+  Path: /project
+  Debounce: 500ms
+  Press Ctrl+C to stop.
+
+>>> Re-running task: test
+
+OK Completed in 1.032s
+Watching for changes...
+
+# Watch with extension filter
+$ fledge watch test --ext rs,toml
+* Watching for changes to re-run task test
+  Path: /project
+  Extensions: rs, toml
+  Debounce: 500ms
+
+# Watch a lane
+$ fledge watch ci --lane
+* Watching for changes to re-run lane ci
+
+# Watch a specific directory with custom debounce
+$ fledge watch build --path src --debounce 1000
+
+# Watch with terminal clear
+$ fledge watch test --clear
+```
+
+## Error Cases
+
+| Error | When | Behavior |
+|-------|------|----------|
+| Watch path not found | Specified `--path` doesn't exist | Error with path |
+| Watcher creation failed | OS-level filesystem watch error | Error with context |
+| Target execution failed | Task/lane exits non-zero | Print error, continue watching |
+| Channel disconnected | Watcher dropped unexpectedly | Exit gracefully |
+
+## Dependencies
+
+- `run` module (task execution)
+- `lanes` module (lane execution)
+- `notify` crate (filesystem events)
+
+## Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1 | 2026-04-23 | Initial spec |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -102,6 +102,7 @@ pub enum LaneAction {
     Run {
         name: String,
         dry_run: bool,
+        json: bool,
     },
     List {
         json: bool,
@@ -163,7 +164,11 @@ pub fn run(action: LaneAction) -> Result<()> {
             let config = load_lane_config()?;
             list_lanes(&config.lanes, json)
         }
-        LaneAction::Run { name, dry_run } => {
+        LaneAction::Run {
+            name,
+            dry_run,
+            json,
+        } => {
             let config = load_lane_config()?;
             let lane = config.lanes.get(&name).ok_or_else(|| {
                 let available: Vec<&str> = config.lanes.keys().map(|s| s.as_str()).collect();
@@ -184,7 +189,7 @@ pub fn run(action: LaneAction) -> Result<()> {
                 dry_run_lane(&name, lane)
             } else {
                 let project_dir = std::env::current_dir().context("getting current directory")?;
-                execute_lane(&name, lane, &config.tasks, &project_dir)
+                execute_lane(&name, lane, &config.tasks, &project_dir, json)
             }
         }
     }
@@ -410,7 +415,12 @@ fn execute_lane(
     lane: &LaneDef,
     tasks: &BTreeMap<String, TaskDef>,
     project_dir: &Path,
+    json: bool,
 ) -> Result<()> {
+    if json {
+        return execute_lane_json(lane_name, lane, tasks, project_dir);
+    }
+
     let desc = lane.description.as_deref().unwrap_or("(no description)");
     println!(
         "{} {} — {}",
@@ -497,6 +507,89 @@ fn execute_lane(
     }
 
     Ok(())
+}
+
+fn execute_lane_json(
+    lane_name: &str,
+    lane: &LaneDef,
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+) -> Result<()> {
+    let total_steps = lane.steps.len();
+    let mut step_results: Vec<serde_json::Value> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+    let lane_start = Instant::now();
+
+    for (i, step) in lane.steps.iter().enumerate() {
+        let step_desc = step_description(step);
+        let step_start = Instant::now();
+        let result = match step {
+            Step::TaskRef(name) => execute_task_with_deps(name, tasks, project_dir),
+            Step::Inline { run: cmd } => execute_inline(cmd, project_dir),
+            Step::Parallel { parallel } => execute_parallel(parallel, tasks, project_dir),
+        };
+        let elapsed = step_start.elapsed();
+        let success = result.is_ok();
+        let error_msg = result.err().map(|e| e.to_string());
+
+        step_results.push(serde_json::json!({
+            "step": i + 1,
+            "name": step_desc,
+            "success": success,
+            "duration_ms": elapsed.as_millis() as u64,
+            "error": error_msg,
+        }));
+
+        if !success {
+            failures.push(step_desc.clone());
+            if lane.fail_fast {
+                break;
+            }
+        }
+    }
+
+    let total_elapsed = lane_start.elapsed();
+    let success = failures.is_empty();
+
+    let output = serde_json::json!({
+        "lane": lane_name,
+        "description": lane.description.as_deref().unwrap_or(""),
+        "total_steps": total_steps,
+        "success": success,
+        "duration_ms": total_elapsed.as_millis() as u64,
+        "fail_fast": lane.fail_fast,
+        "steps": step_results,
+        "failures": failures,
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+
+    if !success {
+        bail!(
+            "Lane '{}' completed with {} failure(s)",
+            lane_name,
+            failures.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn step_description(step: &Step) -> String {
+    match step {
+        Step::TaskRef(name) => name.clone(),
+        Step::Inline { run: cmd } => cmd.clone(),
+        Step::Parallel { parallel } => {
+            let names: Vec<String> = parallel
+                .iter()
+                .map(|item| match item {
+                    ParallelItem::TaskRef(name) => name.clone(),
+                    ParallelItem::Inline { run: cmd } => cmd.clone(),
+                })
+                .collect();
+            format!("parallel({})", names.join(", "))
+        }
+    }
 }
 
 fn format_duration(d: std::time::Duration) -> String {
@@ -1822,7 +1915,13 @@ steps = ["a", "b"]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("seq", &config.lanes["seq"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "seq",
+            &config.lanes["seq"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_ok());
     }
 
@@ -1842,6 +1941,7 @@ steps = [{ run = "echo inline-works" }]
             &config.lanes["inline"],
             &config.tasks,
             &project_dir,
+            false,
         );
         assert!(result.is_ok());
     }
@@ -1859,7 +1959,13 @@ steps = [{ parallel = ["a", "b"] }]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("par", &config.lanes["par"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "par",
+            &config.lanes["par"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_ok());
     }
 
@@ -1901,7 +2007,13 @@ steps = [{ parallel = ["a", { run = "echo inline-b" }] }]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("mixed", &config.lanes["mixed"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "mixed",
+            &config.lanes["mixed"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_ok());
     }
 
@@ -1921,6 +2033,7 @@ steps = [{ parallel = [{ run = "echo one" }, { run = "echo two" }] }]
             &config.lanes["inlines"],
             &config.tasks,
             &project_dir,
+            false,
         );
         assert!(result.is_ok());
     }
@@ -1973,7 +2086,13 @@ steps = ["fail", "ok"]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("ff", &config.lanes["ff"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "ff",
+            &config.lanes["ff"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("failed at step 1"));
     }
@@ -1992,7 +2111,13 @@ steps = ["fail", "ok"]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("noff", &config.lanes["noff"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "noff",
+            &config.lanes["noff"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("1 failure"));
     }
@@ -2013,7 +2138,13 @@ steps = ["build"]
 "#,
         );
         let project_dir = std::env::current_dir().unwrap();
-        let result = execute_lane("ci", &config.lanes["ci"], &config.tasks, &project_dir);
+        let result = execute_lane(
+            "ci",
+            &config.lanes["ci"],
+            &config.tasks,
+            &project_dir,
+            false,
+        );
         assert!(result.is_ok());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,37 @@ struct Cli {
 
 #[derive(clap::Subcommand)]
 enum Commands {
-    /// Manage templates (init, create, search, update, publish, validate, list)
-    #[command(alias = "template")]
-    Templates {
-        #[command(subcommand)]
-        action: TemplatesSubcommand,
+    /// Ask a question about your codebase
+    Ask {
+        /// The question to ask
+        question: Vec<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Generate a changelog from git tags and commits
+    Changelog {
+        /// Number of releases to show
+        #[arg(short, long, default_value = "10")]
+        limit: usize,
+        /// Show a specific tag only
+        #[arg(short, long)]
+        tag: Option<String>,
+        /// Show unreleased changes since the latest tag
+        #[arg(long)]
+        unreleased: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// View CI/CD check status for a branch
+    Checks {
+        /// Branch to check (default: current branch)
+        #[arg(short, long)]
+        branch: Option<String>,
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Generate shell completions
     Completions {
@@ -70,15 +96,26 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
-    /// Manage specs (check, init, new)
-    Spec {
-        #[command(subcommand)]
-        action: SpecSubcommand,
+    /// Check dependency health (outdated, audit, licenses)
+    Deps {
+        /// Check for outdated dependencies
+        #[arg(long)]
+        outdated: bool,
+        /// Run security audit via ecosystem tools
+        #[arg(long)]
+        audit: bool,
+        /// Show dependency licenses
+        #[arg(long)]
+        licenses: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
-    /// Feature branch and PR workflow
-    Work {
-        #[command(subcommand)]
-        action: WorkSubcommand,
+    /// Diagnose project environment health
+    Doctor {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// List and view GitHub issues
     Issues {
@@ -97,113 +134,11 @@ enum Commands {
         #[arg(long, global = true)]
         label: Option<String>,
     },
-    /// List and view GitHub pull requests
-    Prs {
-        #[command(subcommand)]
-        action: Option<PrsSubcommand>,
-        /// Filter by state (open, closed, all)
-        #[arg(short, long, default_value = "open", global = true)]
-        state: String,
-        /// Maximum number of results
-        #[arg(short, long, default_value = "20", global = true)]
-        limit: usize,
-        /// Output results as JSON
-        #[arg(long, global = true)]
-        json: bool,
-    },
-    /// AI-powered code review of current changes
-    Review {
-        /// Base branch to diff against (default: auto-detect)
-        #[arg(short, long)]
-        base: Option<String>,
-        /// Review only a specific file
-        #[arg(short, long)]
-        file: Option<String>,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-        /// Claude model to use (e.g. sonnet, opus, haiku)
-        #[arg(short, long)]
-        model: Option<String>,
-        /// Custom review focus prompt (appended to default instructions)
-        #[arg(short, long)]
-        prompt: Option<String>,
-        /// Output format: summary (default), checklist, inline
-        #[arg(long, default_value = "summary")]
-        format: String,
-    },
-    /// View CI/CD check status for a branch
-    Checks {
-        /// Branch to check (default: current branch)
-        #[arg(short, long)]
-        branch: Option<String>,
-        /// Output results as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// Run a project task defined in fledge.toml
-    Run {
-        /// Task name to run (lists tasks if omitted)
-        task: Option<String>,
-        /// Create a starter fledge.toml
-        #[arg(long)]
-        init: bool,
-        /// List available tasks
-        #[arg(short, long)]
-        list: bool,
-        /// Override detected project language (e.g. rust, node, go, python, swift, ruby, java-gradle, java-maven)
-        #[arg(long)]
-        lang: Option<String>,
-        /// Output results as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// Watch for file changes and re-run a task or lane
-    Watch {
-        /// Task name to re-run on changes (use --lane for lanes)
-        name: String,
-        /// Watch and re-run a lane instead of a task
-        #[arg(long)]
-        lane: bool,
-        /// Only watch a specific directory (default: current directory)
-        #[arg(short, long)]
-        path: Option<PathBuf>,
-        /// Only trigger on specific file extensions (comma-separated, e.g. "rs,toml")
-        #[arg(short, long)]
-        ext: Option<String>,
-        /// Debounce interval in milliseconds
-        #[arg(short, long, default_value = "500")]
-        debounce: u64,
-        /// Clear terminal before each run
-        #[arg(long)]
-        clear: bool,
-    },
     /// Manage and run composable workflow pipelines
     #[command(alias = "lane")]
     Lanes {
         #[command(subcommand)]
         action: LaneSubcommand,
-    },
-    /// Generate a changelog from git tags and commits
-    Changelog {
-        /// Number of releases to show
-        #[arg(short, long, default_value = "10")]
-        limit: usize,
-        /// Show a specific tag only
-        #[arg(short, long)]
-        tag: Option<String>,
-        /// Show unreleased changes since the latest tag
-        #[arg(long)]
-        unreleased: bool,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// Diagnose project environment health
-    Doctor {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
     },
     /// Project code metrics (LOC, churn, test ratio)
     Metrics {
@@ -220,27 +155,26 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Check dependency health (outdated, audit, licenses)
-    Deps {
-        /// Check for outdated dependencies
-        #[arg(long)]
-        outdated: bool,
-        /// Run security audit via ecosystem tools
-        #[arg(long)]
-        audit: bool,
-        /// Show dependency licenses
-        #[arg(long)]
-        licenses: bool,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-    },
     /// Manage plugins (install, remove, list, search)
     #[command(alias = "plugin")]
     Plugins {
         #[command(subcommand)]
         action: PluginSubcommand,
         /// Output as JSON
+        #[arg(long, global = true)]
+        json: bool,
+    },
+    /// List and view GitHub pull requests
+    Prs {
+        #[command(subcommand)]
+        action: Option<PrsSubcommand>,
+        /// Filter by state (open, closed, all)
+        #[arg(short, long, default_value = "open", global = true)]
+        state: String,
+        /// Maximum number of results
+        #[arg(short, long, default_value = "20", global = true)]
+        limit: usize,
+        /// Output results as JSON
         #[arg(long, global = true)]
         json: bool,
     },
@@ -267,13 +201,79 @@ enum Commands {
         #[arg(long)]
         allow_dirty: bool,
     },
-    /// Ask a question about your codebase
-    Ask {
-        /// The question to ask
-        question: Vec<String>,
+    /// AI-powered code review of current changes
+    Review {
+        /// Base branch to diff against (default: auto-detect)
+        #[arg(short, long)]
+        base: Option<String>,
+        /// Review only a specific file
+        #[arg(short, long)]
+        file: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Claude model to use (e.g. sonnet, opus, haiku)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Custom review focus prompt (appended to default instructions)
+        #[arg(short, long)]
+        prompt: Option<String>,
+        /// Output format: summary (default), checklist, inline
+        #[arg(long, default_value = "summary")]
+        format: String,
+    },
+    /// Run a project task defined in fledge.toml
+    Run {
+        /// Task name to run (lists tasks if omitted)
+        task: Option<String>,
+        /// Create a starter fledge.toml
+        #[arg(long)]
+        init: bool,
+        /// List available tasks
+        #[arg(short, long)]
+        list: bool,
+        /// Override detected project language (e.g. rust, node, go, python, swift, ruby, java-gradle, java-maven)
+        #[arg(long)]
+        lang: Option<String>,
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Manage specs (check, init, new)
+    Spec {
+        #[command(subcommand)]
+        action: SpecSubcommand,
+    },
+    /// Manage templates (init, create, search, update, publish, validate, list)
+    #[command(alias = "template")]
+    Templates {
+        #[command(subcommand)]
+        action: TemplatesSubcommand,
+    },
+    /// Watch for file changes and re-run a task or lane
+    Watch {
+        /// Task name to re-run on changes (use --lane for lanes)
+        name: String,
+        /// Watch and re-run a lane instead of a task
+        #[arg(long)]
+        lane: bool,
+        /// Only watch a specific directory (default: current directory)
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+        /// Only trigger on specific file extensions (comma-separated, e.g. "rs,toml")
+        #[arg(short, long)]
+        ext: Option<String>,
+        /// Debounce interval in milliseconds
+        #[arg(short, long, default_value = "500")]
+        debounce: u64,
+        /// Clear terminal before each run
+        #[arg(long)]
+        clear: bool,
+    },
+    /// Feature branch and PR workflow
+    Work {
+        #[command(subcommand)]
+        action: WorkSubcommand,
     },
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -520,6 +520,9 @@ enum LaneSubcommand {
         /// Show execution plan without running
         #[arg(long)]
         dry_run: bool,
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// List available lanes
     List {
@@ -832,7 +835,15 @@ fn run() -> Result<()> {
         }
         Commands::Lanes { action } => {
             let action = match action {
-                LaneSubcommand::Run { name, dry_run } => lanes::LaneAction::Run { name, dry_run },
+                LaneSubcommand::Run {
+                    name,
+                    dry_run,
+                    json,
+                } => lanes::LaneAction::Run {
+                    name,
+                    dry_run,
+                    json,
+                },
                 LaneSubcommand::List { json } => lanes::LaneAction::List { json },
                 LaneSubcommand::Init => lanes::LaneAction::Init,
                 LaneSubcommand::Search {
@@ -875,7 +886,12 @@ fn run() -> Result<()> {
                 LaneSubcommand::External(args) => {
                     let name = args.first().cloned().unwrap_or_default();
                     let dry_run = args.iter().any(|a| a == "--dry-run");
-                    lanes::LaneAction::Run { name, dry_run }
+                    let json = args.iter().any(|a| a == "--json");
+                    lanes::LaneAction::Run {
+                        name,
+                        dry_run,
+                        json,
+                    }
                 }
             };
             lanes::run(action)?;

--- a/src/release.rs
+++ b/src/release.rs
@@ -142,6 +142,7 @@ fn run_pre_lane(lane: &str, dry_run: bool) -> Result<()> {
     let action = crate::lanes::LaneAction::Run {
         name: lane.to_string(),
         dry_run,
+        json: false,
     };
     crate::lanes::run(action)?;
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -149,6 +149,7 @@ fn run_target(opts: &WatchOptions) {
         lanes::run(lanes::LaneAction::Run {
             name: opts.name.clone(),
             dry_run: false,
+            json: false,
         })
     } else {
         task_runner::run(task_runner::RunOptions {


### PR DESCRIPTION
## Summary
- Reorder `Commands` enum alphabetically so `fledge --help` displays commands A-Z instead of in code-addition order
- Add `--json` flag to `fledge lane run` for structured JSON output (lane summary, step results with name/success/duration/error)
- Create full watch spec (v1) with companion files (context, requirements, tasks, testing)
- Update run spec (v1→v2), lanes spec (v8→v9), main spec (v1→v2)

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — 144 tests pass
- [x] `cargo fmt --check` — formatted
- [x] `cargo clippy` — no warnings
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)