### PR TITLE
feat: fledge ask is spec-aware by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,16 +67,34 @@ Commands safe to call non-interactively today: `ask`, `review`, `checks`, `docto
 
 `fledge ask` and `fledge review` delegate to the `claude` CLI, which must be installed and authenticated on the host. The agent running fledge inherits whatever auth the `claude` CLI has.
 
-```bash
-fledge ask "how does the work module build branch names?" --json
-# -> {"question": "...", "answer": "..."}
+### `fledge ask` is spec-aware by default
 
+**Every `fledge ask` invocation automatically prepends a compact index of all specs** (one line per module: name, version, status, files, first-paragraph purpose). Claude can then cite specific specs in its answer even when the user didn't mention them.
+
+```bash
+# Default: compact index of every spec auto-included
+fledge ask "how does the work module build branch names?" --json
+
+# Include full spec + all companion files for one or more modules
+fledge ask --with-specs work "why does it sanitize names this way?"
+fledge ask --with-specs work,trust "how do these modules interact?"
+fledge ask --with-specs all "which modules touch GitHub?"
+
+# Skip the index entirely (saves tokens for off-topic questions)
+fledge ask --no-spec-index "quick Rust syntax question"
+```
+
+When `--with-specs <name>` is passed, fledge loads `specs/<name>/<name>.spec.md` plus every existing companion (`requirements.md`, `context.md`, `tasks.md`, `testing.md`) into the prompt. Companions carry the design rationale — usually what you want for *why* questions.
+
+### `fledge review`
+
+```bash
 fledge review --json                   # reviews current diff vs main
 fledge review --base HEAD~3 --json     # reviews last 3 commits
 fledge review --model opus --format checklist --json
 ```
 
-Neither command currently feeds spec content into the prompt automatically. If you want the LLM to know about specs, grep/read them first and paste excerpts into your own prompt, or use `fledge spec show <name> --json` and include the result.
+Review does not yet feed specs into its prompt — if you want spec-aware review, run `fledge ask --with-specs <name> "review the recent change to X module"` as a workaround.
 
 ## Typical agent workflows
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -41,6 +41,25 @@ fledge follows three rules that make it agent-usable:
 
 `fledge ask` and `fledge review` wrap the `claude` CLI. The host environment must have `claude` installed and authenticated. These commands will exit non-zero if auth is missing — that's a host-config issue, not a fledge issue.
 
+#### `fledge ask` is spec-aware
+
+Every `fledge ask` invocation automatically includes a compact index of every project spec in the prompt, so Claude knows what modules exist and can cite them. For deeper questions, use `--with-specs <name>` (comma-separated, repeatable, or `all`) to load the full spec *and* companions (`requirements.md`, `context.md`, `tasks.md`, `testing.md`) for named modules.
+
+```bash
+# Default: compact index auto-included
+fledge ask "how does the work module build branch names?"
+
+# Full spec + companions for a module
+fledge ask --with-specs work "why does it sanitize names this way?"
+fledge ask --with-specs work,trust "how do these modules interact?"
+fledge ask --with-specs all "which modules touch GitHub?"
+
+# Skip the index (saves tokens for off-topic questions)
+fledge ask --no-spec-index "quick Rust syntax question"
+```
+
+The index adds a few hundred tokens per call; `--with-specs` can add more depending on spec size. Use `--no-spec-index` for questions that have nothing to do with the repo.
+
 ## Typical agent workflows
 
 ### Orient to a new repo
