### PR TITLE
feat: global --non-interactive flag and FLEDGE_NON_INTERACTIVE env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ If you are about to run `npm`, `cargo`, `make`, `git checkout -b`, or `gh pr cre
 
 1. **Prefer fledge subcommands over raw tools** when wrapped. E.g. use `fledge work start` instead of `git checkout -b`, `fledge run test` instead of guessing `cargo test` vs `npm test`.
 2. **Always add `--json` when a command supports it** (see list below). Parse the JSON; do not screen-scrape pretty output.
-3. **Always pass `--yes` / `--force` to commands that otherwise prompt** (see TTY table). A stalled prompt looks like success to you but blocks forever.
+3. **Set `FLEDGE_NON_INTERACTIVE=1` once** in your shell, or pass `--non-interactive` (alias `--ni`) per invocation. Every command then treats confirmation prompts as `--yes`; prompts with no default bail with a clear error instead of blocking forever.
 4. **Check exit codes.** Non-zero means something failed, even if stdout looks fine.
 5. **Don't mutate without running `fledge lane run pre-commit` first** — it's the project-defined quality gate.
 
@@ -52,20 +52,33 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 
 Commands **without** `--json` (pretty output only): `init`, `spec init`, `spec new`, `run`, `publish`, `create-template`, `watch`, `release`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
 
-## Commands that block on TTY prompts
+## Non-interactive mode (the one-switch answer)
 
-These commands use `dialoguer` prompts. Agents must pass the bypass flag or the process will hang forever.
+Set this once at the top of your shell session and forget about it:
 
-| Command | Bypass flag | Effect |
-|---------|------------|--------|
-| `fledge init` | `--yes` | Skip interactive template-variable prompts (uses detected defaults) |
-| `fledge templates publish` | `--yes` | Skip "update existing repo?" confirmation |
-| `fledge templates create` | `--yes` | Skip name/description/type prompts |
-| `fledge plugins install` | `--yes` + `--force` | Skip trust-tier and capability-grant prompts |
-| `fledge plugins publish` | `--yes` | Skip confirmations |
-| `fledge plugins create` | `--yes` | Skip scaffolding prompts |
+```bash
+export FLEDGE_NON_INTERACTIVE=1
+```
 
-Commands safe to call non-interactively today: `ask`, `review`, `checks`, `doctor`, `deps`, `metrics`, `changelog`, `spec *`, `work start`, `work pr`, `run`, `lane run`, `release`, `validate-template`, `search`, `plugins list`, `plugins remove`, `plugins update`, `plugins audit`, `issues`, `prs`, `watch`.
+Or pass the flag per invocation: `fledge --non-interactive <cmd>` (alias `--ni`). Both are equivalent.
+
+When non-interactive mode is active, every command that would otherwise prompt behaves **as if `--yes` / `--force` were passed**:
+
+| Command | Effect |
+|---------|--------|
+| `fledge init` | Skip template-variable prompts (uses detected defaults) |
+| `fledge templates publish` | Skip "update existing repo?" confirmation |
+| `fledge templates create` | Skip name/description/type prompts |
+| `fledge plugins install` | Skip trust-tier and capability-grant prompts |
+| `fledge plugins publish` | Skip confirmations |
+| `fledge plugins create` | Skip scaffolding prompts |
+| `fledge lane publish` | Skip description prompt |
+
+Prompts that have **no sensible default** (e.g. `fledge init` being asked to pick a template when none was specified) fail fast with a clear error naming the flag to pass instead. No silent hangs.
+
+You can still pass `--yes`/`--force` per command if you prefer — they and `FLEDGE_NON_INTERACTIVE` compose.
+
+Commands safe to call even without this flag (they never prompt): `ask`, `review`, `checks`, `doctor`, `deps`, `metrics`, `changelog`, `spec *`, `work start`, `work pr`, `work status`, `run`, `lane run`, `release`, `validate-template`, `search`, `plugins list`, `plugins remove`, `plugins update`, `plugins audit`, `issues`, `prs`, `watch`.
 
 ## AI commands
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -37,9 +37,11 @@ fledge follows three rules that make it agent-usable:
 | `fledge work pr --json` | `{url, number, title, head, base, draft}` |
 | `fledge work status --json` | `{branch, default, ahead, behind, pr}` |
 
-### Commands that block without `--yes`
+### Non-interactive mode (one switch)
 
-`fledge init`, `fledge templates publish`, `fledge templates create`, `fledge plugins install`, `fledge plugins publish`, `fledge plugins create`. Pass `--yes` (and `--force` for plugin install) in agent contexts.
+Set `FLEDGE_NON_INTERACTIVE=1` in your environment, or pass `--non-interactive` (alias `--ni`) per invocation. Both flip a global flag that every prompt site observes: every `--yes`/`--force` is auto-promoted, and prompts that need user input bail cleanly instead of hanging.
+
+Commands covered: `fledge init`, `fledge templates publish`, `fledge templates create`, `fledge plugins install`, `fledge plugins publish`, `fledge plugins create`, `fledge lane publish`.
 
 ### AI-powered commands
 
@@ -132,7 +134,6 @@ Every module in `src/` has a matching spec under `specs/<module>/`. The `.spec.m
 These are known gaps; PRs welcome. Each is tracked via the `agent-surface` label.
 
 - `fledge run`, `fledge init`, `fledge spec init/new`, `fledge release` have no `--json` today
