### PR TITLE
feat: agent-facing surface — AGENTS.md, spec list/show --json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# AGENTS.md — fledge for AI agents
+
+This doc is for AI agents (Claude Code, GPT-based coding agents, OpenHands, etc.) using the `fledge` CLI alongside a human. Humans get `README.md` and `docs/`; agents get this one page.
+
+## What fledge is, in one paragraph
+
+`fledge` is a single-binary dev-lifecycle CLI (Rust). It scaffolds projects from templates, runs tasks (`fledge run`), composes them into lanes (`fledge lane run`), manages branches and PRs (`fledge work`), validates specs (`fledge spec`), checks deps (`fledge deps`), runs AI review (`fledge review`), and more. It replaces ad-hoc Makefile + scripts + per-repo READMEs with a uniform verb/noun interface.
+
+If you are about to run `npm`, `cargo`, `make`, `git checkout -b`, or `gh pr create`, check first whether fledge has a wrapper — it usually does, and the wrapper often has `--json` and guardrails you want.
+
+## Golden rules
+
+1. **Prefer fledge subcommands over raw tools** when wrapped. E.g. use `fledge work start` instead of `git checkout -b`, `fledge run test` instead of guessing `cargo test` vs `npm test`.
+2. **Always add `--json` when a command supports it** (see list below). Parse the JSON; do not screen-scrape pretty output.
+3. **Always pass `--yes` / `--force` to commands that otherwise prompt** (see TTY table). A stalled prompt looks like success to you but blocks forever.
+4. **Check exit codes.** Non-zero means something failed, even if stdout looks fine.
+5. **Don't mutate without running `fledge lane run pre-commit` first** — it's the project-defined quality gate.
+
+## Discover what fledge can do
+
+```bash
+fledge --help                        # top-level command list (human text)
+fledge <cmd> --help                  # per-command flags
+fledge spec list --json              # all 32 specs as a JSON array
+fledge spec show <name> --json       # one spec's structure as JSON
+```
+
+Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for *why* a module exists. When you need context beyond what the code shows, read the spec — particularly `specs/<name>/context.md` (design decisions) and `specs/<name>/requirements.md` (user stories).
+
+## Machine-readable surface (`--json`)
+
+| Command | What you get | Use when |
+|---------|-------------|----------|
+| `fledge spec list --json` | Array of spec summaries (module, version, status, sections, companions) | Orienting to a new codebase |
+| `fledge spec show <name> --json` | Single spec detail (frontmatter + section list + companion status) | Need structured view of one module |
+| `fledge ask "..." --json` | `{question, answer}` from an LLM over the codebase | Answering a question about the code |
+| `fledge review --json` | `{base, file, diff_stats, review}` AI code review of current changes | Before opening a PR |
+| `fledge checks --json` | CI/CD check status for a branch | Verifying a branch is green |
+| `fledge doctor --json` | Environment health diagnostics | Debugging a broken toolchain |
+| `fledge deps --json` | Dependency report (outdated, audit, licenses) | Auditing a project |
+| `fledge metrics --json` | LOC, churn, test ratio per file | Triaging hotspots |
+| `fledge changelog --json` | Structured changelog from tags | Generating release notes |
+| `fledge validate-template --json` | Template validation report | Before publishing a template |
+| `fledge search <q> --json` | Template/plugin search results | Finding reusable pieces |
+| `fledge plugins list --json` | Installed plugins with trust tier, capabilities | Auditing plugin state |
+| `fledge issues --json` | GitHub issues list | Picking up work |
+| `fledge lane run <name> --json` | Lane execution results | Running the project's own CI pipeline |
+
+Commands **without** `--json` (pretty output only): `init`, `spec check`, `spec init`, `spec new`, `run`, `publish`, `create-template`, `watch`, `work`, `release`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
+
+## Commands that block on TTY prompts
+
+These commands use `dialoguer` prompts. Agents must pass the bypass flag or the process will hang forever.
+
+| Command | Bypass flag | Effect |
+|---------|------------|--------|
+| `fledge init` | `--yes` | Skip interactive template-variable prompts (uses detected defaults) |
+| `fledge templates publish` | `--yes` | Skip "update existing repo?" confirmation |
+| `fledge templates create` | `--yes` | Skip name/description/type prompts |
+| `fledge plugins install` | `--yes` + `--force` | Skip trust-tier and capability-grant prompts |
+| `fledge plugins publish` | `--yes` | Skip confirmations |
+| `fledge plugins create` | `--yes` | Skip scaffolding prompts |
+
+Commands safe to call non-interactively today: `ask`, `review`, `checks`, `doctor`, `deps`, `metrics`, `changelog`, `spec *`, `work start`, `work pr`, `run`, `lane run`, `release`, `validate-template`, `search`, `plugins list`, `plugins remove`, `plugins update`, `plugins audit`, `issues`, `prs`, `watch`.
+
+## AI commands
+
+`fledge ask` and `fledge review` delegate to the `claude` CLI, which must be installed and authenticated on the host. The agent running fledge inherits whatever auth the `claude` CLI has.
+
+```bash
+fledge ask "how does the work module build branch names?" --json
+# -> {"question": "...", "answer": "..."}
+
+fledge review --json                   # reviews current diff vs main
+fledge review --base HEAD~3 --json     # reviews last 3 commits
+fledge review --model opus --format checklist --json
+```
+
+Neither command currently feeds spec content into the prompt automatically. If you want the LLM to know about specs, grep/read them first and paste excerpts into your own prompt, or use `fledge spec show <name> --json` and include the result.
+
+## Typical agent workflows
+
+### Start a task
+```bash
+fledge spec list --json                                    # orient
+fledge spec show <module> --json                           # dig into one area
+fledge work start my-change -t feat                        # branch
+```
+
+### Before reporting a task done
+```bash
+fledge lane run pre-commit                                 # fmt + lint + test + spec-check
+# or the project-specific full lane:
+fledge lane run ci
+```
+
+### Open a PR
+```bash
+fledge work pr --title "feat: ..." --body "## Summary\n..."
+```
+
+### Inspect a spec's deeper context as part of planning
+```bash
+cat specs/<name>/context.md      # design decisions
+cat specs/<name>/requirements.md # user stories / acceptance
+cat specs/<name>/tasks.md        # what's done, what's gapped
+cat specs/<name>/testing.md      # test plan
+```
+
+## Exit codes
+
+- `0` — success
+- `1` — user-facing error (bad input, missing file, validation failure, prompt required in non-TTY)
+- Non-zero exit also fires on `fledge spec check` errors, `fledge lane run` failures, and `fledge review` errors
+
+## Project-specific quality gate
+
+This repo defines its own lanes in `fledge.toml`. The key ones for agents:
+
+- `fledge lane run pre-commit` — fmt + lint + test + spec-check (required before opening a PR)
+- `fledge lane run ci` — full CI pipeline locally
+- `fledge lane run check` — quick parallel fmt+lint then test
+- `fledge spec check` — always run if you touched `src/` or `specs/`
+
+## When things go wrong
+
+- **A command hung**: you probably skipped `--yes` or `--force`. Cancel, re-run with the bypass flag.
+- **`fledge ask` / `review` errored with auth**: the host's `claude` CLI isn't set up. This is a host-config problem, not a fledge bug.
+- **`fledge spec check` fails**: read the error — almost always a missing section, missing source file, or unknown status. Don't "fix" it by editing the validator.
+- **`fledge work pr` fails on push**: you're probably not on a remote-tracking branch. Re-run after `git push -u origin HEAD` or debug with `fledge work status`.
+
+## Extending fledge for better agent support
+
+If a command you want doesn't expose `--json`, or a workflow isn't automatable, the right fix is:
+1. Open an issue tagged `agent-surface`
+2. Update the corresponding spec (`specs/<module>/<module>.spec.md`) — bump the version, add the new flag to Public API + Behavioral Examples
+3. Implement + `fledge lane run pre-commit` + PR
+
+The project explicitly welcomes agent-surface improvements.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,5 +18,6 @@
 - [Use Cases & Plugin Ideas](./use-cases.md)
 - [GitHub Integration](./github-integration.md)
 - [CLI Reference](./cli-reference.md)