@@ -92,7 +111,7 @@ Every module in `src/` has a matching spec under `specs/<module>/`. The `.spec.m
 These are known gaps; PRs welcome. Each is tracked via the `agent-surface` label.
 
 - `fledge run`, `fledge init`, `fledge spec check/init/new`, `fledge work`, `fledge release` have no `--json` today
-- `fledge ask` does not automatically feed specs into its prompt — agents must paste spec excerpts themselves
+- `fledge review` does not feed specs into its prompt yet (only `ask` does)
 - No global `--non-interactive` flag that forces `--yes` on every subcommand at once
 - No `fledge introspect --json` to dump the full command tree as JSON
 

--- a/specs/ask/ask.spec.md
+++ b/specs/ask/ask.spec.md
@@ -1,19 +1,20 @@
 ---
 module: ask
-version: 2
+version: 3
 status: active
 files:
   - src/ask.rs
 
 db_tables: []
-depends_on: []
+depends_on:
+  - spec
 ---
 
 # Ask
 
 ## Purpose
 
-Ask questions about your codebase using AI. Sends the question to Claude CLI which has access to the project context, and streams the answer back.
+Ask questions about your codebase using AI. Sends the question to Claude CLI together with a compact index of every module's spec (so Claude knows what modules exist and can cite them), and optionally the full spec + companions for named modules. Streams the answer back.
 
 ## Public API
 
@@ -22,35 +23,76 @@ Ask questions about your codebase using AI. Sends the question to Claude CLI whi
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point for the ask command |
-| `AskOptions` | Options struct with the question text and json flag |
+| `AskOptions` | Options struct with question, json, with_specs, and no_spec_index fields |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `AskOptions` | `{ question: String, json: bool }` |
+| `AskOptions` | `{ question: String, json: bool, with_specs: Vec<String>, no_spec_index: bool }` |
 
 ### Functions
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `run` | `(AskOptions) -> Result<()>` | Sends question to Claude CLI and displays answer |
+| `run` | `(AskOptions) -> Result<()>` | Builds the spec-augmented prompt and delegates to Claude CLI |
+| `build_spec_context` | `(&Path, &[String], bool) -> Result<Option<String>>` | (private) Assemble the spec-context block (index + requested bundles) |
+| `expand_with_specs` | `(&[String], &Path) -> Result<Vec<String>>` | (private) Flatten comma-separated names; `"all"` expands to every module |
+| `build_prompt` | `(&str, bool, Option<&str>) -> String` | (private) Final prompt = preamble + optional spec context + question |
 
 ## Invariants
 
 1. Requires Claude CLI (`claude`) to be installed and authenticated
 2. Question is joined from multiple args (no quotes required)
 3. Claude CLI runs in the current project directory for context
-4. `--json` outputs structured JSON response
+4. `--json` outputs `{question, answer}` structured response
+5. By default, a compact spec index is always prepended to the prompt (one line per module: name, version, status, files, first-paragraph purpose). Skipped only when `--no-spec-index` is passed.
+6. `--with-specs <names>` (comma-separated or repeated) loads full spec + existing companion files for each named module. `"all"` expands to every spec in the project and supersedes any other names in the same invocation.
+7. When no specs exist in the project and no `--with-specs` flag is passed, the prompt is unchanged from the pre-v3 behavior. When `--with-specs <name>` is passed against a project with no specs (or an unknown name), the command bails with a clear error rather than silently succeeding.
+8. Spec loading never silently swallows a user-requested bundle: any `--with-specs <name>` that fails to resolve bails with `loading spec bundle for '<name>'`. The ambient index (when `--no-spec-index` is not set) is best-effort — a malformed frontmatter on an unrelated spec is skipped from the index so one bad spec can't break `ask`.
+9. Module names passed to `--with-specs` are validated to prevent path traversal: `/`, `\`, `..`, `.`, and empty strings are rejected before any filesystem access.
 
 ## Behavioral Examples
 
-### ask — simple question
+### ask — default (index auto-included)
 ```
-$ fledge ask how does template rendering work
+$ fledge ask "how does the work module build branch names?"
 ● Thinking...
 
