### PR TITLE
feat: --json on fledge spec check and work subcommands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 |---------|-------------|----------|
 | `fledge spec list --json` | Array of spec summaries (module, version, status, sections, companions) | Orienting to a new codebase |
 | `fledge spec show <name> --json` | Single spec detail (frontmatter + section list + companion status) | Need structured view of one module |
+| `fledge spec check --json` | `{specs: [{name, version, status, errors, warnings, ...}], totals, strict}` | Spec-sync validation as data |
 | `fledge ask "..." --json` | `{question, answer}` from an LLM over the codebase | Answering a question about the code |
 | `fledge review --json` | `{base, file, diff_stats, spec_context, review}` AI code review of current changes (auto-includes specs of touched modules) | Before opening a PR |
 | `fledge checks --json` | CI/CD check status for a branch | Verifying a branch is green |
@@ -45,8 +46,11 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge plugins list --json` | Installed plugins with trust tier, capabilities | Auditing plugin state |
 | `fledge issues --json` | GitHub issues list | Picking up work |
 | `fledge lane run <name> --json` | Lane execution results | Running the project's own CI pipeline |
+| `fledge work start <name> --json` | `{branch, base, type, prefix, issue}` — branch name the agent just created | Branch scripting |
+| `fledge work pr --json` | `{url, number, title, head, base, draft}` — PR URL to report back | After agent finishes a task |
+| `fledge work status --json` | `{branch, default, ahead, behind, pr?}` — current state of the branch | Pre-action sanity check |
 
-Commands **without** `--json` (pretty output only): `init`, `spec check`, `spec init`, `spec new`, `run`, `publish`, `create-template`, `watch`, `work`, `release`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
+Commands **without** `--json` (pretty output only): `init`, `spec init`, `spec new`, `run`, `publish`, `create-template`, `watch`, `release`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
 
 ## Commands that block on TTY prompts
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -20,6 +20,7 @@ fledge follows three rules that make it agent-usable:
 |---------|---------------|
 | `fledge spec list --json` | Array of `{name, version, status, path, files, section_count, required_sections, companions, missing_companions}` |
 | `fledge spec show <name> --json` | `{name, version, status, path, files, sections, companions, missing_companions}` |
+| `fledge spec check --json` | `{specs: [{name, version, status, file_count, section_count, required_count, errors, warnings}], totals: {checked, errors, warnings}, strict}` |
 | `fledge ask "..." --json` | `{question, answer}` |
 | `fledge review --json` | `{base, file, diff_stats, spec_context, review}` |
 | `fledge checks --json` | CI check status |
@@ -32,6 +33,9 @@ fledge follows three rules that make it agent-usable:
 | `fledge plugins list --json` | Installed plugins |
 | `fledge issues --json` | GitHub issues |
 | `fledge lane run <name> --json` | Lane execution results |
+| `fledge work start <name> --json` | `{branch, base, type, prefix, issue}` |
+| `fledge work pr --json` | `{url, number, title, head, base, draft}` |
+| `fledge work status --json` | `{branch, default, ahead, behind, pr}` |
 
 ### Commands that block without `--yes`
 
@@ -127,7 +131,7 @@ Every module in `src/` has a matching spec under `specs/<module>/`. The `.spec.m
 
 These are known gaps; PRs welcome. Each is tracked via the `agent-surface` label.
 
-- `fledge run`, `fledge init`, `fledge spec check/init/new`, `fledge work`, `fledge release` have no `--json` today
+- `fledge run`, `fledge init`, `fledge spec init/new`, `fledge release` have no `--json` today
 - No global `--non-interactive` flag that forces `--yes` on every subcommand at once
 - No `fledge introspect --json` to dump the full command tree as JSON
 

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 4
+version: 5
 status: active
 files:
   - src/spec.rs
@@ -22,7 +22,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point that dispatches to the appropriate spec subcommand |
-| `SpecAction` | Enum of subcommands: Check, Init, New, List, Show |
+| `SpecAction` | Enum of subcommands: Check (strict, json), Init, New, List, Show |
 | `SpecFrontmatter` | Parsed YAML frontmatter from a spec file |
 | `IndexEntry` | Compact prompt-friendly record of one spec (name, version, status, purpose, files) |
 | `collect_index` | Enumerate every spec as `IndexEntry`s, sorted by name |