+- [Using fledge with AI Agents](./agents.md)
 - [Troubleshooting](./troubleshooting.md)
 - [Changelog](./changelog.md)

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -1,0 +1,105 @@
+# Using fledge with AI Agents
+
+fledge is designed for humans *and* AI agents to use the same CLI. Human-facing docs (the rest of this book) cover *why* and *how-to*; this page covers what an agent specifically needs to know.
+
+The canonical short-form entrypoint for agents lives at `AGENTS.md` in the repository root. This page is its long-form companion — link or point agents to either.
+
+## Design principles
+
+fledge follows three rules that make it agent-usable:
+
+1. **Structured output is first-class.** Most commands accept `--json`. Never require an agent to screen-scrape.
+2. **Non-interactive bypass exists.** Every command that prompts has a `--yes` or `--force` flag. Silence isn't success — it's a hung process.
+3. **Specs are machine-readable.** `fledge spec list --json` and `fledge spec show <name> --json` let agents discover the codebase's intent without filesystem spelunking.
+
+## The agent-facing surface
+
+### Commands with `--json`
+
+| Command | Payload shape |
+|---------|---------------|
+| `fledge spec list --json` | Array of `{name, version, status, path, files, section_count, required_sections, companions, missing_companions}` |
+| `fledge spec show <name> --json` | `{name, version, status, path, files, sections, companions, missing_companions}` |
+| `fledge ask "..." --json` | `{question, answer}` |
+| `fledge review --json` | `{base, file, diff_stats, review}` |
+| `fledge checks --json` | CI check status |
+| `fledge doctor --json` | Environment diagnostics |
+| `fledge deps --json` | Dependency report |
+| `fledge metrics --json` | LOC / churn / test ratio |
+| `fledge changelog --json` | Structured changelog |
+| `fledge validate-template --json` | Template validation report |
+| `fledge search <q> --json` | Search results |
+| `fledge plugins list --json` | Installed plugins |
+| `fledge issues --json` | GitHub issues |
+| `fledge lane run <name> --json` | Lane execution results |
+
+### Commands that block without `--yes`
+
+`fledge init`, `fledge templates publish`, `fledge templates create`, `fledge plugins install`, `fledge plugins publish`, `fledge plugins create`. Pass `--yes` (and `--force` for plugin install) in agent contexts.
+
+### AI-powered commands
+
+`fledge ask` and `fledge review` wrap the `claude` CLI. The host environment must have `claude` installed and authenticated. These commands will exit non-zero if auth is missing — that's a host-config issue, not a fledge issue.
+
+## Typical agent workflows
+
+### Orient to a new repo
+
+```bash
+fledge doctor --json                 # is the toolchain present?
+fledge spec list --json              # what modules exist, what's their status?
+fledge spec show <interesting> --json  # drill in
+cat specs/<name>/context.md          # design decisions (not yet in JSON)
+```
+
+### Do a task
+
+```bash
+fledge work start my-change -t feat  # branch created off main
+# ... edit files ...
+fledge lane run pre-commit           # fmt + lint + test + spec-check
+fledge work pr --title "..." --body "..."  # push + open PR
+```
+
+### Validate before reporting done
+
+```bash
+fledge lane run pre-commit           # project's required gate
+fledge spec check                    # no drift between code and specs
+fledge checks --json                 # CI status after push
+```
+
+## Reading specs programmatically
+
+Every module in `src/` has a matching spec under `specs/<module>/`. The `.spec.md` file holds the formal API, invariants, and change log. The companion files hold:
+
+| File | What's inside |
+|------|----------------|
+| `requirements.md` | User stories, acceptance criteria, constraints, out-of-scope |
+| `tasks.md` | What's done, what's gapped, review sign-offs |
+| `context.md` | Design decisions, files-to-read-first, current status |
+| `testing.md` | Unit/integration/manual test plan |
+
+`fledge spec show <name> --json` returns the frontmatter and section list, but not the body text. For body text, read the file directly.
+
+## Exit codes
+
+- `0` — success
+- Non-zero — some failure (validation, missing prereq, user-facing error). Always check.
+
+## What's not yet agent-friendly
+
+These are known gaps; PRs welcome. Each is tracked via the `agent-surface` label.
+
+- `fledge run`, `fledge init`, `fledge spec check/init/new`, `fledge work`, `fledge release` have no `--json` today
+- `fledge ask` does not automatically feed specs into its prompt — agents must paste spec excerpts themselves
+- No global `--non-interactive` flag that forces `--yes` on every subcommand at once
+- No `fledge introspect --json` to dump the full command tree as JSON
+
+## Contributing agent-surface improvements
+
+1. Open an issue tagged `agent-surface` describing what you need.
+2. Update the relevant spec (`specs/<module>/<module>.spec.md`) — bump version, add the new flag to Public API and Behavioral Examples, add a Change Log entry.
+3. Implement. Run `fledge lane run pre-commit`. Open a PR via `fledge work pr`.
+
+The goal is that every fledge command, eventually, is equally usable by a human at a terminal and an agent scripting against it.