-[AI response streamed here]
+[Claude reads the index, knows there's a `work` module, cites specs/work/work.spec.md in its answer]
+```
+
+### ask — with full spec + companions for a module
+```
+$ fledge ask --with-specs work "why does the work module sanitize branch names this way?"
+● Thinking...
+
+[Claude has the full spec, context.md design decisions, and requirements.md in its prompt]
+```
+
+### ask — multiple specs, comma or repeated
+```
+$ fledge ask --with-specs work,trust "how do these modules interact?"
+$ fledge ask --with-specs work --with-specs trust "how do these modules interact?"
+```
+
+### ask — nuclear option
+```
+$ fledge ask --with-specs all "which modules touch GitHub?"
+```
+
+### ask — skip the index (saves tokens)
+```
+$ fledge ask --no-spec-index "quick syntax question: how do I declare an async trait?"
+```
+
+### ask — json
+```
+$ fledge ask --json "what is the release workflow?"
+{
+  "question": "what is the release workflow?",
+  "answer": "..."
+}
 ```
 
 ### ask — no question
@@ -65,15 +107,18 @@ error: Please provide a question. Usage: fledge ask <question>
 |-------|------|----------|
 | Claude CLI not installed | `claude --version` fails | Bail with install instructions |
 | No question provided | Empty args | Bail with usage hint |
-| Claude CLI error | Non-zero exit | Bail with error |
+| `--with-specs <name>` where `specs/<name>/` does not exist | Unknown module | Bail with the looked-at path |
+| Claude CLI error | Non-zero exit | Bail with stderr |
 
 ## Dependencies
 
 - Claude CLI — AI inference (external dependency)
+- `spec` module — `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-23 | Default-on spec index in prompt; add `--with-specs` for full spec+companion bundles; add `--no-spec-index` escape hatch. Depends on `spec` module helpers. |
 | 2 | 2026-04-21 | Add json field to AskOptions |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/ask/context.md
+++ b/specs/ask/context.md
@@ -15,3 +15,7 @@ spec: ask.spec.md
 - Join args without requiring quotes — `fledge ask how does X work` is more natural than `fledge ask "how does X work"`
 - Shell out to `claude` CLI for project context awareness rather than calling the API directly
 - No conversation state — each invocation is stateless to keep the implementation simple
+- v3 adds a default-on spec index to every prompt. Rationale: the specs are the richest source of *why* in the repo, and `ask` without them was strictly worse than a generic Claude chat in a project with strong documentation. The index is small (~one line per module) so it barely affects cost but materially changes the quality of answers.
+- `--with-specs` uses the same `spec::load_module_bundle` helper that `spec show` will eventually consume. Keeping this logic in the `spec` module means any future change to bundle format (e.g. filtering long sections) is a single-file change.
+- `"all"` expansion is guarded by the fact that fledge projects have ~32 specs today; a truly massive spec tree would warrant pagination, but that's premature.
+- `--no-spec-index` exists for the narrow case where a user wants to ask a pure syntax/API question unrelated to the repo — saves a few hundred tokens on the prompt prefix.

--- a/specs/ask/tasks.md
+++ b/specs/ask/tasks.md
@@ -11,3 +11,14 @@ spec: ask.spec.md
 - [x] Wire up CLI subcommand in main.rs
 - [x] Write unit tests
 - [x] Run verification suite
+- [x] Default-on spec index (compact purpose per module, feeds into every `ask`)
+- [x] `--with-specs <names>` flag (comma/repeat, `"all"` expansion)
+- [x] `--no-spec-index` escape hatch
+- [x] Unit tests for `build_prompt`, `expand_with_specs`, and prompt composition
+- [x] CLI test that `ask --help` advertises the new flags
+
+## Gaps
+
+- The compact index uses the first paragraph of `## Purpose`; a module whose Purpose opens with a list or table gets a weaker summary
+- No caching — every `ask` invocation re-reads and re-renders all 32 specs. Not a bottleneck today but something to revisit if the prompt prefix grows
+- Companions are included whole; for huge `context.md` files this could balloon the prompt. A future pass could section-filter companions

--- a/specs/ask/testing.md
+++ b/specs/ask/testing.md
@@ -9,8 +9,19 @@ spec: ask.spec.md
 - Argument joining (multiple words become one question string)
 - Empty question detection
 - Claude CLI availability check
+- `build_prompt` includes the question
+- `build_prompt` adds the JSON instruction only when `json=true`
+- `build_prompt` includes the spec context block when provided, omits it when `None`
+- `expand_with_specs` flattens comma-separated and repeated flags, dedups, handles whitespace
+- `expand_with_specs("all", …)` returns every module name sorted
 
 ### Integration Tests
 
 - `fledge ask <question>` returns a response (requires Claude CLI)
 - `fledge ask` with no arguments shows usage hint
+- `fledge ask --help` advertises `--with-specs` and `--no-spec-index`
+
+### Not tested (by design)
+
+- End-to-end LLM quality — this depends on Claude's behavior, not fledge
+- Network-dependent tests are deliberately omitted from the CI suite

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -64,6 +64,10 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 8. `spec list` returns sorted results by module name; `--json` emits an array (empty array when no specs)
 9. `spec show` errors if the spec is not found and suggests `fledge spec list`
 10. `spec list` and `spec show` are read-only — they never mutate the filesystem
+11. `collect_index` silently skips specs whose frontmatter is malformed or files are unreadable, so a single broken spec never breaks a caller like `fledge ask`
+12. `collect_index` returns an empty `Vec` (not an error) when the project has no `.specsync/` or no `specs/` directory
+13. `load_module_bundle` errors only when the specific requested module is missing; missing companions are simply omitted
+14. `render_index_markdown` produces stable output (entries must be pre-sorted; `collect_index` already guarantees this)
 
 ## Behavioral Examples
 
@@ -206,5 +210,6 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-23 | Expose `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`, and `IndexEntry` for consumers that need spec content in prompt-friendly form (`ask` is the first such consumer). Add `extract_purpose` helper. |
 | 2 | 2026-04-23 | Add `spec list` (alias `ls`) and `spec show`, both with `--json` support for agent/tool consumption |
 | 1 | 2026-04-19 | Initial spec for fledge spec integration |

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -1,15 +1,22 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::path::Path;
 use std::process::Command;
+
+use crate::spec;
 
 pub struct AskOptions {
     pub question: String,
     pub json: bool,
+    pub with_specs: Vec<String>,
+    pub no_spec_index: bool,
 }
 
 pub fn run(options: AskOptions) -> Result<()> {
     crate::github::ensure_claude_cli()?;
 
-    let prompt = build_prompt(&options.question, options.json);
+    let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let spec_context = build_spec_context(&root, &options.with_specs, options.no_spec_index)?;
+    let prompt = build_prompt(&options.question, options.json, spec_context.as_deref());
 
     let sp = crate::spinner::Spinner::start("Thinking:");
 
@@ -41,7 +48,73 @@ pub fn run(options: AskOptions) -> Result<()> {
     Ok(())
 }
 
-fn build_prompt(question: &str, json: bool) -> String {
+fn build_spec_context(
+    root: &Path,
+    with_specs: &[String],
+    no_index: bool,
+) -> Result<Option<String>> {
+    let needs_index = !no_index;
+    let needs_bundles = !with_specs.is_empty();
+
+    if !needs_index && !needs_bundles {
+        return Ok(None);
+    }
+
+    let mut context = String::new();
+
+    if needs_index {
+        // Ambient context: a broken .specsync/ or malformed spec shouldn't
+        // break `ask`. Silently fall back to no index in that case.
+        if let Ok(entries) = spec::collect_index(root) {
+            if !entries.is_empty() {
+                context.push_str(&spec::render_index_markdown(&entries));
+                context.push('\n');
+            }
+        }
+    }
+
+    if needs_bundles {
+        let expanded = expand_with_specs(with_specs, root)?;
+        for name in &expanded {
+            let bundle = spec::load_module_bundle(root, name)
+                .with_context(|| format!("loading spec bundle for '{name}'"))?;
+            context.push_str(&bundle);
+        }
+    }
+
+    if context.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(context))
+    }
+}
+
+fn expand_with_specs(with_specs: &[String], root: &Path) -> Result<Vec<String>> {
+    let mut names: Vec<String> = Vec::new();
+    let mut include_all = false;
+    for raw in with_specs {
+        for part in raw.split(',') {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed.eq_ignore_ascii_case("all") {
+                include_all = true;
+                continue;
+            }
+            names.push(trimmed.to_string());
+        }
+    }
+    if include_all {
+        names = spec::all_module_names(root).unwrap_or_default();
+    } else {
+        names.sort();
+        names.dedup();
+    }
+    Ok(names)
+}
+
+fn build_prompt(question: &str, json: bool, spec_context: Option<&str>) -> String {
     let mut prompt = String::from(
         "You are a helpful assistant answering questions about a codebase.\n\
         The user is in a project directory and wants to understand their code.\n\
@@ -49,6 +122,14 @@ fn build_prompt(question: &str, json: bool) -> String {
     );
     if json {
         prompt.push_str("Return your answer as plain text (it will be wrapped in JSON).\n");
+    }
+    if let Some(ctx) = spec_context {
+        prompt.push_str(
+            "\nThe project maintains formal specs under `specs/<module>/`. \
+             Treat the context below as authoritative — prefer it over guessing from file names.\n\n",
+        );
+        prompt.push_str(ctx);
+        prompt.push('\n');
     }
     prompt.push_str(&format!("\nQuestion: {question}"));
     prompt
@@ -60,21 +141,35 @@ mod tests {
 
     #[test]
     fn build_prompt_contains_question() {
-        let prompt = build_prompt("how does init work?", false);
+        let prompt = build_prompt("how does init work?", false, None);
         assert!(prompt.contains("how does init work?"));
         assert!(prompt.contains("Question:"));
     }
 
     #[test]
     fn build_prompt_json_flag_adds_instruction() {
-        let prompt = build_prompt("test", true);
+        let prompt = build_prompt("test", true, None);
         assert!(prompt.contains("plain text"));
     }
 
     #[test]
     fn build_prompt_no_json_flag_omits_instruction() {
-        let prompt = build_prompt("test", false);
+        let prompt = build_prompt("test", false, None);
         assert!(!prompt.contains("plain text"));
+    }
+
+    #[test]
+    fn build_prompt_includes_spec_context_when_provided() {
+        let ctx = "## Available specs\n- foo v1\n";
+        let prompt = build_prompt("q", false, Some(ctx));
+        assert!(prompt.contains("Available specs"));
+        assert!(prompt.contains("foo v1"));
+    }
+
+    #[test]
+    fn build_prompt_omits_spec_block_when_none() {
+        let prompt = build_prompt("q", false, None);
+        assert!(!prompt.contains("Available specs"));
     }
 
     #[test]
@@ -82,8 +177,74 @@ mod tests {
         let opts = AskOptions {
             question: "what is this?".to_string(),
             json: false,
+            with_specs: Vec::new(),
+            no_spec_index: false,
         };
         assert_eq!(opts.question, "what is this?");
         assert!(!opts.json);
+    }
+
+    #[test]
+    fn expand_with_specs_handles_comma_and_dedup() {
+        let root = std::path::PathBuf::from(".");
+        let names = vec![
+            "foo,bar".to_string(),
+            "bar".to_string(),
+            " baz ".to_string(),
+        ];
+        let expanded = expand_with_specs(&names, &root).unwrap();
+        assert_eq!(expanded, vec!["bar", "baz", "foo"]);
+    }
+
+    #[test]
+    fn expand_with_specs_empty_input_returns_empty() {
+        let root = std::path::PathBuf::from(".");
+        let expanded = expand_with_specs(&[], &root).unwrap();
+        assert!(expanded.is_empty());
+    }
+
+    #[test]
+    fn expand_with_specs_all_returns_every_module() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+        for name in ["cat", "bat", "ant"] {
+            let dir = tmp.path().join(format!("specs/{name}"));
+            fs::create_dir_all(&dir).unwrap();
+            let spec = format!(
+                "---\nmodule: {name}\nversion: 1\nstatus: active\nfiles: []\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nP.\n"
+            );
+            fs::write(dir.join(format!("{name}.spec.md")), spec).unwrap();
+        }
+
+        let expanded = expand_with_specs(&["all".to_string()], tmp.path()).unwrap();
+        assert_eq!(expanded, vec!["ant", "bat", "cat"]);
+    }
+
+    #[test]
+    fn build_spec_context_bails_on_missing_with_specs_even_in_empty_project() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        // Empty project — no .specsync, no specs
+        let err = build_spec_context(tmp.path(), &["ghost".to_string()], false).unwrap_err();
+        assert!(err.to_string().contains("loading spec bundle for 'ghost'"));
+    }
+
+    #[test]
+    fn build_spec_context_returns_none_when_nothing_requested() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let ctx = build_spec_context(tmp.path(), &[], true).unwrap();
+        assert!(ctx.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,13 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Include full spec + companions for these modules in the prompt
+        /// (comma-separated, repeatable, use "all" for every spec)
+        #[arg(long, value_name = "NAMES")]
+        with_specs: Vec<String>,
+        /// Omit the compact spec index from the prompt (saves tokens)
+        #[arg(long)]
+        no_spec_index: bool,
     },
     /// Generate a changelog from git tags and commits
     Changelog {
@@ -1024,13 +1031,20 @@ fn run() -> Result<()> {
                 allow_dirty,
             })?;
         }