-- No global `--non-interactive` flag that forces `--yes` on every subcommand at once
 - No `fledge introspect --json` to dump the full command tree as JSON
 
 ## Contributing agent-surface improvements

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,6 +1,6 @@
 ---
 module: main
-version: 2
+version: 3
 status: active
 files:
   - src/main.rs
@@ -85,10 +85,13 @@ All modules are dependencies — main dispatches to every subcommand module. See
 2. Unknown commands are forwarded to `plugin::resolve_plugin_command` for plugin pass-through
 3. Shell completions support bash, zsh, fish, and PowerShell via `--install` flag
 4. The `--version` and `--help` flags are handled by clap
+5. The top-level `--non-interactive` flag (aliased `--ni`) is a clap `global = true` arg, available on every subcommand. When set, or when `FLEDGE_NON_INTERACTIVE` env var is truthy (`1`/`true`/`yes`/`y`/`on`), `utils::set_non_interactive(true)` is called before dispatch, so every prompt site in the dispatched command observes it
+6. `utils::init_non_interactive_from_env()` runs before `Cli::parse()` so the env var is honored even when users don't pass the flag
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-23 | Add `--non-interactive` global flag (alias `--ni`) and `FLEDGE_NON_INTERACTIVE` env var. Sets `utils::NON_INTERACTIVE` before dispatch; each subcommand with `--yes`/`--force` auto-promotes it when the flag is set; prompts that have no default bail with a clear error. |
 | 2 | 2026-04-23 | Add `watch` to depends_on |
 | 1 | 2026-04-21 | Initial spec |

--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -21,7 +21,10 @@ struct TemplateAnswers {
     include_prompts: bool,
 }
 
