### PR TITLE
feat: fledge review auto-includes specs for modules in the diff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge spec list --json` | Array of spec summaries (module, version, status, sections, companions) | Orienting to a new codebase |
 | `fledge spec show <name> --json` | Single spec detail (frontmatter + section list + companion status) | Need structured view of one module |
 | `fledge ask "..." --json` | `{question, answer}` from an LLM over the codebase | Answering a question about the code |
-| `fledge review --json` | `{base, file, diff_stats, review}` AI code review of current changes | Before opening a PR |
+| `fledge review --json` | `{base, file, diff_stats, spec_context, review}` AI code review of current changes (auto-includes specs of touched modules) | Before opening a PR |
 | `fledge checks --json` | CI/CD check status for a branch | Verifying a branch is green |
 | `fledge doctor --json` | Environment health diagnostics | Debugging a broken toolchain |
 | `fledge deps --json` | Dependency report (outdated, audit, licenses) | Auditing a project |
@@ -86,15 +86,19 @@ fledge ask --no-spec-index "quick Rust syntax question"
 
 When `--with-specs <name>` is passed, fledge loads `specs/<name>/<name>.spec.md` plus every existing companion (`requirements.md`, `context.md`, `tasks.md`, `testing.md`) into the prompt. Companions carry the design rationale — usually what you want for *why* questions.
 
-### `fledge review`
+### `fledge review` (spec-aware, auto-detect)
+
+`fledge review` auto-detects which modules a diff touches (via each spec's frontmatter `files:` and any edits under `specs/<name>/`) and includes their full spec + companion files as context. Nothing to pass — it just works.
 
 ```bash
-fledge review --json                   # reviews current diff vs main
-fledge review --base HEAD~3 --json     # reviews last 3 commits
+fledge review --json                       # auto-detects, cites specs in review
+fledge review --base HEAD~3 --json         # reviews last 3 commits with spec context
+fledge review --with-specs plugin --json   # auto-detected + force-include plugin spec
+fledge review --no-auto-specs --json       # back to spec-free review
 fledge review --model opus --format checklist --json
 ```
 
-Review does not yet feed specs into its prompt — if you want spec-aware review, run `fledge ask --with-specs <name> "review the recent change to X module"` as a workaround.
+The JSON output now contains a `spec_context` array listing every module whose spec was included. The prompt is explicitly constrained: Claude reviews *only the diff*, treats the specs as context-only, and must not suggest changes to code outside the diff or critique the specs themselves.
 
 ## Typical agent workflows
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -21,7 +21,7 @@ fledge follows three rules that make it agent-usable:
 | `fledge spec list --json` | Array of `{name, version, status, path, files, section_count, required_sections, companions, missing_companions}` |
 | `fledge spec show <name> --json` | `{name, version, status, path, files, sections, companions, missing_companions}` |
 | `fledge ask "..." --json` | `{question, answer}` |
-| `fledge review --json` | `{base, file, diff_stats, review}` |
+| `fledge review --json` | `{base, file, diff_stats, spec_context, review}` |
 | `fledge checks --json` | CI check status |
 | `fledge doctor --json` | Environment diagnostics |
 | `fledge deps --json` | Dependency report |
@@ -59,6 +59,23 @@ fledge ask --no-spec-index "quick Rust syntax question"
 ```
 
 The index adds a few hundred tokens per call; `--with-specs` can add more depending on spec size. Use `--no-spec-index` for questions that have nothing to do with the repo.
+
+#### `fledge review` is spec-aware via auto-detection
+
+`fledge review` inspects the diff's changed-file list, matches each path against every spec's frontmatter `files:` field and against the `specs/<name>/` prefix, and automatically includes the matched modules' full spec bundles as context. No flag needed — just run it.
+
+```bash
+# Default: auto-detect specs for modules in the diff
+fledge review
+
+# Auto-detected + force-include additional specs
+fledge review --with-specs plugin,config
+
+# Opt out of auto-detection (still honors --with-specs if passed)
+fledge review --no-auto-specs
+```
+
+The review prompt is explicitly constrained: specs are context *only*, the review target is always the diff, Claude must not suggest changes to unchanged code or critique the specs. JSON output adds a `spec_context` array so agents can see which specs shaped the review.
 
 ## Typical agent workflows
 