--- a/specs/spec/context.md
+++ b/specs/spec/context.md
@@ -18,3 +18,6 @@ The implementation focuses on structural validation (frontmatter, sections, file
 - Parse YAML frontmatter manually (split on `---` delimiters) rather than adding a YAML dependency
 - Reuse serde for frontmatter deserialization via a simple YAML-to-JSON converter
 - Compatible with spec-sync v4 config format so CI and local checks stay in sync
+- `spec list` and `spec show` were added in v2 specifically to give AI agents a machine-readable view of the spec tree. Without them, an agent had to shell out to `ls specs/`, guess filenames, and hand-parse frontmatter. Both commands expose the same frontmatter-derived shape that `check` already computes internally.
+- `spec list --json` emits `[]` on empty directories (not an error, not a message) so agents can unconditionally parse the output as JSON.
+- `spec show` errors when the module is missing, rather than returning null/empty — an agent getting a non-zero exit immediately knows to fall back to `spec list`.

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 1
+version: 2
 status: active
 files:
   - src/spec.rs
@@ -13,7 +13,7 @@ depends_on: []
 
 ## Purpose
 
-Integrates spec-sync validation into fledge as native subcommands. Provides `fledge spec check` to validate specs against source code, `fledge spec init` to scaffold a `.specsync/` configuration directory, and `fledge spec new <name>` to create a new spec module with companion files.
+Integrates spec-sync validation into fledge as native subcommands. Provides `fledge spec check` to validate specs against source code, `fledge spec init` to scaffold a `.specsync/` configuration directory, `fledge spec new <name>` to create a new spec module with companion files, `fledge spec list` to enumerate all specs, and `fledge spec show <name>` to inspect a single spec's structure. `list` and `show` support `--json` so agents and tools can consume spec metadata programmatically.
 
 ## Public API
 
@@ -22,16 +22,18 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point that dispatches to the appropriate spec subcommand |
-| `SpecAction` | Enum of subcommands: Check, Init, New |
+| `SpecAction` | Enum of subcommands: Check, Init, New, List, Show |
 | `SpecFrontmatter` | Parsed YAML frontmatter from a spec file |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `SpecAction` | Enum of subcommands: Check, Init, New |
+| `SpecAction` | Enum of subcommands: Check, Init, New, List, Show |
 | `SpecFrontmatter` | Parsed YAML frontmatter from a spec file |
 | `SpecResult` | Result of validating a single spec (warnings + errors) |
+| `SpecSummary` | (private) Summary for `list`: name, version, status, path, files, section/required counts, companions, missing companions |
+| `SpecDetail` | (private) Detail for `show`: name, version, status, path, files, sections, companions, missing companions |
 | `ValidationIssue` | Individual issue: message and is_error flag |
 
 ### Traits
@@ -43,10 +45,12 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `run` | `(SpecAction) -> Result<()>` | Dispatches to check, init, or new |
+| `run` | `(SpecAction) -> Result<()>` | Dispatches to check, init, new, list, or show |
 | `check` | `(root: &Path, strict: bool) -> Result<()>` | Validates all specs and prints report (private) |
 | `init` | `(root: &Path) -> Result<()>` | Scaffolds `.specsync/` with config.toml, registry.toml, .gitignore, version (private) |
 | `new_spec` | `(root: &Path, name: &str) -> Result<()>` | Creates spec directory with spec.md and companion files (private) |
+| `list_specs` | `(root: &Path, json: bool) -> Result<()>` | Enumerate specs with frontmatter, section counts, and companion status (private) |
+| `show_spec` | `(root: &Path, name: &str, json: bool) -> Result<()>` | Show a single spec's frontmatter, sections, and companion status (private) |
 
 ## Invariants
 
@@ -57,6 +61,9 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 5. All files listed in frontmatter `files` must exist on disk
 6. All required sections from config must be present in the spec body
 7. Companion files (requirements.md, tasks.md, context.md, testing.md) are validated if present
+8. `spec list` returns sorted results by module name; `--json` emits an array (empty array when no specs)
+9. `spec show` errors if the spec is not found and suggests `fledge spec list`
+10. `spec list` and `spec show` are read-only — they never mutate the filesystem
 
 ## Behavioral Examples
 
@@ -111,19 +118,86 @@ $ fledge spec new auth
   Spec module 'auth' created. Edit specs/auth/auth.spec.md to get started.
 ```
 
+### spec list — enumerate specs
+```
+$ fledge spec list
+● ask v2 (active)
+    specs/ask/ask.spec.md — 1 source file, 7/7 sections, 4 companion files
+● trust v1 (active)
+    specs/trust/trust.spec.md — 1 source file, 7/7 sections, 4 companion files
+
+  32 spec(s) found
+```
+
+### spec list --json — machine-readable summary
+```
+$ fledge spec list --json
+[
+  {
+    "name": "trust",
+    "version": 1,
+    "status": "active",
+    "path": "specs/trust/trust.spec.md",
+    "files": ["src/trust.rs"],
+    "section_count": 7,
+    "required_sections": 7,
+    "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
+    "missing_companions": []
+  }
+]
+```
+
+### spec show — inspect one spec
+```
+$ fledge spec show trust
+trust v1 (active)
+  path: specs/trust/trust.spec.md
+  source files:
+    - src/trust.rs
+  sections (7):
+    - Purpose
+    - Public API
+    - Invariants
+    - Behavioral Examples
+    - Error Cases
+    - Dependencies
+    - Change Log
+  companions:
+    ✓ requirements.md
+    ✓ tasks.md
+    ✓ context.md
+    ✓ testing.md
+```
+
+### spec show --json — full detail
+```
+$ fledge spec show trust --json
+{
+  "name": "trust",
+  "version": 1,
+  "status": "active",
+  "path": "specs/trust/trust.spec.md",
+  "files": ["src/trust.rs"],
+  "sections": ["Purpose", "Public API", "Invariants", ...],
+  "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
+  "missing_companions": []
+}
+```
+
 ## Error Cases
 
 | Error | When | Behavior |
 |-------|------|----------|
-| `.specsync/config.toml` not found | `spec check` without init | Print helpful message suggesting `fledge spec init` |
+| `.specsync/config.toml` not found | `spec check`, `spec list`, or `spec show` without init | Print helpful message suggesting `fledge spec init` |
 | `.specsync/` already exists | `spec init` on initialized project | Bail with message |
 | Spec directory already exists | `spec new <name>` where `specs/<name>/` exists | Bail with message |
-| Invalid YAML frontmatter | Spec file has malformed frontmatter | Report as error, continue checking other specs |
-| No specs found | `spec check` with empty specs directory | Print message, exit 0 |
+| Invalid YAML frontmatter | Spec file has malformed frontmatter | `check` reports as error; `list` surfaces as a parse error line; `show` bails with context |
+| No specs found | `spec check` or `spec list` with empty specs directory | Print message (or `[]` with `--json`), exit 0 |
+| Spec not found | `spec show <name>` with unknown module | Bail with suggestion to run `fledge spec list` |
 
 ## Dependencies
 
-- `serde` / `serde_json` — frontmatter parsing
+- `serde` / `serde_json` — frontmatter parsing and JSON output
 - `toml` — config reading/writing
 - `walkdir` — spec directory traversal
 - `console` — styled terminal output
@@ -132,4 +206,5 @@ $ fledge spec new auth
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-23 | Add `spec list` (alias `ls`) and `spec show`, both with `--json` support for agent/tool consumption |
 | 1 | 2026-04-19 | Initial spec for fledge spec integration |

--- a/specs/spec/tasks.md
+++ b/specs/spec/tasks.md
@@ -12,3 +12,13 @@ spec: spec.spec.md
 - [x] Wire up CLI subcommands in main.rs
 - [x] Write unit tests
 - [x] Run verification suite (test, clippy, fmt)
+- [x] Implement `spec list` + `ls` alias with pretty and JSON output
+- [x] Implement `spec show <name>` with pretty and JSON output
+- [x] Share a `COMPANION_FILES` constant between check/list/show
+- [x] Bump spec module to v2 and document new subcommands
+
+## Gaps
+
+- No way to filter `spec list` by status or companion-completeness — agents must post-filter JSON
+- `spec show` does not include companion file *contents* — reading `tasks.md`/`context.md` still requires a filesystem read
+- No `spec sections <name>` subcommand to dump section bodies (agents wanting the Purpose of a module must still parse the markdown themselves)

--- a/specs/spec/testing.md
+++ b/specs/spec/testing.md
@@ -22,3 +22,9 @@ spec: spec.spec.md
 - `fledge spec check` on fledge's own specs (self-validation)
 - `fledge spec init` in a temp directory
 - `fledge spec new` in an initialized project
+- `fledge spec list` enumerates all specs, sorted by name
+- `fledge spec list --json` produces parseable JSON array (empty array for empty projects)
+- `fledge spec ls` is a working alias for `list`
+- `fledge spec show <name>` prints frontmatter, sections, companions for a real module
+- `fledge spec show <name> --json` produces parseable JSON object
+- `fledge spec show <missing>` exits non-zero with a suggestion to run `fledge spec list`

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,10 +403,25 @@ enum SpecSubcommand {
     },
     /// Initialize spec-sync configuration
     Init,
+    /// List all specs in the project
+    #[command(alias = "ls")]
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Scaffold a new spec module
     New {
         /// Module name
         name: String,
+    },
+    /// Show a single spec's frontmatter, sections, and companions
+    Show {
+        /// Module name
+        name: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -712,7 +727,9 @@ fn run() -> Result<()> {
             let action = match action {
                 SpecSubcommand::Check { strict } => spec::SpecAction::Check { strict },
                 SpecSubcommand::Init => spec::SpecAction::Init,
+                SpecSubcommand::List { json } => spec::SpecAction::List { json },
                 SpecSubcommand::New { name } => spec::SpecAction::New { name },
+                SpecSubcommand::Show { name, json } => spec::SpecAction::Show { name, json },
             };
             spec::run(action)?;
         }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,9 +1,11 @@
 use anyhow::{bail, Context, Result};
 use console::style;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
+
+const COMPANION_FILES: &[&str] = &["requirements.md", "tasks.md", "context.md", "testing.md"];
 
 #[derive(Debug, Deserialize)]
 struct SpecSyncConfig {
@@ -62,6 +64,8 @@ pub fn run(action: SpecAction) -> Result<()> {
         SpecAction::Check { strict } => check(&root, strict),
         SpecAction::Init => init(&root),
         SpecAction::New { name } => new_spec(&root, &name),
+        SpecAction::List { json } => list_specs(&root, json),
+        SpecAction::Show { name, json } => show_spec(&root, &name, json),
     }
 }
 
@@ -70,6 +74,33 @@ pub enum SpecAction {
     Check { strict: bool },
     Init,
     New { name: String },
+    List { json: bool },
+    Show { name: String, json: bool },
+}
+
+#[derive(Debug, Serialize)]
+struct SpecSummary {
+    name: String,
+    version: u32,
+    status: String,
+    path: String,
+    files: Vec<String>,
+    section_count: usize,
+    required_sections: usize,
+    companions: Vec<String>,
+    missing_companions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SpecDetail {
+    name: String,
+    version: u32,
+    status: String,
+    path: String,
+    files: Vec<String>,
+    sections: Vec<String>,
+    companions: Vec<String>,
+    missing_companions: Vec<String>,
 }
 
 fn load_config(project_root: &Path) -> Result<SpecSyncConfig> {
@@ -281,8 +312,7 @@ fn validate_spec(
     }
 
     let spec_dir = spec_path.parent().unwrap_or(project_root);
-    let companion_files = ["requirements.md", "tasks.md", "context.md", "testing.md"];
-    for companion in &companion_files {
+    for companion in COMPANION_FILES {
         let companion_path = spec_dir.join(companion);
         if !companion_path.exists() {
             issues.push(ValidationIssue {
@@ -431,6 +461,243 @@ fn check(root: &Path, strict: bool) -> Result<()> {
             );
         }
         std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn find_spec_files(specs_dir: &Path) -> Vec<PathBuf> {
+    let mut spec_paths = Vec::new();
+    for entry in WalkDir::new(specs_dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "md") {
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            if name.ends_with(".spec.md") {
+                spec_paths.push(path.to_path_buf());
+            }
+        }
+    }
+    spec_paths
+}
+
+fn classify_companions(spec_dir: &Path) -> (Vec<String>, Vec<String>) {
+    let mut present = Vec::new();
+    let mut missing = Vec::new();
+    for companion in COMPANION_FILES {
+        if spec_dir.join(companion).exists() {
+            present.push((*companion).to_string());
+        } else {
+            missing.push((*companion).to_string());
+        }
+    }
+    (present, missing)
+}
+
+fn build_summary(spec_path: &Path, root: &Path, required_count: usize) -> Result<SpecSummary> {
+    let content = fs::read_to_string(spec_path)
+        .with_context(|| format!("reading {}", spec_path.display()))?;
+    let (fm, body) = parse_frontmatter(&content)
+        .with_context(|| format!("parsing frontmatter in {}", spec_path.display()))?;
+    let sections = extract_sections(&body);
+    let (companions, missing_companions) = classify_companions(spec_path.parent().unwrap_or(root));
+    let rel_path = spec_path
+        .strip_prefix(root)
+        .unwrap_or(spec_path)
+        .display()
+        .to_string();
+    Ok(SpecSummary {
+        name: fm.module,
+        version: fm.version,
+        status: fm.status,
+        path: rel_path,
+        files: fm.files,
+        section_count: sections.len(),
+        required_sections: required_count,
+        companions,
+        missing_companions,
+    })
+}
+
+fn list_specs(root: &Path, json: bool) -> Result<()> {
+    let config = load_config(root)?;
+    let specs_dir = root.join(config.specs_dir.as_deref().unwrap_or("specs"));
+    let required_count = if config.required_sections.is_empty() {
+        7
+    } else {
+        config.required_sections.len()
+    };
+
+    if !specs_dir.exists() {
+        if json {
+            println!("[]");
+        } else {
+            println!(
+                "{} No specs directory found at {}",
+                style("*").cyan().bold(),
+                style(specs_dir.display()).dim()
+            );
+        }
+        return Ok(());
+    }
+
+    let mut summaries: Vec<SpecSummary> = Vec::new();
+    let mut parse_errors: Vec<(PathBuf, String)> = Vec::new();
+    for path in find_spec_files(&specs_dir) {
+        match build_summary(&path, root, required_count) {
+            Ok(summary) => summaries.push(summary),
+            Err(e) => parse_errors.push((path, e.to_string())),
+        }
+    }
+    summaries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&summaries)?);
+        return Ok(());
+    }
+
+    if summaries.is_empty() && parse_errors.is_empty() {
+        println!(
+            "{} No spec files found in {}",
+            style("*").cyan().bold(),
+            style(specs_dir.display()).dim()
+        );
+        return Ok(());
+    }
+
+    for summary in &summaries {
+        let status_marker = match summary.status.as_str() {
+            "active" | "stable" => style("●").green(),
+            "draft" | "review" => style("●").yellow(),
+            "deprecated" | "archived" => style("●").red(),
+            _ => style("●").dim(),
+        };
+        println!(
+            "{} {} {} ({})",
+            status_marker,
+            style(&summary.name).bold(),
+            style(format!("v{}", summary.version)).dim(),
+            summary.status,
+        );
+        println!(
+            "    {} — {} source {}, {}/{} sections, {} companion {}",
+            style(&summary.path).dim(),
+            summary.files.len(),
+            if summary.files.len() == 1 {
+                "file"
+            } else {
+                "files"
+            },
+            summary.section_count,
+            summary.required_sections,
+            summary.companions.len(),
+            if summary.companions.len() == 1 {
+                "file"
+            } else {
+                "files"
+            },
+        );
+        if !summary.missing_companions.is_empty() {
+            println!(
+                "    {} {}",
+                style("missing:").yellow(),
+                summary.missing_companions.join(", ")
+            );
+        }
+    }
+
+    for (path, err) in &parse_errors {
+        println!(
+            "{} {} — {}",
+            style("❌").red().bold(),
+            path.display(),
+            style(err).red()
+        );
+    }
+
+    println!();
+    println!("  {} spec(s) found", summaries.len());
+    Ok(())
+}
+
+fn show_spec(root: &Path, name: &str, json: bool) -> Result<()> {
+    let config = load_config(root)?;
+    let specs_dir = root.join(config.specs_dir.as_deref().unwrap_or("specs"));
+    let spec_path = specs_dir.join(name).join(format!("{name}.spec.md"));
+
+    if !spec_path.exists() {
+        bail!(
+            "No spec found for '{}'. Looked at {}. Run {} to see available specs.",
+            name,
+            spec_path.display(),
+            style("fledge spec list").cyan()
+        );
+    }
+
+    let content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("reading {}", spec_path.display()))?;
+    let (fm, body) = parse_frontmatter(&content)
+        .with_context(|| format!("parsing frontmatter in {}", spec_path.display()))?;
+    let sections = extract_sections(&body);
+    let spec_dir = spec_path.parent().unwrap_or(root);
+    let (companions, missing_companions) = classify_companions(spec_dir);
+    let rel_path = spec_path
+        .strip_prefix(root)
+        .unwrap_or(&spec_path)
+        .display()
+        .to_string();
+
+    let detail = SpecDetail {
+        name: fm.module,
+        version: fm.version,
+        status: fm.status,
+        path: rel_path,
+        files: fm.files,
+        sections,
+        companions,
+        missing_companions,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&detail)?);
+        return Ok(());
+    }
+
+    println!(
+        "{} {} ({})",
+        style(&detail.name).bold().cyan(),
+        style(format!("v{}", detail.version)).dim(),
+        detail.status,
+    );
+    println!("  path: {}", style(&detail.path).dim());
+
+    if detail.files.is_empty() {
+        println!("  source files: {}", style("(none)").dim());
+    } else {
+        println!("  source files:");
+        for file in &detail.files {
+            println!("    - {file}");
+        }
+    }
+
+    if detail.sections.is_empty() {
+        println!("  sections: {}", style("(none)").dim());
+    } else {
+        println!("  sections ({}):", detail.sections.len());
+        for section in &detail.sections {
+            println!("    - {section}");
+        }
+    }
+
+    if detail.companions.is_empty() {
+        println!("  companions: {}", style("(none present)").yellow());
+    } else {
+        println!("  companions:");
+        for companion in &detail.companions {
+            println!("    {} {}", style("✓").green(), companion);
+        }
+    }
+    for companion in &detail.missing_companions {
+        println!("    {} {}", style("✗").yellow(), companion);
     }
 
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -906,6 +906,96 @@ fn cli_spec_new_creates_spec() {
     assert!(tmp.path().join("specs/auth").exists());
 }
 
+#[test]
+fn cli_spec_list_in_project() {
+    let output = run_fledge(&["spec", "list"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("spec(s) found"),
+        "expected summary line in output: {stdout}"
+    );
+}
+
+#[test]
+fn cli_spec_list_ls_alias() {
+    let output = run_fledge(&["spec", "ls"]);
+    assert!(output.status.success());
+}
+
+#[test]
+fn cli_spec_list_json_valid() {
+    let output = run_fledge(&["spec", "list", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(parsed.is_array(), "expected JSON array, got {parsed}");
+    let arr = parsed.as_array().unwrap();
+    assert!(!arr.is_empty(), "fledge project should have specs");
+    let first = &arr[0];
+    for field in [
+        "name",
+        "version",
+        "status",
+        "path",
+        "files",
+        "section_count",
+        "required_sections",
+        "companions",
+        "missing_companions",
+    ] {
+        assert!(first.get(field).is_some(), "missing field: {field}");
+    }
+}
+
+#[test]
+fn cli_spec_list_json_empty_dir() {
+    let tmp = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    run_fledge_in(tmp.path(), &["spec", "init"]);
+
+    let output = run_fledge_in(tmp.path(), &["spec", "list", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(parsed.is_array());
+    assert!(parsed.as_array().unwrap().is_empty());
+}
+
+#[test]
+fn cli_spec_show_existing_module() {
+    let output = run_fledge(&["spec", "show", "spec"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("spec"));
+    assert!(stdout.contains("sections"));
+}
+
+#[test]
+fn cli_spec_show_json_valid() {
+    let output = run_fledge(&["spec", "show", "spec", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(parsed.is_object());
+    assert_eq!(parsed["name"].as_str(), Some("spec"));
+    assert!(parsed["sections"].is_array());
+    assert!(parsed["companions"].is_array());
+    assert!(parsed["missing_companions"].is_array());
+}
+
+#[test]
+fn cli_spec_show_missing_module_fails() {
+    let output = run_fledge(&["spec", "show", "definitely-not-a-real-spec-xyz"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("No spec found") || stderr.contains("not"));
+}
+
 // ──────────────────────────────────────────────────────────
 // Changelog command (requires git repo)
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes fledge usable by AI agents without screen-scraping or TTY workarounds. Two pieces:

- **AGENTS.md at repo root** + **docs/src/agents.md** — canonical entrypoint for agents. Documents the machine-readable surface (every command with \`--json\`), TTY bypass flags (\`--yes\`/\`--force\`), exit codes, and typical agent workflows (orient → work → ship).
- **\`fledge spec list\`** (alias \`ls\`) and **\`fledge spec show <name>\`** — both with \`--json\`. Agents can now enumerate the 32 specs and drill into any one programmatically, replacing \`ls specs/\` + hand-parsed frontmatter.

Spec module bumped v1 → v2 with new Public API, Behavioral Examples, Error Cases, Change Log; companion files updated. Seven new integration tests (test count 144 → 151).

## Why

Today an agent orienting to fledge either has to parse \`--help\` text or walk the specs directory manually. Both are brittle. \`spec list --json\` and \`spec show <name> --json\` give every agent the same structured view that \`fledge spec check\` already builds internally — and AGENTS.md teaches agents how to consume it.

## Test plan

- [x] \`fledge lane run pre-commit\` — fmt + lint + test + spec-check green
- [x] \`fledge spec list\` — pretty output, 32 specs, sorted
- [x] \`fledge spec list --json\` — parseable JSON array
- [x] \`fledge spec show spec --json\` — parseable JSON object, name/version/sections/companions all present
- [x] \`fledge spec show nonexistent\` — non-zero exit, suggests \`spec list\`
- [x] \`fledge spec ls\` — alias works
- [x] 7 new integration tests pass (151 total, 0 failures)