-        Commands::Ask { question, json } => {
+        Commands::Ask {
+            question,
+            json,
+            with_specs,
+            no_spec_index,
+        } => {
             if question.is_empty() {
                 anyhow::bail!("Please provide a question. Usage: fledge ask <question>");
             }
             ask::run(ask::AskOptions {
                 question: question.join(" "),
                 json,
+                with_specs,
+                no_spec_index,
             })?;
         }
         Commands::Completions { shell, install } => {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -103,6 +103,16 @@ struct SpecDetail {
     missing_companions: Vec<String>,
 }
 
+/// A compact entry suitable for prompt-context indexes.
+#[derive(Debug, Clone)]
+pub struct IndexEntry {
+    pub name: String,
+    pub version: u32,
+    pub status: String,
+    pub purpose: Option<String>,
+    pub files: Vec<String>,
+}
+
 fn load_config(project_root: &Path) -> Result<SpecSyncConfig> {
     let config_path = project_root.join(".specsync/config.toml");
     if !config_path.exists() {
@@ -216,6 +226,41 @@ fn extract_sections(body: &str) -> Vec<String> {
         }
     }
     sections
+}
+
+fn extract_purpose(body: &str) -> Option<String> {
+    let mut in_purpose = false;
+    let mut paragraph = String::new();
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("## ") {
+            if in_purpose {
+                break;
+            }
+            if trimmed == "## Purpose" {
+                in_purpose = true;
+            }
+            continue;
+        }
+        if !in_purpose {
+            continue;
+        }
+        if line.trim().is_empty() {
+            if !paragraph.is_empty() {
+                break;
+            }
+            continue;
+        }
+        if !paragraph.is_empty() {
+            paragraph.push(' ');
+        }
+        paragraph.push_str(line.trim());
+    }
+    if paragraph.is_empty() {
+        None
+    } else {
+        Some(paragraph)
+    }
 }
 
 fn validate_spec(
@@ -493,6 +538,120 @@ fn classify_companions(spec_dir: &Path) -> (Vec<String>, Vec<String>) {
     (present, missing)
 }
 
+fn specs_dir_from_config(root: &Path) -> Result<PathBuf> {
+    let config = load_config(root)?;
+    Ok(root.join(config.specs_dir.as_deref().unwrap_or("specs")))
+}
+
+fn validate_module_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("Module name cannot be empty");
+    }
+    if name == "." || name == ".." {
+        bail!("Invalid module name '{name}'");
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        bail!("Invalid module name '{name}': may not contain path separators or '..'");
+    }
+    Ok(())
+}
+
+/// Collect a compact, sorted index of every spec in the project.
+/// Intended for feeding into LLM prompts or other machine-readable consumers.
+pub fn collect_index(root: &Path) -> Result<Vec<IndexEntry>> {
+    let specs_dir = specs_dir_from_config(root)?;
+    if !specs_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    for path in find_spec_files(&specs_dir) {
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok((fm, body)) = parse_frontmatter(&content) else {
+            continue;
+        };
+        entries.push(IndexEntry {
+            name: fm.module,
+            version: fm.version,
+            status: fm.status,
+            purpose: extract_purpose(&body),
+            files: fm.files,
+        });
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(entries)
+}
+
+/// Render an index as a compact markdown block suitable for prompt injection.
+pub fn render_index_markdown(entries: &[IndexEntry]) -> String {
+    let mut out = String::from("## Available specs\n\n");
+    out.push_str(
+        "This project documents each module in `specs/<name>/`. \
+         Run `fledge spec show <name>` for the full detail.\n\n",
+    );
+    for entry in entries {
+        let purpose = entry
+            .purpose
+            .as_deref()
+            .unwrap_or("(no purpose documented)");
+        let files = if entry.files.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", entry.files.join(", "))
+        };
+        out.push_str(&format!(
+            "- **{}** v{} ({}){} — {}\n",
+            entry.name, entry.version, entry.status, files, purpose,
+        ));
+    }
+    out
+}
+
+/// Return every module name that has a `specs/<name>/<name>.spec.md` file.
+pub fn all_module_names(root: &Path) -> Result<Vec<String>> {
+    Ok(collect_index(root)?.into_iter().map(|e| e.name).collect())
+}
+
+/// Load the full spec bundle for a single module: its `.spec.md` plus whichever
+/// companion files exist, concatenated as a single markdown block with headers.
+pub fn load_module_bundle(root: &Path, name: &str) -> Result<String> {
+    validate_module_name(name)?;
+    let specs_dir = specs_dir_from_config(root)?;
+    let module_dir = specs_dir.join(name);
+    let spec_path = module_dir.join(format!("{name}.spec.md"));
+    if !spec_path.exists() {
+        bail!(
+            "No spec found for '{}' (looked at {})",
+            name,
+            spec_path.display()
+        );
+    }
+
+    let mut bundle = String::new();
+    bundle.push_str(&format!("## Spec bundle: {name}\n\n"));
+
+    let spec_content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("reading {}", spec_path.display()))?;
+    bundle.push_str(&format!("### `{name}.spec.md`\n\n"));
+    bundle.push_str(spec_content.trim_end());
+    bundle.push_str("\n\n");
+
+    for companion in COMPANION_FILES {
+        let companion_path = module_dir.join(companion);
+        if !companion_path.exists() {
+            continue;
+        }
+        let companion_content = fs::read_to_string(&companion_path)
+            .with_context(|| format!("reading {}", companion_path.display()))?;
+        bundle.push_str(&format!("### `{companion}`\n\n"));
+        bundle.push_str(companion_content.trim_end());
+        bundle.push_str("\n\n");
+    }
+
+    Ok(bundle)
+}
+
 fn build_summary(spec_path: &Path, root: &Path, required_count: usize) -> Result<SpecSummary> {
     let content = fs::read_to_string(spec_path)
         .with_context(|| format!("reading {}", spec_path.display()))?;
@@ -620,6 +779,7 @@ fn list_specs(root: &Path, json: bool) -> Result<()> {
 }
 
 fn show_spec(root: &Path, name: &str, json: bool) -> Result<()> {
+    validate_module_name(name)?;
     let config = load_config(root)?;
     let specs_dir = root.join(config.specs_dir.as_deref().unwrap_or("specs"));
     let spec_path = specs_dir.join(name).join(format!("{name}.spec.md"));
@@ -783,6 +943,7 @@ hashes.json
 }
 
 fn new_spec(root: &Path, name: &str) -> Result<()> {
+    validate_module_name(name)?;
     let config = load_config(root)?;
     let specs_dir = root.join(config.specs_dir.as_deref().unwrap_or("specs"));
     let spec_dir = specs_dir.join(name);
@@ -1119,6 +1280,146 @@ More text.
         let body = "No sections here, just text.";
         let sections = extract_sections(body);
         assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn test_extract_purpose_happy_path() {
+        let body = "\n## Purpose\n\nA short description.\n\n## Public API\n\ntext\n";
+        assert_eq!(extract_purpose(body), Some("A short description.".into()));
+    }
+
+    #[test]
+    fn test_extract_purpose_multiline_joined() {
+        let body = "## Purpose\n\nLine one\nline two\n\n## Next\n";
+        assert_eq!(extract_purpose(body), Some("Line one line two".into()));
+    }
+
+    #[test]
+    fn test_extract_purpose_missing_section() {
+        let body = "## Public API\n\ntext\n";
+        assert_eq!(extract_purpose(body), None);
+    }
+
+    fn scaffold_min_project(tmp: &TempDir, modules: &[&str]) {
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+        for name in modules {
+            let dir = tmp.path().join(format!("specs/{name}"));
+            fs::create_dir_all(&dir).unwrap();
+            let spec = format!(
+                "---\nmodule: {name}\nversion: 1\nstatus: active\nfiles: []\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nPurpose of {name}.\n\n## Public API\n\n## Invariants\n\n## Behavioral Examples\n\n## Error Cases\n\n## Dependencies\n\n## Change Log\n"
+            );
+            fs::write(dir.join(format!("{name}.spec.md")), spec).unwrap();
+            fs::write(dir.join("requirements.md"), "---\nspec: x\n---\nreq body\n").unwrap();
+            fs::write(dir.join("context.md"), "---\nspec: x\n---\ncontext body\n").unwrap();
+        }
+    }
+
+    #[test]
+    fn test_collect_index_sorted_with_purpose() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &["zebra", "alpha", "mango"]);
+
+        let entries = collect_index(tmp.path()).unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mango", "zebra"]);
+        assert_eq!(entries[0].purpose, Some("Purpose of alpha.".into()));
+        assert_eq!(entries[0].version, 1);
+        assert_eq!(entries[0].status, "active");
+    }
+
+    #[test]
+    fn test_collect_index_empty_project() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &[]);
+        let entries = collect_index(tmp.path()).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_render_index_markdown_contains_entries() {
+        let entries = vec![
+            IndexEntry {
+                name: "foo".into(),
+                version: 2,
+                status: "active".into(),
+                purpose: Some("Does foo.".into()),
+                files: vec!["src/foo.rs".into()],
+            },
+            IndexEntry {
+                name: "bar".into(),
+                version: 1,
+                status: "draft".into(),
+                purpose: None,
+                files: Vec::new(),
+            },
+        ];
+        let md = render_index_markdown(&entries);
+        assert!(md.contains("## Available specs"));
+        assert!(md.contains("**foo** v2 (active)"));
+        assert!(md.contains("Does foo."));
+        assert!(md.contains("**bar** v1 (draft)"));
+        assert!(md.contains("(no purpose documented)"));
+    }
+
+    #[test]
+    fn test_all_module_names_sorted() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &["beta", "alpha"]);
+        let names = all_module_names(tmp.path()).unwrap();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_load_module_bundle_includes_spec_and_companions() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &["alpha"]);
+        let bundle = load_module_bundle(tmp.path(), "alpha").unwrap();
+        assert!(bundle.contains("## Spec bundle: alpha"));
+        assert!(bundle.contains("### `alpha.spec.md`"));
+        assert!(bundle.contains("Purpose of alpha."));
+        assert!(bundle.contains("### `requirements.md`"));
+        assert!(bundle.contains("req body"));
+        assert!(bundle.contains("### `context.md`"));
+        assert!(bundle.contains("context body"));
+        // tasks and testing not scaffolded, so not present
+        assert!(!bundle.contains("### `tasks.md`"));
+        assert!(!bundle.contains("### `testing.md`"));
+    }
+
+    #[test]
+    fn test_load_module_bundle_missing_module_errors() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &[]);
+        let err = load_module_bundle(tmp.path(), "ghost").unwrap_err();
+        assert!(err.to_string().contains("No spec found"));
+    }
+
+    #[test]
+    fn test_load_module_bundle_rejects_path_traversal() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_min_project(&tmp, &["real"]);
+
+        for bad in ["../evil", "..\\evil", "foo/bar", "foo\\bar", "..", ".", ""] {
+            let err = load_module_bundle(tmp.path(), bad).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("Invalid module name") || msg.contains("cannot be empty"),
+                "expected rejection for '{bad}', got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_module_name_allows_normal_names() {
+        assert!(validate_module_name("trust").is_ok());
+        assert!(validate_module_name("create_template").is_ok());
+        assert!(validate_module_name("plugin-protocol").is_ok());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2600,3 +2600,11 @@ fn cli_ask_accepts_json_flag() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("--json"));
 }