-pub fn run(options: CreateTemplateOptions) -> Result<()> {
+pub fn run(mut options: CreateTemplateOptions) -> Result<()> {
+    if crate::utils::is_non_interactive() {
+        options.yes = true;
+    }
     let target = options.output.join(&options.name);
 
     if target.exists() {

--- a/src/init.rs
+++ b/src/init.rs
@@ -21,7 +21,10 @@ pub struct InitOptions {
     pub yes: bool,
 }
 
-pub fn run(opts: InitOptions) -> Result<()> {
+pub fn run(mut opts: InitOptions) -> Result<()> {
+    if crate::utils::is_non_interactive() {
+        opts.yes = true;
+    }
     crate::plugin::run_lifecycle_hook("pre_init").ok();
     let config = Config::load().context("loading config")?;
     let extra_paths = config.extra_template_paths();

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -1505,6 +1505,7 @@ fn publish_lanes(
     description: Option<&str>,
     yes: bool,
 ) -> Result<()> {
+    let yes = yes || crate::utils::is_non_interactive();
     let config = crate::config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,12 @@ mod work;
     about = "Dev-lifecycle CLI — get your projects ready to fly."
 )]
 struct Cli {
+    /// Run without prompts: treat every interactive confirmation as --yes,
+    /// and bail with a clear error on prompts that have no default. Also
+    /// settable via the FLEDGE_NON_INTERACTIVE env var.
+    #[arg(long, global = true, visible_alias = "ni")]
+    non_interactive: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -742,7 +748,13 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    // Env var is honored regardless of how the CLI is invoked, so agent shells
+    // can set FLEDGE_NON_INTERACTIVE=1 once and forget about it.
+    utils::init_non_interactive_from_env();
     let cli = Cli::parse();
+    if cli.non_interactive {
+        utils::set_non_interactive(true);
+    }
 
     match cli.command {
         Commands::Templates { action } => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -416,6 +416,7 @@ fn validate_plugin_name(name: &str) -> Result<()> {
 }
 
 fn install_plugin(source: &str, force: bool) -> Result<()> {
+    let force = force || crate::utils::is_non_interactive();
     let (_, git_ref) = parse_source_ref(source);
     let url = normalize_source(source);
     let repo_name = extract_name_from_source(source);
@@ -1391,6 +1392,7 @@ fn make_executable(_path: &Path) -> Result<()> {
 }
 
 fn create_plugin(name: &str, output: &Path, description: Option<&str>, yes: bool) -> Result<()> {
+    let yes = yes || crate::utils::is_non_interactive();
     let target = output.join(name);
 
     if target.exists() {
@@ -1652,6 +1654,7 @@ fn publish_plugin(
     description: Option<&str>,
     yes: bool,
 ) -> Result<()> {
+    let yes = yes || crate::utils::is_non_interactive();
     let config = crate::config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -13,7 +13,10 @@ pub struct PublishOptions {
     pub yes: bool,
 }
 
-pub fn run(options: PublishOptions) -> Result<()> {
+pub fn run(mut options: PublishOptions) -> Result<()> {
+    if crate::utils::is_non_interactive() {
+        options.yes = true;
+    }
     let config = crate::config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,58 @@
 use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+/// Global flag: when set, every prompt site must either auto-answer (because
+/// its command also has `--yes`/`--force` passed explicitly or now forced by
+/// this flag) or bail with a clear error.
+static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Whether the user has explicitly asked for a non-interactive run, either via
+/// the `--non-interactive` flag or the `FLEDGE_NON_INTERACTIVE` env var.
+pub fn is_non_interactive() -> bool {
+    NON_INTERACTIVE.load(Ordering::Relaxed)
+}
+
+/// Set the global non-interactive flag. Called from `main` after parsing CLI
+/// args and the env var.
+pub fn set_non_interactive(value: bool) {
+    NON_INTERACTIVE.store(value, Ordering::Relaxed);
+}
+
+/// Read `FLEDGE_NON_INTERACTIVE` from the environment and, if set to a truthy
+/// value, flip the global flag. Accepts `1`, `true`, `yes`, `y`, `on`
+/// (case-insensitive).
+pub fn init_non_interactive_from_env() {
+    if let Ok(raw) = std::env::var("FLEDGE_NON_INTERACTIVE") {
+        if is_truthy(&raw) {
+            set_non_interactive(true);
+        }
+    }
+}
+
+fn is_truthy(s: &str) -> bool {
+    matches!(
+        s.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "y" | "on"
+    )
+}
+
+/// A run is "interactive" if stdin is a TTY **and** the non-interactive flag
+/// is not set. This means `require_interactive` and any code gating on this
+/// helper will correctly refuse to prompt when the user asked for a scripted
+/// run.
 pub fn is_interactive() -> bool {
-    std::io::stdin().is_terminal()
+    !is_non_interactive() && std::io::stdin().is_terminal()
 }
 
 pub fn require_interactive(flag_name: &str) -> anyhow::Result<()> {
+    if is_non_interactive() {
+        anyhow::bail!(
+            "This command requires interactive input but --non-interactive (or FLEDGE_NON_INTERACTIVE) is set.\n  \
+             Use --{} to skip prompts, provide all required arguments via flags,\n  \
+             or unset FLEDGE_NON_INTERACTIVE / omit --non-interactive to run interactively.",
+            flag_name
+        );
+    }
     if !is_interactive() {
         anyhow::bail!(
             "This command requires interactive input but stdin is not a TTY.\n  \
@@ -222,5 +270,81 @@ mod tests {
     #[test]
     fn test_validate_github_org_slashes() {
         assert!(validate_github_org("my/org").is_err());
+    }
+
+    #[test]
+    fn test_is_truthy_accepts_common_values() {
+        for v in ["1", "true", "TRUE", "Yes", "y", "ON", "  on "] {
+            assert!(is_truthy(v), "expected '{v}' to be truthy");
+        }
+    }
+
+    #[test]
+    fn test_is_truthy_rejects_common_falsy_values() {
+        for v in ["", "0", "false", "no", "off", "nope", "blue"] {
+            assert!(!is_truthy(v), "expected '{v}' to be falsy");
+        }
+    }
+
+    // The global atomic is process-wide. `cargo test` runs tests in parallel
+    // threads by default, so every test that mutates the flag serializes on
+    // this mutex. A Drop guard restores the previous value even if a test
+    // panics mid-body.
+    use std::sync::Mutex;
+    static NON_INTERACTIVE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct NonInteractiveGuard<'a> {
+        _lock: std::sync::MutexGuard<'a, ()>,
+        prev: bool,
+    }
+
+    impl NonInteractiveGuard<'_> {
+        fn new(set_to: bool) -> Self {
+            let lock = NON_INTERACTIVE_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let prev = is_non_interactive();
+            set_non_interactive(set_to);
+            Self { _lock: lock, prev }
+        }
+    }
+
+    impl Drop for NonInteractiveGuard<'_> {
+        fn drop(&mut self) {
+            set_non_interactive(self.prev);
+        }
+    }
+
+    #[test]
+    fn test_set_and_is_non_interactive() {
+        let _guard = NonInteractiveGuard::new(true);
+        assert!(is_non_interactive());
+        set_non_interactive(false);
+        assert!(!is_non_interactive());
+    }
+
+    #[test]
+    fn test_require_interactive_bails_when_non_interactive_set() {
+        let _guard = NonInteractiveGuard::new(true);
+        let result = require_interactive("yes");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("--non-interactive") || msg.contains("FLEDGE_NON_INTERACTIVE"),
+            "error should mention the flag or env var, got: {msg}"
+        );
+        assert!(
+            msg.contains("unset FLEDGE_NON_INTERACTIVE") || msg.contains("omit --non-interactive"),
+            "error should offer escape hatch, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_is_interactive_respects_non_interactive_flag() {
+        let _guard = NonInteractiveGuard::new(true);
+        assert!(
+            !is_interactive(),
+            "should be non-interactive when flag is set"
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2725,3 +2725,38 @@ fn cli_ask_accepts_with_specs_flag() {
     assert!(stdout.contains("--with-specs"));
     assert!(stdout.contains("--no-spec-index"));
 }
+
+#[test]
+fn cli_global_non_interactive_flag_present_in_help() {
+    let output = run_fledge(&["--help"]);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("--non-interactive"),
+        "expected --non-interactive in top-level help: {stdout}"
+    );
+}
+
+#[test]
+fn cli_non_interactive_accepted_on_subcommand() {
+    // Global clap args don't appear in every subcommand's --help, but they
+    // must still be *accepted* on subcommands. A passing help invocation
+    // (exit 0) is enough to confirm the parser accepts the arg there.
+    let output = run_fledge(&["--non-interactive", "spec", "list", "--json"]);
+    assert!(
+        output.status.success(),
+        "--non-interactive was rejected: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let _parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+}
+
+#[test]
+fn cli_non_interactive_alias_ni_accepted() {
+    let output = run_fledge(&["--ni", "doctor", "--json"]);
+    assert!(
+        output.status.success(),
+        "--ni was rejected: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

One switch that makes fledge agent-safe everywhere.

- \`FLEDGE_NON_INTERACTIVE=1\` in the environment (agents set it once in the shell), or
- \`--non-interactive\` (alias \`--ni\`) top-level flag (available on every subcommand)

When set, every command that has \`--yes\`/\`--force\` behaves as if that flag was passed, and prompts that have no sensible default bail with an actionable error instead of hanging.

## Impl

- \`utils::NON_INTERACTIVE\` atomic + \`is_non_interactive\`, \`set_non_interactive\`, \`init_non_interactive_from_env\` helpers.
- \`is_interactive()\` now ANDs \`!is_non_interactive()\` into its result — every code path that gated on "can I prompt?" respects the flag for free.
- \`require_interactive()\` gets an expanded error message that offers the escape hatch (\`unset FLEDGE_NON_INTERACTIVE\` / omit \`--non-interactive\`).
- Each prompt-bearing command (\`init\`, \`publish\`, \`create_template\`, \`plugin install/create/publish\`, \`lane publish\`) forces its \`yes\`/\`force\` flag to true when non-interactive mode is active.

## Dogfood

\`fledge review\` caught four real issues, all fixed:

1. Parallel-\`cargo test\` race on the process-wide atomic — added \`Mutex<()>\` + \`NonInteractiveGuard\` with Drop-based restore.
2. \`require_interactive\` error didn't mention the unset/omit escape hatch.
3. Inconsistent override pattern (\`create_template\` was rebuilding a struct; others used \`mut opts\`). Unified.
4. Stale \`fledge prompts select\` reference in AGENTS.md.

## Test plan

- [x] \`fledge lane run pre-commit\` — fmt + lint + test + spec-check green, 0 warnings
- [x] \`cargo test\` — 845 passed (+8 new), 0 failed
- [x] \`fledge --non-interactive spec list --json\` works
- [x] \`fledge --ni doctor --json\` works (alias)
- [x] \`FLEDGE_NON_INTERACTIVE=1 fledge ...\` works

## Spec bumps
- \`main\` v2 → v3 (new invariants document the global flag wiring)