@@ -35,7 +35,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 
 | Type | Description |
 |------|-------------|
-| `SpecAction` | Enum of subcommands: Check, Init, New, List, Show |
+| `SpecAction` | Enum of subcommands: Check (strict, json), Init, New, List, Show |
 | `SpecFrontmatter` | Parsed YAML frontmatter from a spec file |
 | `SpecResult` | Result of validating a single spec (warnings + errors) |
 | `SpecSummary` | (private) Summary for `list`: name, version, status, path, files, section/required counts, companions, missing companions |
@@ -53,7 +53,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `run` | `(SpecAction) -> Result<()>` | Dispatches to check, init, new, list, or show |
-| `check` | `(root: &Path, strict: bool) -> Result<()>` | Validates all specs and prints report (private) |
+| `check` | `(root: &Path, strict: bool, json: bool) -> Result<()>` | Validates all specs and prints a human or JSON report (private) |
 | `init` | `(root: &Path) -> Result<()>` | Scaffolds `.specsync/` with config.toml, registry.toml, .gitignore, version (private) |
 | `new_spec` | `(root: &Path, name: &str) -> Result<()>` | Creates spec directory with spec.md and companion files (private) |
 | `list_specs` | `(root: &Path, json: bool) -> Result<()>` | Enumerate specs with frontmatter, section counts, and companion status (private) |
@@ -222,6 +222,7 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-04-23 | Add `--json` to `spec check`. Payload: `{specs: [{name, version, status, file_count, section_count, required_count, errors, warnings}], totals: {checked, errors, warnings}, strict}`. Exit code still non-zero on errors or strict-with-warnings. |
 | 4 | 2026-04-23 | Add `specs_for_changed_files` for `review`'s spec auto-detection (matches frontmatter `files:` and `<specs_dir>/<name>/` directory prefix, respecting the configured `specs_dir`) |
 | 3 | 2026-04-23 | Expose `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`, and `IndexEntry` for consumers that need spec content in prompt-friendly form (`ask` is the first such consumer). Add `extract_purpose` helper. |
 | 2 | 2026-04-23 | Add `spec list` (alias `ls`) and `spec show`, both with `--json` support for agent/tool consumption |

--- a/specs/work/context.md
+++ b/specs/work/context.md
@@ -19,3 +19,6 @@ Fledge is evolving from scaffolding to a project lifecycle tool. `fledge work` p
 - `--issue` flag prepends the issue number to the name portion for GitHub issue linking
 - Sanitize branch names (lowercase, replace non-alphanumeric with hyphens) to avoid git issues
 - `generate_title_from_branch` dynamically strips any known type prefix rather than hardcoding a few
+- **v6: `--json` added to all three subcommands** so agents can drive the workflow without parsing human-formatted output. Rationale: agents using `fledge work start` need the branch name back; agents using `fledge work pr` need the PR URL and number; `fledge work status` should give a shape compatible with `fledge checks --json` and `fledge prs --json`. Each JSON payload is a single top-level object.
+- In JSON mode, spinners and ✅ output are suppressed entirely so the only stdout content is the JSON payload. Errors still go to stderr, and the process still exits non-zero on failure — so `if fledge work pr --json; then ... fi` works as expected.
+- `status` now also reports `behind` (commits the base has that the branch doesn't). Cheap and agent-useful.

--- a/specs/work/tasks.md
+++ b/specs/work/tasks.md
@@ -16,3 +16,12 @@ spec: work.spec.md
 - [x] Add custom prefix override (--prefix flag)
 - [x] Add WorkConfig with fledge.toml [work] section support
 - [x] Update spec to v2 for flexible branch types
+- [x] Add `--json` to `start`, `pr`, `status` (v6): pretty output suppressed in JSON mode; errors still surface on stderr; exit codes unchanged
+- [x] Add `behind` count to `status` JSON output (uses `git rev-list --count branch..base`)
+- [x] `extract_pr_number` helper parses the trailing `/<n>` from `gh pr create`'s URL output
+
+## Gaps
+
+- No JSON option for `init` / `publish` / `create-template` / plugins create/publish — these are once-per-project commands and currently remain pretty-only
+- `status --json` omits detached-HEAD and no-upstream edge cases in the payload schema (they still bail with an error, so agents can detect via non-zero exit)
+- `pr --json` still runs the git push and gh pr create through the external processes; no capture of their intermediate stderr in the JSON (stderr still prints on failure)

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 5
+version: 6
 status: active
 files:
   - src/work.rs
@@ -32,7 +32,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 
 | Type | Description |
 |------|-------------|
-| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base), Pr, Status |
+| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base, json), Pr (title, body, draft, base, json), Status (json) |
 | `WorkConfig` | Deserializable config with `branch_format` and `default_type` fields |
 
 ### Traits
