### PR TITLE
release: prep v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-04-23
+
+### Added
+
+- Swift (Package.swift) and Kotlin (Gradle/Maven) dependency support in `fledge deps` (#239)
+
 ## [0.12.0] - 2026-04-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["CorvidLabs <corvidlabs@proton.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."


### PR DESCRIPTION
## Summary
- Bump version to 0.12.1
- Add changelog entry for Swift and Kotlin/Gradle/Maven deps support (#239)

## Test plan
- [x] All 144 tests pass
- [x] Pre-commit checks pass (specs, formatting, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)