@@ -111,7 +128,6 @@ Every module in `src/` has a matching spec under `specs/<module>/`. The `.spec.m
 These are known gaps; PRs welcome. Each is tracked via the `agent-surface` label.
 
 - `fledge run`, `fledge init`, `fledge spec check/init/new`, `fledge work`, `fledge release` have no `--json` today
-- `fledge review` does not feed specs into its prompt yet (only `ask` does)
 - No global `--non-interactive` flag that forces `--yes` on every subcommand at once
 - No `fledge introspect --json` to dump the full command tree as JSON
 

--- a/specs/review/context.md
+++ b/specs/review/context.md
@@ -15,3 +15,8 @@ spec: review.spec.md
 - Shell out to `claude` CLI rather than calling the API directly — leverages Claude's project context and avoids managing API keys separately
 - Show diff stats before AI output so the developer knows the scope of the review
 - Auto-detect default branch (main vs master) rather than hardcoding
+- **v5: spec-awareness is auto-detected, not opt-in**. Rationale: the most common case is "I changed files in module X; tell me what I got wrong." Making the user manually pick specs defeats the point. Auto-detect uses two signals: (1) any file in the diff matches a spec's frontmatter `files:`, (2) any file in the diff is under `specs/<name>/`. Either triggers inclusion.
+- **The review target is always the diff**. The prompt explicitly forbids Claude from critiquing the specs themselves or suggesting changes to unmodified code. This matches user intent: "review my changes" — specs answer the question "what were these changes *supposed* to do?" but are not on trial.
+- `--no-auto-specs` exists as an escape hatch for the rare case of reviewing a diff in a project with stale specs, where the spec context would be actively misleading
+- `--with-specs` mirrors the flag on `fledge ask` so the two commands feel consistent
+- The JSON output now includes `spec_context: [...]` so agents and tooling can see which specs shaped the review without re-running the command

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,19 +1,20 @@
 ---
 module: review
-version: 4
+version: 5
 status: active
 files:
   - src/review.rs
 
 db_tables: []
-depends_on: []
+depends_on:
+  - spec
 ---
 
 # Review
 
 ## Purpose
 
-AI-powered code review of current branch changes. Gets the git diff against a base branch and sends it to the Claude CLI for review, displaying actionable feedback inline.
+AI-powered code review of current branch changes. Gets the git diff against a base branch and sends it to the Claude CLI for review, displaying actionable feedback inline. When the repo is spec-tracked, `review` automatically detects which modules the diff touches (via each spec's `files:` frontmatter and any edits under `specs/<name>/`) and includes their full spec + companion files as *context* for the review. The review target is always the diff itself — specs are reference material.
 
 ## Public API
 
@@ -22,14 +23,14 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point for the review command |
-| `ReviewOptions` | Options struct with base branch, file filter, json flag, model, prompt, and format |
+| `ReviewOptions` | Options struct with base, file, json, model, prompt, format, with_specs, no_auto_specs |
 | `ReviewFormat` | Enum for review output format: Summary, Checklist, or Inline |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `ReviewOptions` | `{ base: Option<String>, file: Option<String>, json: bool, model: Option<String>, prompt: Option<String>, format: ReviewFormat }` |
+| `ReviewOptions` | `{ base, file, json, model, prompt, format, with_specs: Vec<String>, no_auto_specs: bool }` |
 | `ReviewFormat` | Enum: `Summary` (default, concise markdown), `Checklist` (markdown checklist), `Inline` (file:line comments) |
 
 ### Functions
@@ -37,6 +38,9 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `run` | `(ReviewOptions) -> Result<()>` | Runs AI code review on current diff |
+| `build_spec_context` | `(&Path, &[String], &[String], bool) -> Result<Option<(Vec<String>, String)>>` | (private) Assemble auto-detected + explicit spec bundles and return `(names, body)` |
+| `build_prompt` | `(&str, &ReviewFormat, Option<&str>, Option<&str>) -> String` | (private) Compose the final prompt: review instructions + optional spec context + diff |
+| `get_changed_files` | `(&str, Option<&str>) -> Result<Vec<String>>` | (private) `git diff --name-only` for spec auto-detection |
 
 ## Invariants
 
@@ -45,34 +49,65 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 3. Empty diffs bail with a clear message
 4. Shows diff stats before the AI review output
 5. `--file` flag restricts review to a single file's changes
-6. `--json` outputs structured JSON review results
+6. `--json` outputs structured JSON review results (including the list of specs included in context)
 7. `--model` overrides the Claude model used for review
 8. `--prompt` appends a custom focus prompt to the default review instructions
 9. `--format` controls output style: `summary` (default), `checklist`, or `inline`
+10. When the repo has specs, `review` auto-detects relevant modules by intersecting the diff's changed-file list with each spec's frontmatter `files:` field and with the `<specs_dir>/<name>/` directory prefix (respects the `specs_dir` key from `.specsync/config.toml`, defaulting to `specs/`)
+11. `--with-specs <names>` (comma-separated, repeatable) appends named modules to the auto-detected set and dedupes
+12. `--no-auto-specs` skips the auto-detection step (but still honors `--with-specs`)
+13. The review target is always the diff; the prompt explicitly instructs Claude that specs are context-only and that changes outside the diff must not be suggested
+14. A broken or missing `.specsync/` never blocks a review — spec auto-detection silently falls back to empty
+15. An explicit `--with-specs <name>` that doesn't resolve bails with a clear error naming the missing module
+16. `--file <path>` narrows both the diff AND the auto-detection input — only specs whose `files:` or directory intersects that single path will be auto-included. Use `--with-specs` alongside `--file` if you want additional context
 
 ## Behavioral Examples
 
-### review — review all changes
+### review — auto-detected spec context (default)
 ```
 $ fledge review