@@ -45,9 +45,9 @@ Provides opinionated git workflow commands for feature branch development. `fled
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `run` | `(WorkAction) -> Result<()>` | Dispatches to start, pr, or status |
-| `start` | `(name, branch_type, issue, prefix, base) -> Result<()>` | Creates and checks out a branch with configurable type and naming |
-| `pr` | `(title, body, draft, base) -> Result<()>` | Creates a PR via `gh` CLI |
-| `status` | `() -> Result<()>` | Shows current branch, commits ahead, and PR status |
+| `start` | `(name, branch_type, issue, prefix, base, json) -> Result<()>` | Creates and checks out a branch with configurable type and naming |
+| `pr` | `(title, body, draft, base, json) -> Result<()>` | Creates a PR via `gh` CLI |
+| `status` | `(json: bool) -> Result<()>` | Shows current branch, commits ahead/behind, and PR status |
 | `sanitize_branch_name` | `(&str) -> String` | Lowercase, replace special chars with hyphens, collapse consecutive hyphens |
 | `generate_title_from_branch` | `(&str) -> String` | Strip type prefix, convert hyphens to spaces, title-case |
 | `build_branch_name` | `(name, branch_type, issue, prefix, config) -> String` | Apply format template with `{author}`, `{type}`, `{name}`, `{issue}` substitution |
@@ -71,6 +71,10 @@ Provides opinionated git workflow commands for feature branch development. `fled
 12. `generate_title_from_branch` strips any valid branch type prefix (feat/, feature/, fix/, bug/, chore/, task/, docs/, hotfix/, refactor/)
 13. Plugin lifecycle hook `post_work_start` runs after branch creation (errors silently ignored via `.ok()`)
 14. Plugin lifecycle hook `pre_pr` runs before PR creation (errors propagate and abort the PR)
+15. `--json` on `start` emits `{branch, base, type, prefix, issue}` and suppresses the pretty ✅ output
+16. `--json` on `pr` emits `{url, number, title, head, base, draft}` and suppresses spinner + pretty output
+17. `--json` on `status` emits `{branch, default, ahead, behind, pr: {number, state, url} | null}`. `behind` is `null` when `git rev-list` can't compute it (e.g. the base hasn't been fetched) — this is distinct from `0` (up-to-date) so agents can detect "needs fetch" vs "up to date"
+18. `--json` never silences errors — error messages still go to stderr; exit code is still non-zero on failure
 
 ## Behavioral Examples
 