+
+#[test]
+fn cli_ask_accepts_with_specs_flag() {
+    let output = run_fledge(&["ask", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--with-specs"));
+    assert!(stdout.contains("--no-spec-index"));
+}


### PR DESCRIPTION
## Summary

Makes \`fledge ask\` the first differentiator on the agent-surface axis: a dev-CLI question-answerer that knows your codebase's own documentation.

- **Default-on spec index**: every \`fledge ask\` now prepends a one-line-per-module summary (name, version, status, files, first paragraph of Purpose). Claude cites specific specs in answers without being asked.
- **\`--with-specs <names>\`** loads the full \`.spec.md\` *and* all companion files (\`requirements.md\`, \`context.md\`, \`tasks.md\`, \`testing.md\`) for named modules. Comma-separated, repeatable, \`all\` supported.
- **\`--no-spec-index\`** escape hatch for off-topic questions.

## Why this is the one change that moves the needle

From the strategy discussion: the specs system is fledge's most unusual asset, and until today \`fledge ask\` was a thin wrapper around \`claude\` that ignored it. With this change, \`fledge ask\` in a fledge-managed repo is strictly better than a generic Claude chat, because it automatically hands Claude the *why* behind every module. Other modules' \`ask\` equivalents can't do this — they don't have structured specs to hand over.

## Stacked on #242

This branch depends on the \`spec list\` / \`spec show\` helpers from #242. Please merge #242 first, then this will fast-forward.

## Self-reviewed with \`fledge review\`

Ran \`fledge review --base 0xleif/feat/agent-surface --format checklist\` (dogfooding the AI review). It surfaced three real issues, all addressed in this PR:

1. **\`--with-specs\` on an empty project silently succeeded** — now bails with a clear error message naming the requested module.
2. **Path traversal** — module names are now validated against \`/\`, \`\\\`, \`..\`, \`.\`, and empty strings before any filesystem access. Applied to \`load_module_bundle\`, \`show_spec\`, and \`new_spec\`.
3. **Prompt preamble inconsistency** when using \`--no-spec-index\` — reworded.

## Test plan

- [x] \`fledge lane run pre-commit\` (fmt + lint + test + spec-check) green
- [x] \`fledge ask --help\` advertises new flags
- [x] \`cargo test\` — 811 passed (5 new spec unit tests, 13 new ask unit tests, 1 new CLI test, 1 new spec integration test)
- [x] \`fledge review\` loop surfaced and I fixed: silent success on empty project, path traversal, preamble copy
- [ ] Manual: \`fledge ask --with-specs work "why does the work module sanitize branch names?"\` on a real spec (needs \`claude\` auth; blocked on human to verify)

## Spec module versions

- \`ask\` v2 → v3 (new flags, new dependency on \`spec\`)
- \`spec\` v2 → v3 (new public API: \`collect_index\`, \`render_index_markdown\`, \`load_module_bundle\`, \`all_module_names\`, \`IndexEntry\`)