### PR TITLE
docs: add trust spec companion files

### DIFF
--- a/specs/trust/context.md
+++ b/specs/trust/context.md
@@ -1,0 +1,33 @@
+---
+spec: trust.spec.md
+---
+
+## Key Decisions
+
+- Extracted from `plugin.rs` so `templates`, `lanes`, and `search` can share one classification rule — trust tiers are a cross-cutting concept, not a plugin-only one
+- `TrustTier` serializes as lowercase strings (`"official"`, `"community"`, `"unverified"`) for stable JSON output across commands
+- `OFFICIAL_ORGS` is a `&[&str]` constant, not runtime config — changing the official set is a code change and should require a PR
+- `Community` tier is defined now even though no source maps to it, so downstream code (list, audit, search) already handles three cases and adding community sources later is additive
+- `parse_source_ref` uses `rsplit_once('@')` and explicitly guards against credential URLs (`https://user:token@host/...`) and SSH prefixes (`git@github.com:...`) to avoid mis-parsing the `@` as a ref delimiter
+- Styled labels use fixed colors (green=official, cyan=community, yellow=unverified) — consistent across every command that shows trust tiers
+
+## Files to Read First
+
+- `src/trust.rs` — complete implementation (~100 LOC + tests)
+- `specs/trust/trust.spec.md` — formal API, invariants, and behavioral examples
+- `src/plugin.rs` — primary consumer; shows how tiers surface in `list`, `install`, and `audit`
+- `src/search.rs`, `src/lanes.rs`, `src/init.rs` — other consumers using `determine_trust_tier_from_owner`
+
+## Current Status
+
+- Fully implemented at v1
+- Consumed by 4 modules: `plugin`, `lanes`, `search`, `init`
+- 13 unit tests covering all source forms (shorthand, HTTPS, SSH, with/without ref, case sensitivity, credential URLs)
+- No known bugs or open work items
+
+## Notes
+
+- If you're adding a new extension type that installs from a source URL, reach for `determine_trust_tier` — do not reinvent the classification
+- If you need to surface tier in CLI output, call `styled_label()` for terminal display and `label()` for JSON / structured output
+- `parse_source_ref` handles the common `owner/repo@ref` shorthand; if you need to parse the ref separately before classifying, call it first and pass the base to `determine_trust_tier`
+- The `#[allow(dead_code)]` on `TrustTier` is intentional: not every variant is constructed from every call site, but all three are public API surface

--- a/specs/trust/tasks.md
+++ b/specs/trust/tasks.md
@@ -1,0 +1,28 @@
+---
+spec: trust.spec.md
+---
+
+## Tasks
+
+- [x] Extract trust tier logic from `plugin.rs` into shared `trust` module
+- [x] Define `TrustTier` enum (Official, Community, Unverified) with serde lowercase serialization
+- [x] Implement `label` and `styled_label` methods on `TrustTier`
+- [x] Implement `determine_trust_tier` supporting HTTPS, SSH, and shorthand forms
+- [x] Implement `determine_trust_tier_from_owner` for direct owner classification
+- [x] Implement `parse_source_ref` with credential-URL safety (no false-split on `user:token@host`)
+- [x] Wire module into `plugin`, `lanes`, `search`, and `init`
+- [x] Write unit tests covering all source forms and the community tier label
+- [x] Write spec
+
+## Gaps
+
+- `Community` tier is defined and styled but no source currently maps to it — reserved for a future verified-contributor program
+- Org matching is limited to a hardcoded `OFFICIAL_ORGS` list (`CorvidLabs`, `corvidlabs`); no runtime configuration
+- No support for non-GitHub sources (GitLab, self-hosted) — all classification assumes GitHub URLs or `owner/repo` shorthand
+
+## Review Sign-offs
+
+- **Product**: done
+- **QA**: done
+- **Design**: n/a
+- **Dev**: done

--- a/specs/trust/testing.md
+++ b/specs/trust/testing.md
@@ -1,0 +1,61 @@
+---
+spec: trust.spec.md
+---
+
+## Test Plan
+
+### Unit Tests
+
+Located in `src/trust.rs` under `#[cfg(test)] mod tests`:
+
+- `official_shorthand` — `CorvidLabs/repo` classifies as `Official`
+- `official_full_url` — `https://github.com/CorvidLabs/repo` classifies as `Official`
+- `official_ssh_url` — `git@github.com:CorvidLabs/repo.git` classifies as `Official`
+- `official_with_ref` — `CorvidLabs/repo@v1.0.0` classifies as `Official` (ref stripped before classification)
+- `official_case_insensitive` — lowercase `corvidlabs/repo` classifies as `Official`
+- `unverified_third_party` — `someuser/repo` classifies as `Unverified`
+- `unverified_full_url` — `https://github.com/someuser/repo` classifies as `Unverified`
+- `owner_based_official` — `determine_trust_tier_from_owner("CorvidLabs")` returns `Official`
+- `owner_based_unverified` — `determine_trust_tier_from_owner("someuser")` returns `Unverified`
+- `parse_source_ref_with_tag` — splits `someone/repo@v1.2.0` into `("someone/repo", Some("v1.2.0"))`
+- `parse_source_ref_without_tag` — leaves `someone/repo` unsplit, ref `None`
+- `parse_source_ref_full_url_with_tag` — splits `https://github.com/…/repo.git@v2.0.0` correctly
+- `parse_source_ref_credential_url_no_split` — credential URL `https://user:token@github.com/…` does NOT split on credential `@`
+- `labels` — `label()` returns `"official"`, `"community"`, `"unverified"`
+
+### Integration Tests
+
+Trust classification is exercised end-to-end through the consuming modules:
+
+- `plugin list` / `plugin audit` — trust tier appears in output for each installed plugin (`tests/cli.rs` plugin tests)
+- `search` / `lane search` — tier badge appears next to each discovered template/lane
+- `init` — official template vs unverified template paths
+
+No dedicated integration test file for `trust` itself — the API surface is pure functions over strings and is covered comprehensively by unit tests.
+
+### Manual Testing
+
+```bash
+# Install from an official source and verify badge
+fledge plugins install CorvidLabs/fledge-plugin-example
+fledge plugins list          # expect green [official]
+fledge plugins audit         # expect [official] in audit output
+
+# Install from an unverified source
+fledge plugins install someuser/fledge-plugin-example
+fledge plugins list          # expect yellow [unverified]
+
+# Search shows tier per result
+fledge plugins search deploy
+fledge search rust           # templates also show tier
+
+# JSON output uses lowercase labels
+fledge plugins list --json | jq '.[].trust_tier'
+# -> "official" / "unverified"
+```
+
+### Regression Watch
+
+- Adding a new consumer module: make sure it uses `determine_trust_tier` rather than re-implementing org matching
+- Any change to `OFFICIAL_ORGS` or URL parsing logic must be covered by a new unit test before shipping
+- Credential URL handling (`parse_source_ref_credential_url_no_split`) is the subtlest case — never remove that test without an explicit replacement


### PR DESCRIPTION
## Summary
- Adds `tasks.md`, `context.md`, and `testing.md` to `specs/trust/` so the module matches the documentation standard used by every other spec.
- Resolves the three companion-file warnings previously surfaced by `fledge spec check`.

## Test plan
- [x] `fledge spec check` — 32 specs, 0 errors, 0 warnings
- [x] `fledge lane run pre-commit` — fmt, lint, test, spec-check all green