@@ -144,6 +148,59 @@ $ fledge work status
   PR: #42 (open) — https://github.com/owner/repo/pull/42
 ```
 
+### work start --json
+```
+$ fledge work start add-search --json
+{
+  "branch": "leif/feat/add-search",
+  "base": "main",
+  "type": "feat",
+  "prefix": null,
+  "issue": null
+}
+```
+
+### work pr --json
+```
+$ fledge work pr --json
+{
+  "url": "https://github.com/owner/repo/pull/42",
+  "number": 42,
+  "title": "Add search command",
+  "head": "leif/feat/add-search",
+  "base": "main",
+  "draft": false
+}
+```
+
+### work status --json
+```
+$ fledge work status --json
+{
+  "branch": "leif/feat/add-search",
+  "default": "main",
+  "ahead": 3,
+  "behind": 0,
+  "pr": {
+    "number": 42,
+    "state": "open",
+    "url": "https://github.com/owner/repo/pull/42"
+  }
+}
+```
+
+### work status --json — when base hasn't been fetched
+```
+$ fledge work status --json
+{
+  "branch": "leif/feat/add-search",
+  "default": "main",
+  "ahead": 3,
+  "behind": null,
+  "pr": null
+}
+```
+
 ## Error Cases
 
 | Error | When | Behavior |
@@ -173,3 +230,4 @@ $ fledge work status
 | 3 | 2026-04-20 | Added `feature`, `bug`, `task` as valid branch types |
 | 4 | 2026-04-21 | Correct load_work_config as internal (not exported) |
 | 5 | 2026-04-22 | Document lifecycle hooks: post_work_start (silent) and pre_pr (propagating) |
+| 6 | 2026-04-23 | Add `--json` to `start`, `pr`, and `status`. `status` now also reports `behind`. Pretty output suppressed in JSON mode; errors still go to stderr. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,9 @@ enum SpecSubcommand {
         /// Treat warnings as errors
         #[arg(long)]
         strict: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Initialize spec-sync configuration
     Init,
@@ -458,6 +461,9 @@ enum WorkSubcommand {
         /// Base branch to branch from (default: main)
         #[arg(long)]
         base: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Create a pull request from the current branch
     Pr {
@@ -473,9 +479,16 @@ enum WorkSubcommand {
         /// Target base branch for the PR
         #[arg(long)]
         base: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Show current branch and PR status
-    Status,
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]
@@ -740,7 +753,7 @@ fn run() -> Result<()> {
         }
         Commands::Spec { action } => {
             let action = match action {
-                SpecSubcommand::Check { strict } => spec::SpecAction::Check { strict },
+                SpecSubcommand::Check { strict, json } => spec::SpecAction::Check { strict, json },
                 SpecSubcommand::Init => spec::SpecAction::Init,
                 SpecSubcommand::List { json } => spec::SpecAction::List { json },
                 SpecSubcommand::New { name } => spec::SpecAction::New { name },
@@ -756,25 +769,29 @@ fn run() -> Result<()> {
                     issue,
                     prefix,
                     base,
+                    json,
                 } => work::WorkAction::Start {
                     name,
                     branch_type,
                     issue,
                     prefix,
                     base,
+                    json,
                 },
                 WorkSubcommand::Pr {
                     title,
                     body,
                     draft,
                     base,
+                    json,
                 } => work::WorkAction::Pr {
                     title,
                     body,
                     draft,
                     base,
+                    json,
                 },
-                WorkSubcommand::Status => work::WorkAction::Status,
+                WorkSubcommand::Status { json } => work::WorkAction::Status { json },
             };
             work::run(action)?;
         }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -61,7 +61,7 @@ impl SpecResult {
 pub fn run(action: SpecAction) -> Result<()> {
     let root = find_project_root();
     match action {
-        SpecAction::Check { strict } => check(&root, strict),
+        SpecAction::Check { strict, json } => check(&root, strict, json),
         SpecAction::Init => init(&root),
         SpecAction::New { name } => new_spec(&root, &name),
         SpecAction::List { json } => list_specs(&root, json),
@@ -71,7 +71,7 @@ pub fn run(action: SpecAction) -> Result<()> {
 
 #[derive(Debug)]
 pub enum SpecAction {
-    Check { strict: bool },
+    Check { strict: bool, json: bool },
     Init,
     New { name: String },
     List { json: bool },
@@ -378,16 +378,25 @@ fn validate_spec(
     }
 }
 
-fn check(root: &Path, strict: bool) -> Result<()> {
+fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
     let config = load_config(root)?;
     let specs_dir = root.join(config.specs_dir.as_deref().unwrap_or("specs"));
 
     if !specs_dir.exists() {
-        println!(
-            "{} No specs directory found at {}",
-            style("*").cyan().bold(),
-            style(specs_dir.display()).dim()
-        );
+        if json {
+            let payload = serde_json::json!({
+                "specs": [],
+                "totals": { "checked": 0, "errors": 0, "warnings": 0 },
+                "strict": strict,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            println!(
+                "{} No specs directory found at {}",
+                style("*").cyan().bold(),
+                style(specs_dir.display()).dim()
+            );
+        }
         return Ok(());
     }
 
@@ -418,11 +427,20 @@ fn check(root: &Path, strict: bool) -> Result<()> {
     }
 
     if results.is_empty() {
-        println!(
-            "{} No spec files found in {}",
-            style("*").cyan().bold(),
-            style(specs_dir.display()).dim()
-        );
+        if json {
+            let payload = serde_json::json!({
+                "specs": [],
+                "totals": { "checked": 0, "errors": 0, "warnings": 0 },
+                "strict": strict,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            println!(
+                "{} No spec files found in {}",
+                style("*").cyan().bold(),
+                style(specs_dir.display()).dim()
+            );
+        }
         return Ok(());
     }
 
@@ -430,13 +448,56 @@ fn check(root: &Path, strict: bool) -> Result<()> {
 
     let mut total_errors = 0;
     let mut total_warnings = 0;
+    for result in &results {
+        total_errors += result.error_count();
+        total_warnings += result.warning_count();
+    }
+
+    if json {
+        let specs_payload: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                let errors: Vec<&str> = r
+                    .issues
+                    .iter()
+                    .filter(|i| i.is_error)
+                    .map(|i| i.message.as_str())
+                    .collect();
+                let warnings: Vec<&str> = r
+                    .issues
+                    .iter()
+                    .filter(|i| !i.is_error)
+                    .map(|i| i.message.as_str())
+                    .collect();
+                serde_json::json!({
+                    "name": r.name,
+                    "version": r.version,
+                    "status": r.status,
+                    "file_count": r.file_count,
+                    "section_count": r.section_count,
+                    "required_count": r.required_count,
+                    "errors": errors,
+                    "warnings": warnings,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "specs": specs_payload,
+            "totals": {
+                "checked": results.len(),
+                "errors": total_errors,
+                "warnings": total_warnings,
+            },
+            "strict": strict,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        if total_errors > 0 || (strict && total_warnings > 0) {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
 
     for result in &results {
-        let errors = result.error_count();
-        let warnings = result.warning_count();
-        total_errors += errors;
-        total_warnings += warnings;
-
         if result.has_errors() || (strict && result.has_warnings()) {
             print!(
                 "{} {} (v{}, {})",

--- a/src/work.rs
+++ b/src/work.rs
@@ -64,14 +64,18 @@ pub enum WorkAction {
         issue: Option<u64>,
         prefix: Option<String>,
         base: Option<String>,
+        json: bool,
     },
     Pr {
         title: Option<String>,
         body: Option<String>,
         draft: bool,
         base: Option<String>,
+        json: bool,
     },
-    Status,
+    Status {
+        json: bool,
+    },
 }
 
 pub fn run(action: WorkAction) -> Result<()> {
@@ -83,20 +87,29 @@ pub fn run(action: WorkAction) -> Result<()> {
             issue,
             prefix,
             base,
+            json,
         } => start(
             &name,
             branch_type.as_deref(),
             issue,
             prefix.as_deref(),
             base.as_deref(),
+            json,
         ),
         WorkAction::Pr {
             title,
             body,
             draft,
             base,
-        } => pr(title.as_deref(), body.as_deref(), draft, base.as_deref()),
-        WorkAction::Status => status(),
+            json,
+        } => pr(
+            title.as_deref(),
+            body.as_deref(),
+            draft,
+            base.as_deref(),
+            json,
+        ),
+        WorkAction::Status { json } => status(json),
     }
 }
 
@@ -171,6 +184,7 @@ fn start(
     issue: Option<u64>,
     prefix: Option<&str>,
     base: Option<&str>,
+    json: bool,
 ) -> Result<()> {
     if has_uncommitted_changes()? {
         bail!("Uncommitted changes detected. Commit or stash before starting work.");
@@ -234,24 +248,41 @@ fn start(
 
     git_output(&["checkout", "-b", &branch_name, &base_branch])?;
 
-    println!(
-        "{} Created branch {} from {}",
-        style("✅").green().bold(),
-        style(&branch_name).cyan(),
-        style(&base_branch).dim()
-    );
-    println!(
-        "{} Switched to {}",
-        style("✅").green().bold(),
-        style(&branch_name).cyan()
-    );
-
     crate::plugin::run_lifecycle_hook("post_work_start").ok();
+
+    if json {
+        let payload = serde_json::json!({
+            "branch": branch_name,
+            "base": base_branch,
+            "type": btype,
+            "prefix": prefix,
+            "issue": issue,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!(
+            "{} Created branch {} from {}",
+            style("✅").green().bold(),
+            style(&branch_name).cyan(),
+            style(&base_branch).dim()
+        );
+        println!(
+            "{} Switched to {}",
+            style("✅").green().bold(),
+            style(&branch_name).cyan()
+        );
+    }
 
     Ok(())
 }
 
-fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) -> Result<()> {
+fn pr(
+    title: Option<&str>,
+    body: Option<&str>,
+    draft: bool,
+    base: Option<&str>,
+    json: bool,
+) -> Result<()> {
     if Command::new("gh").arg("--version").output().is_err() {
         bail!(
             "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/ and run `gh auth login`."
@@ -268,31 +299,43 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
         );
     }
 
-    let commits_ahead = commits_ahead_of(&branch, base.unwrap_or(&default))?;
+    let base_branch = base.unwrap_or(&default).to_string();
+    let commits_ahead = commits_ahead_of(&branch, &base_branch)?;
     if commits_ahead == 0 {
         bail!(
             "No commits ahead of '{}'. Make some changes first.",
-            base.unwrap_or(&default)
+            base_branch
         );
     }
 
     crate::plugin::run_lifecycle_hook("pre_pr")?;
 
-    let sp = crate::spinner::Spinner::start(&format!("Pushing {} to origin:", &branch));
+    let push_sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start(&format!(
+            "Pushing {} to origin:",
+            &branch
+        )))
+    };
     let push_output = Command::new("git")
         .args(["push", "-u", "origin", &branch])
         .output()?;
-    sp.finish();
+    if let Some(sp) = push_sp {
+        sp.finish();
+    }
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
         bail!("Failed to push: {}", stderr.trim());
     }
 
-    println!(
-        "{} Pushed {} to origin",
-        style("✅").green().bold(),
-        style(&branch).cyan()
-    );
+    if !json {
+        println!(
+            "{} Pushed {} to origin",
+            style("✅").green().bold(),
+            style(&branch).cyan()
+        );
+    }
 
     let pr_title = match title {
         Some(t) => t.to_string(),
@@ -320,9 +363,15 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
         gh_args.push(b.to_string());
     }
 
-    let sp = crate::spinner::Spinner::start("Creating pull request:");
+    let create_sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Creating pull request:"))
+    };
     let gh_output = Command::new("gh").args(&gh_args).output()?;
-    sp.finish();
+    if let Some(sp) = create_sp {
+        sp.finish();
+    }
 
     if !gh_output.status.success() {
         let stderr = String::from_utf8_lossy(&gh_output.stderr);
@@ -332,20 +381,33 @@ fn pr(title: Option<&str>, body: Option<&str>, draft: bool, base: Option<&str>) 
     let pr_url = String::from_utf8_lossy(&gh_output.stdout)
         .trim()
         .to_string();
+    let pr_number = extract_pr_number(&pr_url);
 
-    let draft_label = if draft { "draft " } else { "" };
-    println!(
-        "{} Created {}PR: \"{}\"",
-        style("✅").green().bold(),
-        draft_label,
-        style(&pr_title).green()
-    );
-    println!("  {}", style(&pr_url).dim());
+    if json {
+        let payload = serde_json::json!({
+            "url": pr_url,
+            "number": pr_number,
+            "title": pr_title,
+            "head": branch,
+            "base": base_branch,
+            "draft": draft,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        let draft_label = if draft { "draft " } else { "" };
+        println!(
+            "{} Created {}PR: \"{}\"",
+            style("✅").green().bold(),
+            draft_label,
+            style(&pr_title).green()
+        );
+        println!("  {}", style(&pr_url).dim());
+    }
 
     Ok(())
 }
 
-fn status() -> Result<()> {
+fn status(json: bool) -> Result<()> {
     let branch = current_branch()?;
     if branch.is_empty() {
         bail!("Detached HEAD — not on any branch.");
@@ -353,16 +415,12 @@ fn status() -> Result<()> {
 
     let default = default_branch()?;
     let ahead = commits_ahead_of(&branch, &default)?;
+    // `behind` needs the remote-tracking base; returns None if the base hasn't
+    // been fetched. That's distinct from "actually 0 behind" and agents need
+    // to tell them apart.
+    let behind: Option<usize> = commits_behind_of(&branch, &default).ok();
 
-    println!(
-        "  Branch: {} ({} {} ahead of {})",
-        style(&branch).cyan(),
-        ahead,
-        if ahead == 1 { "commit" } else { "commits" },
-        style(&default).dim()
-    );
-
-    if Command::new("gh").arg("--version").output().is_ok() {
+    let pr_info = if Command::new("gh").arg("--version").output().is_ok() {
         let gh_output = Command::new("gh")
             .args([
                 "pr",
@@ -379,21 +437,82 @@ fn status() -> Result<()> {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let lines: Vec<&str> = stdout.trim().lines().collect();
                 if lines.len() >= 3 {
-                    println!(
-                        "  PR: #{} ({}) — {}",
-                        style(lines[0]).green(),
-                        lines[1].to_lowercase(),
-                        style(lines[2]).dim()
-                    );
+                    let number: Option<u64> = lines[0].parse().ok();
+                    Some((number, lines[1].to_lowercase(), lines[2].to_string()))
+                } else {
+                    None
                 }
             }
-            _ => {
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    if json {
+        let pr_payload = match &pr_info {
+            Some((number, state, url)) => serde_json::json!({
+                "number": number,
+                "state": state,
+                "url": url,
+            }),
+            None => serde_json::Value::Null,
+        };
+        let payload = serde_json::json!({
+            "branch": branch,
+            "default": default,
+            "ahead": ahead,
+            "behind": behind,  // null when rev-list fails (e.g. base not fetched)
+            "pr": pr_payload,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        let behind_display = match behind {
+            Some(n) if n > 0 => format!(", {} behind", n),
+            _ => String::new(),
+        };
+        println!(
+            "  Branch: {} ({} {} ahead of {}{})",
+            style(&branch).cyan(),
+            ahead,
+            if ahead == 1 { "commit" } else { "commits" },
+            style(&default).dim(),
+            behind_display,
+        );
+        match &pr_info {
+            Some((number, state, url)) => {
+                let number_display = number
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "?".to_string());
+                println!(
+                    "  PR: #{} ({}) — {}",
+                    style(number_display).green(),
+                    state,
+                    style(url).dim()
+                );
+            }
+            None => {
                 println!("  PR: {}", style("none").dim());
             }
         }
     }
 
     Ok(())
+}
+
+fn commits_behind_of(branch: &str, base: &str) -> Result<usize> {
+    let range = format!("{branch}..{base}");
+    let output = git_output(&["rev-list", "--count", &range])?;
+    Ok(output.parse().unwrap_or(0))
+}
+
+fn extract_pr_number(url: &str) -> Option<u64> {
+    // GitHub PR URLs always contain `/pull/<n>`. Anchor on that rather than
+    // the last path segment so trailing `/`, `?query`, or `#fragment` don't
+    // silently turn into `None`.
+    let after_pull = url.rsplit_once("/pull/")?.1;
+    let end = after_pull.find(['/', '?', '#']).unwrap_or(after_pull.len());
+    after_pull[..end].parse().ok()
 }
 
 fn commits_ahead_of(branch: &str, base: &str) -> Result<usize> {
@@ -705,5 +824,58 @@ test = "cargo test"
         assert!(VALID_BRANCH_TYPES.contains(&"hotfix"));
         assert!(VALID_BRANCH_TYPES.contains(&"refactor"));
         assert!(!VALID_BRANCH_TYPES.contains(&"yolo"));
+    }
+
+    #[test]
+    fn extract_pr_number_basic() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/42"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_trailing_slash() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/42/"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_with_query() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/42?q=1"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_with_fragment() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/42#comment"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_subpath() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/pull/42/files"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_no_pull_segment() {
+        assert_eq!(
+            extract_pr_number("https://github.com/owner/repo/issues/42"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_pr_number_not_a_url() {
+        assert_eq!(extract_pr_number("not-a-url"), None);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -996,6 +996,83 @@ fn cli_spec_show_missing_module_fails() {
     assert!(stderr.contains("No spec found") || stderr.contains("not"));
 }
 
+#[test]
+fn cli_spec_check_json_valid() {
+    let output = run_fledge(&["spec", "check", "--json"]);
+    // May pass or fail on the repo's specs; either way stdout must be JSON
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(parsed.is_object());
+    assert!(parsed["specs"].is_array());
+    assert!(parsed["totals"].is_object());
+    assert!(parsed["totals"]["checked"].is_number());
+    assert!(parsed["totals"]["errors"].is_number());
+    assert!(parsed["totals"]["warnings"].is_number());
+    assert!(parsed["strict"].is_boolean());
+}
+
+#[test]
+fn cli_spec_check_json_spec_shape() {
+    let output = run_fledge(&["spec", "check", "--json"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let specs = parsed["specs"].as_array().unwrap();
+    assert!(!specs.is_empty(), "fledge repo should have specs");
+    let first = &specs[0];
+    for field in [
+        "name",
+        "version",
+        "status",
+        "file_count",
+        "section_count",
+        "required_count",
+        "errors",
+        "warnings",
+    ] {
+        assert!(first.get(field).is_some(), "missing field: {field}");
+    }
+    assert!(first["errors"].is_array());
+    assert!(first["warnings"].is_array());
+}
+
+#[test]
+fn cli_work_start_help_shows_json_flag() {
+    let output = run_fledge(&["work", "start", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--json"));
+}
+
+#[test]
+fn cli_work_pr_help_shows_json_flag() {
+    let output = run_fledge(&["work", "pr", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--json"));
+}
+
+#[test]
+fn cli_work_status_help_shows_json_flag() {
+    let output = run_fledge(&["work", "status", "--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--json"));
+}
+
+#[test]
+fn cli_work_status_json_in_repo() {
+    // Current repo is a git repo with a current branch, so this should succeed.
+    let output = run_fledge(&["work", "status", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(parsed.is_object());
+    assert!(parsed["branch"].is_string());
+    assert!(parsed["default"].is_string());
+    assert!(parsed["ahead"].is_number());
+    // behind is either a number or null (base-not-fetched sentinel)
+    assert!(parsed["behind"].is_number() || parsed["behind"].is_null());
+    // pr is either null or an object — both are valid
+    assert!(parsed.get("pr").is_some());
+}
+
 // ──────────────────────────────────────────────────────────
 // Changelog command (requires git repo)
 // ──────────────────────────────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1058,14 +1058,46 @@ fn cli_work_status_help_shows_json_flag() {
 
 #[test]
 fn cli_work_status_json_in_repo() {
-    // Current repo is a git repo with a current branch, so this should succeed.
-    let output = run_fledge(&["work", "status", "--json"]);
-    assert!(output.status.success());
+    // Run inside a temp git repo with a real branch — avoids the detached-HEAD
+    // situation that CI check-out sometimes produces.
+    let tmp = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let output = run_fledge_in(tmp.path(), &["work", "status", "--json"]);
+    assert!(
+        output.status.success(),
+        "work status --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert!(parsed.is_object());
-    assert!(parsed["branch"].is_string());
-    assert!(parsed["default"].is_string());
+    assert_eq!(parsed["branch"].as_str(), Some("feature"));
+    assert_eq!(parsed["default"].as_str(), Some("main"));
     assert!(parsed["ahead"].is_number());
     // behind is either a number or null (base-not-fetched sentinel)
     assert!(parsed["behind"].is_number() || parsed["behind"].is_null());


### PR DESCRIPTION
## Summary

Closes the agent-visible \`--json\` gaps on the high-traffic read/write commands:

- **\`fledge spec check --json\`** — \`{specs: [...], totals, strict}\`. Exit code still non-zero on errors.
- **\`fledge work start --json\`** — \`{branch, base, type, prefix, issue}\`.
- **\`fledge work pr --json\`** — \`{url, number, title, head, base, draft}\`.
- **\`fledge work status --json\`** — \`{branch, default, ahead, behind, pr}\`. \`behind\` is \`null\` when \`git rev-list\` can't compute it (base not fetched), distinct from \`0\` (up-to-date).

Spinners and pretty output are suppressed in JSON mode so stdout is a pure JSON payload. Errors still go to stderr; exit codes unchanged.

## Dogfooded \`fledge review\`

The new spec-aware \`fledge review\` caught two real correctness risks and I fixed both:

1. **\`commits_behind_of(...).unwrap_or(0)\`** silently reported 0 when git failed. An agent would read \`behind: 0\` and skip a needed rebase. Now \`Option<usize>\` → \`null\` on failure.
2. **\`extract_pr_number\`** used naive last-segment splitting, broke on trailing slashes / query strings / subpaths. Rewrote to anchor on \`/pull/\` and respect \`/?#\` boundaries. Added 7 unit tests.

## Spec bumps
- \`work\` v5 → v6
- \`spec\` v4 → v5

## Test plan

- [x] \`fledge lane run pre-commit\` — fmt + lint + test + spec-check green (0 warnings)
- [x] \`cargo test\` — 837 total (+13 new)
- [x] \`fledge work status --json\`, \`fledge spec check --json\` on the real repo — shapes match the spec
- [x] \`fledge review\` surfaced \`behind\` and \`extract_pr_number\` bugs; both fixed