+ src/trust.rs | 12 +++-
+ specs/trust/context.md | 4 +++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+Spec context: trust
+
 ● Reviewing changes against main ...
 
- src/github.rs | 85 ++++++++++++
- src/issues.rs | 120 +++++++++++++++
- 2 files changed, 205 insertions(+)
+[Claude reviews the diff with specs/trust/*.md loaded as context]
+```
 
-[AI review output streamed here]
+### review — opt out of auto-detection
+```
+$ fledge review --no-auto-specs
+```
+
+### review — augment with extra specs
+```
+$ fledge review --with-specs plugin,config
+$ fledge review --with-specs plugin --with-specs config
 ```
 
 ### review — against specific base
 ```
 $ fledge review --base develop
-● Reviewing changes against develop ...
 ```
 
 ### review — single file
 ```
 $ fledge review --file src/github.rs
+```
+
+### review — json (now includes spec_context)
+```
+$ fledge review --json
+{
+  "base": "main",
+  "file": null,
+  "diff_stats": "...",
+  "spec_context": ["trust"],
+  "review": "..."
+}
 ```
 
 ### review — with custom model and format
@@ -94,16 +129,19 @@ $ fledge review --prompt "Focus on security vulnerabilities"
 | No changes | Empty diff against base | Bail with message |
 | Claude CLI error | Non-zero exit from claude | Bail with error |
 | Invalid format | Unknown `--format` value | Bail with error listing valid formats |
+| `--with-specs <name>` not found | Named module has no spec | Bail with "loading spec bundle for '<name>'" context |
 
 ## Dependencies
 
 - Claude CLI — AI inference (external dependency)
-- Git CLI — diff generation
+- Git CLI — diff generation, `--name-only` for changed-file detection
+- `spec` module — `specs_for_changed_files` (auto-detect), `load_module_bundle` (full spec+companions)
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-04-23 | Spec-aware review: auto-detect specs for diffed modules (honors `specs_dir` config), `--with-specs`, `--no-auto-specs`, `spec_context` field in JSON output, prompt constraints to keep review target on the diff only |
 | 4 | 2026-04-23 | Add ReviewFormat enum, model/prompt/format fields to ReviewOptions |
 | 3 | 2026-04-22 | Document default branch fallback algorithm (symbolic-ref → main → master → fallback main) |
 | 2 | 2026-04-21 | Add json field to ReviewOptions |

--- a/specs/review/tasks.md
+++ b/specs/review/tasks.md
@@ -12,3 +12,15 @@ spec: review.spec.md
 - [x] Wire up CLI subcommand in main.rs
 - [x] Write unit tests
 - [x] Run verification suite
+- [x] Auto-detect spec context from diff changed-file list (match frontmatter `files:` and `specs/<name>/` prefix)
+- [x] `--with-specs <names>` to append explicit modules
+- [x] `--no-auto-specs` to disable auto-detection
+- [x] Add `spec_context` field to JSON output so agents can see which specs were in prompt
+- [x] Constrain prompt: specs are context-only, review target is the diff, no comments on unchanged code
+- [x] Show `Spec context: trust, work` line in pretty output when specs were included
+
+## Gaps
+
+- No token-budget guardrail: a huge diff touching many modules could balloon the prompt. In practice diffs are small and specs are small — revisit if this bites
+- No way to include *only a section* of a spec (e.g. just `## Invariants`) — whole-bundle or nothing
+- `review` still doesn't review the review diff itself (meta) — the prompt tells Claude to ignore the specs as review targets, but if this file-pair IS the diff (e.g. reviewing changes to specs/review), auto-detect will include review's own spec. That's intentional: it gives Claude the invariants it should check against

--- a/specs/review/testing.md
+++ b/specs/review/testing.md
@@ -10,9 +10,23 @@ spec: review.spec.md
 - Empty diff detection
 - Diff stat line parsing
 - File filter flag applied to git diff command
+- `build_prompt` includes the diff
+- `build_prompt` format variants (summary, checklist, inline)
+- `build_prompt` respects custom focus prompt
+- `build_prompt` includes spec context when provided, omits it when None
+- `build_prompt` spec-context block contains the review-scope constraint language (`CRITICAL`, `context only`, "Do NOT suggest changes", "Do NOT critique or review the specs")
+- `build_spec_context` returns None when `--no-auto-specs` and no `--with-specs`
+- `build_spec_context` merges auto-detected and explicit modules, deduped and sorted
+- `build_spec_context` honors `--no-auto-specs` (skips auto-detection but still loads explicit bundles if any)
 
 ### Integration Tests
 
 - `fledge review` runs against a branch with changes (requires Claude CLI)
 - `fledge review --file <path>` restricts diff to one file
 - Empty diff produces a clear error message
+- `fledge review --help` advertises `--with-specs` and `--no-auto-specs`
+
+### Not tested (by design)
+
+- End-to-end LLM output quality — depends on Claude's behavior, not fledge. Manual verification by authors.
+- No test that Claude obeys the "review only the diff" constraint in practice — we can only enforce the *instruction* in the prompt

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 3
+version: 4
 status: active
 files:
   - src/spec.rs
@@ -29,6 +29,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | `render_index_markdown` | Render a slice of `IndexEntry` as a markdown block suitable for prompt injection |
 | `load_module_bundle` | Concatenate a module's `.spec.md` and existing companion files into one markdown blob |
 | `all_module_names` | Sorted list of every module name with a `.spec.md` file |
+| `specs_for_changed_files` | Module names whose `files:` or `specs/<name>/` directory intersects a given set of paths |
 
 ### Structs & Enums
 
@@ -61,6 +62,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | `render_index_markdown` | `(&[IndexEntry]) -> String` | Format entries as `## Available specs\n- **name** vN (status) — src/foo.rs — purpose` |
 | `load_module_bundle` | `(&Path, &str) -> Result<String>` | Spec body + each existing companion, each under its own `### \`filename\`` header |
 | `all_module_names` | `(&Path) -> Result<Vec<String>>` | Convenience wrapper over `collect_index` returning just names |
+| `specs_for_changed_files` | `(&Path, &[String]) -> Result<Vec<String>>` | Used by `fledge review` to auto-detect which module specs are relevant to a diff |
 
 ## Invariants
 
@@ -220,6 +222,7 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-23 | Add `specs_for_changed_files` for `review`'s spec auto-detection (matches frontmatter `files:` and `<specs_dir>/<name>/` directory prefix, respecting the configured `specs_dir`) |
 | 3 | 2026-04-23 | Expose `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`, and `IndexEntry` for consumers that need spec content in prompt-friendly form (`ask` is the first such consumer). Add `extract_purpose` helper. |
 | 2 | 2026-04-23 | Add `spec list` (alias `ls`) and `spec show`, both with `--json` support for agent/tool consumption |
 | 1 | 2026-04-19 | Initial spec for fledge spec integration |

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,14 @@ enum Commands {
         /// Output format: summary (default), checklist, inline
         #[arg(long, default_value = "summary")]
         format: String,
+        /// Include full spec + companions for these modules in the review
+        /// context (comma-separated, repeatable). Appended to any
+        /// auto-detected specs.
+        #[arg(long, value_name = "NAMES")]
+        with_specs: Vec<String>,
+        /// Disable auto-detection of specs based on files in the diff
+        #[arg(long)]
+        no_auto_specs: bool,
     },
     /// Run a project task defined in fledge.toml
     Run {
@@ -845,6 +853,8 @@ fn run() -> Result<()> {
             model,
             prompt,
             format,
+            with_specs,
+            no_auto_specs,
         } => {
             let format: review::ReviewFormat =
                 format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
@@ -855,6 +865,8 @@ fn run() -> Result<()> {
                 model,
                 prompt,
                 format,
+                with_specs,
+                no_auto_specs,
             })?;
         }
         Commands::Lanes { action } => {

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,7 +1,10 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use console::style;
 use std::fmt;
+use std::path::Path;
 use std::process::Command;
+
+use crate::spec;
 
 #[derive(Debug, Clone, Default)]
 pub enum ReviewFormat {
@@ -43,6 +46,8 @@ pub struct ReviewOptions {
     pub model: Option<String>,
     pub prompt: Option<String>,
     pub format: ReviewFormat,
+    pub with_specs: Vec<String>,
+    pub no_auto_specs: bool,
 }
 
 pub fn run(options: ReviewOptions) -> Result<()> {
@@ -61,12 +66,39 @@ pub fn run(options: ReviewOptions) -> Result<()> {
     }
 
     let diff_stats = get_diff_stats(&base, options.file.as_deref())?;
+    let changed_files = get_changed_files(&base, options.file.as_deref())?;
 
     if !options.json && !diff_stats.is_empty() {
         println!("{}\n", style(&diff_stats).dim());
     }
 
-    let prompt = build_prompt(&diff, &options.format, options.prompt.as_deref());
+    let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let spec_context = build_spec_context(
+        &root,
+        &changed_files,
+        &options.with_specs,
+        options.no_auto_specs,
+    )?;
+
+    if !options.json {
+        if let Some(names) = spec_context.as_ref().map(|(names, _)| names.clone()) {
+            if !names.is_empty() {
+                println!(
+                    "{} {}",
+                    style("Spec context:").dim(),
+                    style(names.join(", ")).cyan()
+                );
+                println!();
+            }
+        }
+    }
+
+    let prompt = build_prompt(
+        &diff,
+        &options.format,
+        options.prompt.as_deref(),
+        spec_context.as_ref().map(|(_, body)| body.as_str()),
+    );
 
     let sp = crate::spinner::Spinner::start(&format!("Reviewing changes against {}:", &base));
 
@@ -94,10 +126,15 @@ pub fn run(options: ReviewOptions) -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     if options.json {
+        let spec_names = spec_context
+            .as_ref()
+            .map(|(names, _)| names.clone())
+            .unwrap_or_default();
         let response = serde_json::json!({
             "base": base,
             "file": options.file,
             "diff_stats": diff_stats,
+            "spec_context": spec_names,
             "review": stdout.trim(),
         });
         println!("{}", serde_json::to_string_pretty(&response)?);
@@ -108,7 +145,56 @@ pub fn run(options: ReviewOptions) -> Result<()> {
     Ok(())
 }
 
-fn build_prompt(diff: &str, format: &ReviewFormat, custom_prompt: Option<&str>) -> String {
+/// Returns `(module_names, prompt_body)` for the spec context to include, or
+/// `None` if no specs are to be included.
+fn build_spec_context(
+    root: &Path,
+    changed_files: &[String],
+    with_specs: &[String],
+    no_auto_specs: bool,
+) -> Result<Option<(Vec<String>, String)>> {
+    let mut names: Vec<String> = Vec::new();
+
+    if !no_auto_specs {
+        // Auto-detect: match by frontmatter files: and by specs/<name>/ prefix.
+        // Silent fallback to empty list if the project isn't spec-tracked.
+        if let Ok(matched) = spec::specs_for_changed_files(root, changed_files) {
+            names.extend(matched);
+        }
+    }
+
+    for raw in with_specs {
+        for part in raw.split(',') {
+            let trimmed = part.trim();
+            if !trimmed.is_empty() {
+                names.push(trimmed.to_string());
+            }
+        }
+    }
+
+    names.sort();
+    names.dedup();
+
+    if names.is_empty() {
+        return Ok(None);
+    }
+
+    let mut body = String::new();
+    for name in &names {
+        let bundle = spec::load_module_bundle(root, name)
+            .with_context(|| format!("loading spec bundle for '{name}'"))?;
+        body.push_str(&bundle);
+    }
+
+    Ok(Some((names, body)))
+}
+
+fn build_prompt(
+    diff: &str,
+    format: &ReviewFormat,
+    custom_prompt: Option<&str>,
+    spec_context: Option<&str>,
+) -> String {
     let format_instruction = match format {
         ReviewFormat::Summary => {
             "Be concise. Use markdown formatting. Only comment on things worth changing.\n\
@@ -130,6 +216,18 @@ fn build_prompt(diff: &str, format: &ReviewFormat, custom_prompt: Option<&str>) 
         None => String::new(),
     };
 
+    let context_section = match spec_context {
+        Some(ctx) => format!(
+            "\n\nBackground context — these are the formal specs for the modules touched by the diff below. \
+            They describe *what the modules are supposed to do*. Use them to interpret the changes.\n\n\
+            CRITICAL: your review must cover **only** the diff. Do NOT suggest changes to code that wasn't \
+            modified. Do NOT critique or review the specs themselves — they are context only. If the diff \
+            contradicts a spec invariant, call that out as a bug in the diff.\n\n\
+            {ctx}\n"
+        ),
+        None => String::new(),
+    };
+
     format!(
         "You are a senior code reviewer. Review the following git diff and provide actionable feedback.\n\
         Focus on:\n\
@@ -137,7 +235,7 @@ fn build_prompt(diff: &str, format: &ReviewFormat, custom_prompt: Option<&str>) 
         - Security issues\n\
         - Performance concerns\n\
         - Code clarity and maintainability\n\
-        \n\
+        {context_section}\n\
         {format_instruction}{custom_section}\n\
         \n\
         ```diff\n{diff}\n```"
@@ -198,13 +296,36 @@ fn get_diff_stats(base: &str, file: Option<&str>) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+fn get_changed_files(base: &str, file: Option<&str>) -> Result<Vec<String>> {
+    let mut args = vec!["diff", "--name-only", base];
+    if let Some(f) = file {
+        args.push("--");
+        args.push(f);
+    }
+    let output = Command::new("git").args(&args).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git diff --name-only failed: {}", stderr.trim());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn build_prompt_contains_diff() {
-        let prompt = build_prompt("+ added line\n- removed line", &ReviewFormat::Summary, None);
+        let prompt = build_prompt(
+            "+ added line\n- removed line",
+            &ReviewFormat::Summary,
+            None,
+            None,
+        );
         assert!(prompt.contains("+ added line"));
         assert!(prompt.contains("- removed line"));
         assert!(prompt.contains("```diff"));
@@ -212,7 +333,7 @@ mod tests {
 
     #[test]
     fn build_prompt_includes_review_criteria() {
-        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, None);
         assert!(prompt.contains("Bugs and logic errors"));
         assert!(prompt.contains("Security issues"));
         assert!(prompt.contains("Performance concerns"));
@@ -221,14 +342,14 @@ mod tests {
 
     #[test]
     fn build_prompt_summary_format() {
-        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, None);
         assert!(prompt.contains("Be concise"));
         assert!(prompt.contains("Use markdown formatting"));
     }
 
     #[test]
     fn build_prompt_checklist_format() {
-        let prompt = build_prompt("some diff", &ReviewFormat::Checklist, None);
+        let prompt = build_prompt("some diff", &ReviewFormat::Checklist, None, None);
         assert!(prompt.contains("markdown checklist"));
         assert!(prompt.contains("- [ ]"));
         assert!(prompt.contains("- [x]"));
@@ -236,7 +357,7 @@ mod tests {
 
     #[test]
     fn build_prompt_inline_format() {
-        let prompt = build_prompt("some diff", &ReviewFormat::Inline, None);
+        let prompt = build_prompt("some diff", &ReviewFormat::Inline, None, None);
         assert!(prompt.contains("file:line - comment"));
         assert!(prompt.contains("Group by file"));
     }
@@ -247,13 +368,14 @@ mod tests {
             "some diff",
             &ReviewFormat::Summary,
             Some("Focus on security vulnerabilities"),
+            None,
         );
         assert!(prompt.contains("Additional review focus: Focus on security vulnerabilities"));
     }
 
     #[test]
     fn build_prompt_without_custom_prompt() {
-        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None);
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, None);
         assert!(!prompt.contains("Additional review focus"));
     }
 
@@ -263,9 +385,35 @@ mod tests {
             "some diff",
             &ReviewFormat::Checklist,
             Some("Check for performance issues"),
+            None,
         );
         assert!(prompt.contains("markdown checklist"));
         assert!(prompt.contains("Additional review focus: Check for performance issues"));
+    }
+
+    #[test]
+    fn build_prompt_includes_spec_context_when_provided() {
+        let ctx = "## Spec bundle: trust\n\ntrust spec body";
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, Some(ctx));
+        assert!(prompt.contains("Background context"));
+        assert!(prompt.contains("trust spec body"));
+    }
+
+    #[test]
+    fn build_prompt_spec_context_constrains_scope() {
+        let ctx = "## Spec bundle: trust\n\ntrust spec body";
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, Some(ctx));
+        // The spec-context block must tell Claude the review target is the diff, not the specs.
+        assert!(prompt.contains("CRITICAL"));
+        assert!(prompt.contains("context only"));
+        assert!(prompt.contains("Do NOT suggest changes to code that wasn't"));
+        assert!(prompt.contains("Do NOT critique or review the specs"));
+    }
+
+    #[test]
+    fn build_prompt_omits_spec_block_when_none() {
+        let prompt = build_prompt("some diff", &ReviewFormat::Summary, None, None);
+        assert!(!prompt.contains("Background context"));
     }
 
     #[test]
@@ -305,6 +453,8 @@ mod tests {
             model: None,
             prompt: None,
             format: ReviewFormat::Summary,
+            with_specs: Vec::new(),
+            no_auto_specs: false,
         };
         assert!(opts.base.is_none());
         assert!(opts.file.is_none());
@@ -312,6 +462,8 @@ mod tests {
         assert!(opts.model.is_none());
         assert!(opts.prompt.is_none());
         assert!(matches!(opts.format, ReviewFormat::Summary));
+        assert!(opts.with_specs.is_empty());
+        assert!(!opts.no_auto_specs);
     }
 
     #[test]
@@ -323,6 +475,8 @@ mod tests {
             model: None,
             prompt: None,
             format: ReviewFormat::Summary,
+            with_specs: Vec::new(),
+            no_auto_specs: false,
         };
         assert_eq!(opts.base.unwrap(), "develop");
         assert!(opts.json);
@@ -337,6 +491,8 @@ mod tests {
             model: None,
             prompt: None,
             format: ReviewFormat::Summary,
+            with_specs: Vec::new(),
+            no_auto_specs: false,
         };
         assert_eq!(opts.file.unwrap(), "src/main.rs");
     }
@@ -350,9 +506,78 @@ mod tests {
             model: Some("opus".to_string()),
             prompt: Some("Focus on security".to_string()),
             format: ReviewFormat::Checklist,
+            with_specs: vec!["trust".to_string()],
+            no_auto_specs: true,
         };
         assert_eq!(opts.model.unwrap(), "opus");
         assert_eq!(opts.prompt.unwrap(), "Focus on security");
         assert!(matches!(opts.format, ReviewFormat::Checklist));
+        assert_eq!(opts.with_specs, vec!["trust"]);
+        assert!(opts.no_auto_specs);
+    }
+
+    #[test]
+    fn build_spec_context_returns_none_when_no_specs_requested_and_disabled() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let ctx = build_spec_context(tmp.path(), &["some/file.rs".to_string()], &[], true).unwrap();
+        assert!(ctx.is_none());
+    }
+
+    #[test]
+    fn build_spec_context_combines_auto_and_explicit() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+        for (name, file) in [("trust", "src/trust.rs"), ("work", "src/work.rs")] {
+            let dir = tmp.path().join(format!("specs/{name}"));
+            fs::create_dir_all(&dir).unwrap();
+            let spec = format!(
+                "---\nmodule: {name}\nversion: 1\nstatus: active\nfiles:\n  - {file}\n\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nP.\n"
+            );
+            fs::write(dir.join(format!("{name}.spec.md")), spec).unwrap();
+        }
+
+        // auto-detect will match trust via src/trust.rs; --with-specs adds work
+        let changed = vec!["src/trust.rs".to_string()];
+        let with = vec!["work".to_string()];
+        let (names, body) = build_spec_context(tmp.path(), &changed, &with, false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(names, vec!["trust", "work"]);
+        assert!(body.contains("## Spec bundle: trust"));
+        assert!(body.contains("## Spec bundle: work"));
+    }
+
+    #[test]
+    fn build_spec_context_no_auto_specs_skips_autodetect() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+        let dir = tmp.path().join("specs/trust");
+        fs::create_dir_all(&dir).unwrap();
+        let spec = "---\nmodule: trust\nversion: 1\nstatus: active\nfiles:\n  - src/trust.rs\n\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nP.\n";
+        fs::write(dir.join("trust.spec.md"), spec).unwrap();
+
+        // src/trust.rs is in diff, but --no-auto-specs should prevent auto-include
+        let changed = vec!["src/trust.rs".to_string()];
+        let ctx = build_spec_context(tmp.path(), &changed, &[], true).unwrap();
+        assert!(ctx.is_none());
     }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -613,6 +613,41 @@ pub fn all_module_names(root: &Path) -> Result<Vec<String>> {
     Ok(collect_index(root)?.into_iter().map(|e| e.name).collect())
 }
 
+/// Return the module names whose `files:` frontmatter matches any of the given
+/// paths, or whose `<specs_dir>/<name>/` directory contains any of them.
+///
+/// Used by `fledge review` to automatically include the right spec context
+/// when reviewing a diff. Silent on specs that fail to parse — a broken
+/// spec should never block a review.
+///
+/// Honors the `specs_dir` key from `.specsync/config.toml`, so projects that
+/// put specs under e.g. `docs/specs/` match correctly.
+pub fn specs_for_changed_files(root: &Path, changed_files: &[String]) -> Result<Vec<String>> {
+    let index = collect_index(root)?;
+    // Best-effort: if config is unreadable for any reason, fall back to "specs".
+    let specs_dir_name = load_config(root)
+        .ok()
+        .and_then(|c| c.specs_dir)
+        .unwrap_or_else(|| "specs".to_string());
+    let specs_dir_trimmed = specs_dir_name.trim_end_matches('/');
+
+    let mut matched = Vec::new();
+    for entry in &index {
+        let files_match = entry
+            .files
+            .iter()
+            .any(|f| changed_files.iter().any(|c| c == f));
+        let spec_prefix = format!("{specs_dir_trimmed}/{}/", entry.name);
+        let dir_match = changed_files.iter().any(|c| c.starts_with(&spec_prefix));
+        if files_match || dir_match {
+            matched.push(entry.name.clone());
+        }
+    }
+    matched.sort();
+    matched.dedup();
+    Ok(matched)
+}
+
 /// Load the full spec bundle for a single module: its `.spec.md` plus whichever
 /// companion files exist, concatenated as a single markdown block with headers.
 pub fn load_module_bundle(root: &Path, name: &str) -> Result<String> {
@@ -1420,6 +1455,113 @@ More text.
         assert!(validate_module_name("trust").is_ok());
         assert!(validate_module_name("create_template").is_ok());
         assert!(validate_module_name("plugin-protocol").is_ok());
+    }
+
+    fn scaffold_project_with_source_specs(tmp: &TempDir) {
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+
+        for (name, source_files) in [
+            ("trust", vec!["src/trust.rs"]),
+            ("ask", vec!["src/ask.rs"]),
+            ("work", vec!["src/work.rs"]),
+        ] {
+            let dir = tmp.path().join(format!("specs/{name}"));
+            fs::create_dir_all(&dir).unwrap();
+            let files_yaml = source_files
+                .iter()
+                .map(|f| format!("  - {f}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let spec = format!(
+                "---\nmodule: {name}\nversion: 1\nstatus: active\nfiles:\n{files_yaml}\n\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nP.\n"
+            );
+            fs::write(dir.join(format!("{name}.spec.md")), spec).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_matches_via_frontmatter_files() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_source_specs(&tmp);
+
+        let changed = vec!["src/trust.rs".to_string(), "src/ask.rs".to_string()];
+        let matched = specs_for_changed_files(tmp.path(), &changed).unwrap();
+        assert_eq!(matched, vec!["ask", "trust"]);
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_matches_via_spec_directory() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_source_specs(&tmp);
+
+        let changed = vec!["specs/trust/context.md".to_string()];
+        let matched = specs_for_changed_files(tmp.path(), &changed).unwrap();
+        assert_eq!(matched, vec!["trust"]);
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_deduplicates() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_source_specs(&tmp);
+
+        // Both trust.rs and specs/trust/context.md → single match
+        let changed = vec![
+            "src/trust.rs".to_string(),
+            "specs/trust/context.md".to_string(),
+        ];
+        let matched = specs_for_changed_files(tmp.path(), &changed).unwrap();
+        assert_eq!(matched, vec!["trust"]);
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_no_match() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_source_specs(&tmp);
+
+        let changed = vec!["README.md".to_string(), "Cargo.toml".to_string()];
+        let matched = specs_for_changed_files(tmp.path(), &changed).unwrap();
+        assert!(matched.is_empty());
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_empty_input() {
+        let tmp = TempDir::new().unwrap();
+        scaffold_project_with_source_specs(&tmp);
+        let matched = specs_for_changed_files(tmp.path(), &[]).unwrap();
+        assert!(matched.is_empty());
+    }
+
+    #[test]
+    fn test_specs_for_changed_files_honors_custom_specs_dir() {
+        let tmp = TempDir::new().unwrap();
+        let specsync = tmp.path().join(".specsync");
+        fs::create_dir_all(&specsync).unwrap();
+        fs::write(
+            specsync.join("config.toml"),
+            "specs_dir = \"docs/specs\"\nrequired_sections = []\n",
+        )
+        .unwrap();
+        let dir = tmp.path().join("docs/specs/trust");
+        fs::create_dir_all(&dir).unwrap();
+        let spec = "---\nmodule: trust\nversion: 1\nstatus: active\nfiles:\n  - src/trust.rs\n\ndb_tables: []\ndepends_on: []\n---\n\n## Purpose\n\nP.\n";
+        fs::write(dir.join("trust.spec.md"), spec).unwrap();
+
+        // Match via `docs/specs/trust/...` prefix, not `specs/trust/...`
+        let changed = vec!["docs/specs/trust/context.md".to_string()];
+        let matched = specs_for_changed_files(tmp.path(), &changed).unwrap();
+        assert_eq!(matched, vec!["trust"]);
+
+        // Changing a file under the legacy `specs/...` path should NOT match
+        // when the project uses a custom specs_dir
+        let changed_wrong = vec!["specs/trust/context.md".to_string()];
+        let matched_wrong = specs_for_changed_files(tmp.path(), &changed_wrong).unwrap();
+        assert!(matched_wrong.is_empty());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2595,6 +2595,14 @@ fn cli_review_accepts_base_flag() {
 }
 
 #[test]
+fn cli_review_accepts_spec_flags() {
+    let output = run_fledge(&["review", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--with-specs"));
+    assert!(stdout.contains("--no-auto-specs"));
+}
+
+#[test]
 fn cli_ask_accepts_json_flag() {
     let output = run_fledge(&["ask", "--help"]);
     let stdout = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
## Summary

\`fledge review\` now detects which modules a diff touches and automatically loads their spec + companions as *context* for Claude. The review target stays strictly the diff — specs are reference material.

This is the key differentiator discussed in the strategy thread: no other review tool can do this because no other tool has a \`files:\` → spec mapping in the repo.

## What it does

- **Auto-detect** relevant specs via two signals: frontmatter \`files:\` match, or changed paths under \`<specs_dir>/<name>/\`.
- **\`--with-specs <names>\`** (comma or repeated) appends to the auto-detected set.
- **\`--no-auto-specs\`** opts out of auto-detection.
- **Prompt constraints**: Claude is told explicitly that specs are context-only, the review target is the diff, and it must not suggest changes to unchanged code or critique the specs.
- **JSON output** gains a \`spec_context\` array naming every module whose spec was included.

## Dogfooded self-review

Ran \`fledge review --format checklist\` on this branch. It caught and I fixed:

1. **Real bug**: \`specs_for_changed_files\` was hardcoding \`specs/\` as a prefix; projects with a custom \`specs_dir\` would silently miss directory matches. Now reads from \`.specsync/config.toml\`.
2. **Change-log dates** were off by one day (2026-04-24 → 2026-04-23).
3. **\`--file\` interaction** with auto-detect now documented as invariant 16.
4. **AGENTS.md heading** rewritten to be TOC-friendly.

## Spec bumps
- \`review\` v4 → v5
- \`spec\` v3 → v4 (new public helper \`specs_for_changed_files\`)

## Test plan

- [x] \`fledge lane run pre-commit\` — fmt + lint + test + spec-check green, **0 warnings**
- [x] \`cargo test\` — 824 passed (+13 new: 6 \`specs_for_changed_files\`, 7 review unit, 1 CLI)
- [x] \`fledge review --help\` advertises \`--with-specs\` and \`--no-auto-specs\`
- [x] Custom \`specs_dir = "docs/specs"\` test confirms directory match uses config, not hardcoded
- [x] \`fledge review\` on this branch produced a useful, spec-aware review (items above caught by dogfooding)