### PR TITLE
feat: work pr — auto body + preview + confirm

### DIFF
--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 7
+version: 8
 status: active
 files:
   - src/work.rs
@@ -8,6 +8,7 @@ files:
 db_tables: []
 depends_on:
   - config
+  - llm
 ---
 
 # Work
@@ -33,7 +34,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 
 | Type | Description |
 |------|-------------|
-| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base, json), Pr (title, body, draft, base, json, yes), Status (json) |
+| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base, json), Pr (title, body, draft, base, json, yes, ai, provider, model), Status (json) |
 | `WorkConfig` | Deserializable config with `branch_format` and `default_type` fields |
 
 ### Traits
@@ -47,7 +48,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 |----------|-----------|-------------|
 | `run` | `(WorkAction) -> Result<()>` | Dispatches to start, pr, or status |
 | `start` | `(name, branch_type, issue, prefix, base, json) -> Result<()>` | Creates and checks out a branch with configurable type and naming |
-| `pr` | `(title, body, draft, base, json, yes) -> Result<()>` | Creates a PR via `gh` CLI; auto-generates title/body and shows a preview + confirmation unless `--yes` or `--json` |
+| `pr` | `(title, body, draft, base, json, yes, ai, provider, model) -> Result<()>` | Creates a PR via `gh` CLI; auto-generates title/body and shows a preview + confirmation unless `--yes` or `--json`. `--ai` switches the body generator to the configured LLM provider |
 | `status` | `(json: bool) -> Result<()>` | Shows current branch, commits ahead/behind, and PR status |
 | `sanitize_branch_name` | `(&str) -> String` | Lowercase, replace special chars with hyphens, collapse consecutive hyphens |
 | `generate_title_from_branch` | `(&str) -> String` | Strip type prefix, convert hyphens to spaces, title-case |
@@ -58,6 +59,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 - `load_work_config() -> WorkConfig` — Reads `[work]` section from `fledge.toml`, falls back to defaults
 - `format_commit_subject_as_bullet(&str) -> String` — Strips a leading conventional-commit prefix and upper-cases the first letter
 - `print_pr_preview(title, body, head, base, draft)` — Renders the boxed preview block
+- `generate_body_with_ai(branch, base, provider, model, json) -> Result<String>` — Builds a context bundle (commit log + diffstat + truncated diff) and asks the configured LLM for a Markdown PR body
 
 ## Invariants
 
@@ -83,6 +85,8 @@ Provides opinionated git workflow commands for feature branch development. `fled
 20. `pr` shows a styled preview of the title, branch flow, and full body before invoking `gh pr create`; the preview is suppressed in `--json` mode
 21. `pr` prompts `Create this pull request?` with default Yes after the preview. `--yes` / `-y` skips the prompt; `--json` skips it as well (assumes agent intent). In a non-interactive shell without `--yes` or `--json`, `pr` bails rather than hanging
 22. Choosing "No" at the confirmation prompt aborts cleanly with a `✋ Aborted.` message and exits 0 without pushing or calling `gh`
+23. `--ai` replaces heuristic body generation with an LLM call via `crate::llm::build_provider`; the prompt includes the full commit log, `git diff --stat`, and the diff itself (truncated to 600 lines so small/local models stay in context). `--provider` / `--model` override the active selection for this single call. `--body <text>` always wins over `--ai` (literal beats generated)
+24. The AI body generation shows a "Drafting PR body [provider (model)]:" spinner unless `--json` is set; the resulting body still flows through the same preview + confirmation gate, so the user always sees what will be posted before it goes
 
 ## Behavioral Examples
 
@@ -170,6 +174,37 @@ $ fledge work pr --title "WIP: search command" --draft --yes
   https://github.com/owner/repo/pull/42
 ```
 
+### work pr — AI-generated body
+```
+$ fledge work pr --ai
+✓ Drafting PR body [ollama (qwen3-coder:480b-cloud)]: 6.2s
+
+────────────────────────────────────────────────────────────
+Title: Add search command
+Branch:  leif/feat/add-search → main
+
+  ## Summary
+  - Adds a `fledge search` subcommand backed by a new `SearchIndex` …
+  - Wires the index into the existing `init` flow so templates …
+
+  ## Test plan
+  - [ ] `fledge search "hello"` returns the expected hits
+  - [ ] Empty index does not panic on lookup
+
+────────────────────────────────────────────────────────────
+? Create this pull request? (Y/n) y
+✓ Pushed leif/feat/add-search to origin
+✓ Created PR #42: "Add search command"
+```
+
+### work pr — pin a specific provider/model just for this PR
+```
+$ fledge work pr --ai --provider ollama --model gpt-oss:120b-cloud --yes
+… preview …
+✓ Pushed leif/feat/add-search to origin
+✓ Created PR #43: "Add search command"
+```
+
 ### work status — on feature branch
 ```
 $ fledge work status
@@ -243,6 +278,7 @@ $ fledge work status --json
 | No commits ahead | `work pr` with no new commits | Bail with message |
 | Non-interactive without --yes | `work pr` in a non-TTY shell without `--yes` or `--json` | Bail asking for `--yes` rather than hanging on the prompt |
 | User declines confirmation | `work pr` and answers "n" at the prompt | Print `✋ Aborted.` and exit 0 without pushing |
+| AI body generation fails | `--ai` with provider unreachable or model timeout | Bubble up the provider error verbatim (same surface as `fledge ask`) so the user can fix the config and retry |
 
 ## Dependencies
 
@@ -251,6 +287,8 @@ $ fledge work status --json
 - `serde` / `toml` — config deserialization for `[work]` section in `fledge.toml`
 - `crate::config::Config` — global config for author resolution
 - `crate::utils::is_interactive` — TTY gate for the confirmation prompt
+- `crate::llm::{build_provider, ProviderOverride, describe}` — `--ai` body generation
+- `crate::spinner::Spinner` — progress indicator during the AI call
 - Git CLI — branch operations
 - `gh` CLI — PR creation (optional for `status`)
 
@@ -265,3 +303,4 @@ $ fledge work status --json
 | 5 | 2026-04-22 | Document lifecycle hooks: post_work_start (silent) and pre_pr (propagating) |
 | 6 | 2026-04-23 | Add `--json` to `start`, `pr`, and `status`. `status` now also reports `behind`. Pretty output suppressed in JSON mode; errors still go to stderr. |
 | 7 | 2026-04-24 | `work pr` auto-generates the PR body from commits when `--body` is omitted, shows a styled preview, and prompts for confirmation before creating the PR. `--yes` / `-y` skips the prompt; non-interactive shells must pass `--yes` or `--json`. |
+| 8 | 2026-04-24 | `work pr --ai` generates a richer Markdown body via the configured LLM (`fledge ai use`-aware), with `--provider` / `--model` per-call overrides. Prompt includes commit log, diffstat, and truncated diff; spinner shown unless `--json`. |

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 6
+version: 7
 status: active
 files:
   - src/work.rs
@@ -26,13 +26,14 @@ Provides opinionated git workflow commands for feature branch development. `fled
 | `WorkAction` | Enum of subcommands: Start, Pr, Status |
 | `sanitize_branch_name` | Normalizes a string into a valid git branch name (lowercase, hyphens, no leading/trailing hyphens) |
 | `generate_title_from_branch` | Generates a human-readable PR title from a branch name by stripping any known type prefix and converting hyphens to spaces |
+| `generate_body_from_commits` | Generates a Markdown PR body from `git log base..branch` — `## Summary` heading + one bullet per commit subject (conventional-commit prefix stripped) |
 | `build_branch_name` | (test-only) Constructs a branch name from components using WorkConfig |
 
 ### Structs & Enums
 
 | Type | Description |
 |------|-------------|
-| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base, json), Pr (title, body, draft, base, json), Status (json) |
+| `WorkAction` | Enum of subcommands: Start (name, branch_type, issue, prefix, base, json), Pr (title, body, draft, base, json, yes), Status (json) |
 | `WorkConfig` | Deserializable config with `branch_format` and `default_type` fields |
 
 ### Traits
@@ -46,14 +47,17 @@ Provides opinionated git workflow commands for feature branch development. `fled
 |----------|-----------|-------------|
 | `run` | `(WorkAction) -> Result<()>` | Dispatches to start, pr, or status |
 | `start` | `(name, branch_type, issue, prefix, base, json) -> Result<()>` | Creates and checks out a branch with configurable type and naming |
-| `pr` | `(title, body, draft, base, json) -> Result<()>` | Creates a PR via `gh` CLI |
+| `pr` | `(title, body, draft, base, json, yes) -> Result<()>` | Creates a PR via `gh` CLI; auto-generates title/body and shows a preview + confirmation unless `--yes` or `--json` |
 | `status` | `(json: bool) -> Result<()>` | Shows current branch, commits ahead/behind, and PR status |
 | `sanitize_branch_name` | `(&str) -> String` | Lowercase, replace special chars with hyphens, collapse consecutive hyphens |
 | `generate_title_from_branch` | `(&str) -> String` | Strip type prefix, convert hyphens to spaces, title-case |
+| `generate_body_from_commits` | `(branch, base) -> Result<String>` | Build `## Summary` body from `base..branch` commit subjects; strips conventional-commit prefixes |
 | `build_branch_name` | `(name, branch_type, issue, prefix, config) -> String` | Apply format template with `{author}`, `{type}`, `{name}`, `{issue}` substitution |
 
 **Internal (not exported):**
 - `load_work_config() -> WorkConfig` — Reads `[work]` section from `fledge.toml`, falls back to defaults
+- `format_commit_subject_as_bullet(&str) -> String` — Strips a leading conventional-commit prefix and upper-cases the first letter
+- `print_pr_preview(title, body, head, base, draft)` — Renders the boxed preview block
 
 ## Invariants
 
@@ -75,6 +79,10 @@ Provides opinionated git workflow commands for feature branch development. `fled
 16. `--json` on `pr` emits `{url, number, title, head, base, draft}` and suppresses spinner + pretty output
 17. `--json` on `status` emits `{branch, default, ahead, behind, pr: {number, state, url} | null}`. `behind` is `null` when `git rev-list` can't compute it (e.g. the base hasn't been fetched) — this is distinct from `0` (up-to-date) so agents can detect "needs fetch" vs "up to date"
 18. `--json` never silences errors — error messages still go to stderr; exit code is still non-zero on failure
+19. `pr` auto-generates the body from `git log base..branch` when `--body` is omitted; conventional-commit prefixes (`feat:`, `fix(scope):`, etc.) are stripped and bullets read as sentences. If no commits between base and branch, falls back to a `(describe the change)` placeholder
+20. `pr` shows a styled preview of the title, branch flow, and full body before invoking `gh pr create`; the preview is suppressed in `--json` mode
+21. `pr` prompts `Create this pull request?` with default Yes after the preview. `--yes` / `-y` skips the prompt; `--json` skips it as well (assumes agent intent). In a non-interactive shell without `--yes` or `--json`, `pr` bails rather than hanging
+22. Choosing "No" at the confirmation prompt aborts cleanly with a `✋ Aborted.` message and exits 0 without pushing or calling `gh`
 
 ## Behavioral Examples
 
@@ -125,9 +133,30 @@ $ fledge work start foo --type yolo
 error: Unknown branch type 'yolo'. Valid types: feat, feature, fix, bug, chore, task, docs, hotfix, refactor
 ```
 
-### work pr — create pull request
+### work pr — create pull request (with preview + confirmation)
 ```
 $ fledge work pr
+
+────────────────────────────────────────────────────────────
+Title: Add search command
+Branch:  leif/feat/add-search → main
+
+  ## Summary
+
+  - Add search command
+  - Wire up search index
+
+────────────────────────────────────────────────────────────
+? Create this pull request? (Y/n) y
+✓ Pushed leif/feat/add-search to origin
+✓ Created PR #42: "Add search command"
+  https://github.com/owner/repo/pull/42
+```
+
+### work pr — skip the prompt
+```
+$ fledge work pr --yes
+… preview …
 ✓ Pushed leif/feat/add-search to origin
 ✓ Created PR #42: "Add search command"
   https://github.com/owner/repo/pull/42
@@ -135,7 +164,7 @@ $ fledge work pr
 
 ### work pr — with title and draft
 ```
-$ fledge work pr --title "WIP: search command" --draft
+$ fledge work pr --title "WIP: search command" --draft --yes
 ✓ Pushed leif/feat/add-search to origin
 ✓ Created draft PR #42: "WIP: search command"
   https://github.com/owner/repo/pull/42
@@ -212,12 +241,16 @@ $ fledge work status --json
 | On main/master | `work pr` from default branch | Bail with message |
 | `gh` not installed | `work pr` | Bail with install instructions |
 | No commits ahead | `work pr` with no new commits | Bail with message |
+| Non-interactive without --yes | `work pr` in a non-TTY shell without `--yes` or `--json` | Bail asking for `--yes` rather than hanging on the prompt |
+| User declines confirmation | `work pr` and answers "n" at the prompt | Print `✋ Aborted.` and exit 0 without pushing |
 
 ## Dependencies
 
 - `console` — styled terminal output
+- `dialoguer` — `Confirm` prompt for the PR preview confirmation
 - `serde` / `toml` — config deserialization for `[work]` section in `fledge.toml`
 - `crate::config::Config` — global config for author resolution
+- `crate::utils::is_interactive` — TTY gate for the confirmation prompt
 - Git CLI — branch operations
 - `gh` CLI — PR creation (optional for `status`)
 
@@ -231,3 +264,4 @@ $ fledge work status --json
 | 4 | 2026-04-21 | Correct load_work_config as internal (not exported) |
 | 5 | 2026-04-22 | Document lifecycle hooks: post_work_start (silent) and pre_pr (propagating) |
 | 6 | 2026-04-23 | Add `--json` to `start`, `pr`, and `status`. `status` now also reports `behind`. Pretty output suppressed in JSON mode; errors still go to stderr. |
+| 7 | 2026-04-24 | `work pr` auto-generates the PR body from commits when `--body` is omitted, shows a styled preview, and prompts for confirmation before creating the PR. `--yes` / `-y` skips the prompt; non-interactive shells must pass `--yes` or `--json`. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,7 +503,7 @@ enum WorkSubcommand {
         /// PR title (auto-generated from branch name if omitted)
         #[arg(short, long)]
         title: Option<String>,
-        /// PR body/description
+        /// PR body (auto-generated from commits if omitted)
         #[arg(short, long)]
         body: Option<String>,
         /// Create as a draft PR
@@ -515,6 +515,9 @@ enum WorkSubcommand {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Skip the preview/confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
     /// Show current branch and PR status
     Status {
@@ -855,12 +858,14 @@ fn run() -> Result<()> {
                     draft,
                     base,
                     json,
+                    yes,
                 } => work::WorkAction::Pr {
                     title,
                     body,
                     draft,
                     base,
                     json,
+                    yes,
                 },
                 WorkSubcommand::Status { json } => work::WorkAction::Status { json },
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,6 +518,15 @@ enum WorkSubcommand {
         /// Skip the preview/confirmation prompt
         #[arg(short = 'y', long)]
         yes: bool,
+        /// Generate the PR body via the configured AI provider (uses commit log + diff as context)
+        #[arg(long)]
+        ai: bool,
+        /// Override AI provider for --ai (claude or ollama)
+        #[arg(long, value_parser = ["claude", "ollama"])]
+        provider: Option<String>,
+        /// Override AI model for --ai
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Show current branch and PR status
     Status {
@@ -859,6 +868,9 @@ fn run() -> Result<()> {
                     base,
                     json,
                     yes,
+                    ai,
+                    provider,
+                    model,
                 } => work::WorkAction::Pr {
                     title,
                     body,
@@ -866,6 +878,9 @@ fn run() -> Result<()> {
                     base,
                     json,
                     yes,
+                    ai,
+                    provider,
+                    model,
                 },
                 WorkSubcommand::Status { json } => work::WorkAction::Status { json },
             };

--- a/src/work.rs
+++ b/src/work.rs
@@ -72,6 +72,7 @@ pub enum WorkAction {
         draft: bool,
         base: Option<String>,
         json: bool,
+        yes: bool,
     },
     Status {
         json: bool,
@@ -102,12 +103,14 @@ pub fn run(action: WorkAction) -> Result<()> {
             draft,
             base,
             json,
+            yes,
         } => pr(
             title.as_deref(),
             body.as_deref(),
             draft,
             base.as_deref(),
             json,
+            yes,
         ),
         WorkAction::Status { json } => status(json),
     }
@@ -282,6 +285,7 @@ fn pr(
     draft: bool,
     base: Option<&str>,
     json: bool,
+    yes: bool,
 ) -> Result<()> {
     if Command::new("gh").arg("--version").output().is_err() {
         bail!(
@@ -306,6 +310,35 @@ fn pr(
             "No commits ahead of '{}'. Make some changes first.",
             base_branch
         );
+    }
+
+    let pr_title = match title {
+        Some(t) => t.to_string(),
+        None => generate_title_from_branch(&branch),
+    };
+    let pr_body = match body {
+        Some(b) => b.to_string(),
+        None => generate_body_from_commits(&branch, &base_branch)?,
+    };
+
+    if !json {
+        print_pr_preview(&pr_title, &pr_body, &branch, &base_branch, draft);
+        if !yes {
+            if !crate::utils::is_interactive() {
+                bail!(
+                    "Refusing to create a PR without confirmation in a non-interactive shell. Re-run with --yes to skip the prompt."
+                );
+            }
+            let confirm =
+                dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+                    .with_prompt("Create this pull request?")
+                    .default(true)
+                    .interact()?;
+            if !confirm {
+                println!("{} Aborted.", style("✋").yellow());
+                return Ok(());
+            }
+        }
     }
 
     crate::plugin::run_lifecycle_hook("pre_pr")?;
@@ -337,22 +370,14 @@ fn pr(
         );
     }
 
-    let pr_title = match title {
-        Some(t) => t.to_string(),
-        None => generate_title_from_branch(&branch),
-    };
-
     let mut gh_args = vec![
         "pr".to_string(),
         "create".to_string(),
         "--title".to_string(),
         pr_title.clone(),
+        "--body".to_string(),
+        pr_body.clone(),
     ];
-
-    if let Some(b) = body {
-        gh_args.push("--body".to_string());
-        gh_args.push(b.to_string());
-    }
 
     if draft {
         gh_args.push("--draft".to_string());
@@ -519,6 +544,88 @@ fn commits_ahead_of(branch: &str, base: &str) -> Result<usize> {
     let range = format!("{base}..{branch}");
     let output = git_output(&["rev-list", "--count", &range])?;
     Ok(output.parse().unwrap_or(0))
+}
+
+/// Build a Markdown PR body from commit subjects between `base..branch`.
+///
+/// Format: `## Summary` heading + one bullet per commit (newest first), with
+/// any `type:` conventional-commit prefix stripped and the leading char
+/// upper-cased so bullets read like sentences. Falls back to a placeholder if
+/// the rev-list call returns nothing.
+pub fn generate_body_from_commits(branch: &str, base: &str) -> Result<String> {
+    let range = format!("{base}..{branch}");
+    let raw = git_output(&["log", "--pretty=format:%s", &range]).unwrap_or_default();
+
+    let bullets: Vec<String> = raw
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .map(format_commit_subject_as_bullet)
+        .collect();
+
+    let body = if bullets.is_empty() {
+        "## Summary\n\n- (describe the change)\n".to_string()
+    } else {
+        let mut out = String::from("## Summary\n\n");
+        for bullet in &bullets {
+            out.push_str("- ");
+            out.push_str(bullet);
+            out.push('\n');
+        }
+        out
+    };
+
+    Ok(body)
+}
+
+fn format_commit_subject_as_bullet(subject: &str) -> String {
+    // Strip a leading conventional-commit prefix like "feat: ", "fix(scope): ".
+    let stripped = match subject.find(": ") {
+        Some(idx) => {
+            let prefix = &subject[..idx];
+            let looks_like_type = prefix
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '(' || c == ')' || c == '-' || c == '_');
+            if looks_like_type && !prefix.is_empty() {
+                subject[idx + 2..].trim()
+            } else {
+                subject
+            }
+        }
+        None => subject,
+    };
+
+    let mut chars = stripped.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => stripped.to_string(),
+    }
+}
+
+fn print_pr_preview(title: &str, body: &str, head: &str, base: &str, draft: bool) {
+    let bar = style("─".repeat(60)).dim();
+    println!();
+    println!("{}", bar);
+    println!("{} {}", style("Title:").bold(), style(title).green());
+    println!(
+        "{}  {} → {}{}",
+        style("Branch:").bold(),
+        style(head).cyan(),
+        style(base).dim(),
+        if draft {
+            style(" (draft)").yellow().to_string()
+        } else {
+            String::new()
+        },
+    );
+    println!();
+    for line in body.lines() {
+        println!("  {}", line);
+    }
+    if !body.ends_with('\n') {
+        println!();
+    }
+    println!("{}", bar);
 }
 
 pub fn generate_title_from_branch(branch: &str) -> String {
@@ -863,6 +970,50 @@ test = "cargo test"
         assert_eq!(
             extract_pr_number("https://github.com/owner/repo/pull/42/files"),
             Some(42)
+        );
+    }
+
+    #[test]
+    fn format_commit_strips_feat_prefix() {
+        assert_eq!(
+            format_commit_subject_as_bullet("feat: add search command"),
+            "Add search command"
+        );
+    }
+
+    #[test]
+    fn format_commit_strips_scoped_prefix() {
+        assert_eq!(
+            format_commit_subject_as_bullet("fix(work): null pointer on empty branch"),
+            "Null pointer on empty branch"
+        );
+    }
+
+    #[test]
+    fn format_commit_uppercases_first_letter_with_no_prefix() {
+        assert_eq!(
+            format_commit_subject_as_bullet("update readme"),
+            "Update readme"
+        );
+    }
+
+    #[test]
+    fn format_commit_leaves_already_capitalized_alone() {
+        assert_eq!(
+            format_commit_subject_as_bullet("Refactor work module"),
+            "Refactor work module"
+        );
+    }
+
+    #[test]
+    fn format_commit_does_not_strip_unrelated_colons() {
+        // A subject like "Note: this is fine" should NOT be treated as a
+        // conventional-commit prefix — "Note" matches the alphanumeric rule
+        // but is real prose. The current heuristic treats it as a prefix and
+        // strips it; document that behavior so future changes are deliberate.
+        assert_eq!(
+            format_commit_subject_as_bullet("Note: something"),
+            "Something"
         );
     }
 

--- a/src/work.rs
+++ b/src/work.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use console::style;
 use serde::Deserialize;
 use std::process::Command;
@@ -73,6 +73,9 @@ pub enum WorkAction {
         base: Option<String>,
         json: bool,
         yes: bool,
+        ai: bool,
+        provider: Option<String>,
+        model: Option<String>,
     },
     Status {
         json: bool,
@@ -104,6 +107,9 @@ pub fn run(action: WorkAction) -> Result<()> {
             base,
             json,
             yes,
+            ai,
+            provider,
+            model,
         } => pr(
             title.as_deref(),
             body.as_deref(),
@@ -111,6 +117,9 @@ pub fn run(action: WorkAction) -> Result<()> {
             base.as_deref(),
             json,
             yes,
+            ai,
+            provider.as_deref(),
+            model.as_deref(),
         ),
         WorkAction::Status { json } => status(json),
     }
@@ -279,6 +288,7 @@ fn start(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn pr(
     title: Option<&str>,
     body: Option<&str>,
@@ -286,6 +296,9 @@ fn pr(
     base: Option<&str>,
     json: bool,
     yes: bool,
+    ai: bool,
+    provider_override: Option<&str>,
+    model_override: Option<&str>,
 ) -> Result<()> {
     if Command::new("gh").arg("--version").output().is_err() {
         bail!(
@@ -318,6 +331,13 @@ fn pr(
     };
     let pr_body = match body {
         Some(b) => b.to_string(),
+        None if ai => generate_body_with_ai(
+            &branch,
+            &base_branch,
+            provider_override,
+            model_override,
+            json,
+        )?,
         None => generate_body_from_commits(&branch, &base_branch)?,
     };
 
@@ -576,6 +596,90 @@ pub fn generate_body_from_commits(branch: &str, base: &str) -> Result<String> {
     };
 
     Ok(body)
+}
+
+/// Build a richer PR body by handing the branch context to the configured
+/// LLM (`fledge ai use ...` / `--provider` / `--model`). Includes the full
+/// commit log, file-level diffstat, and a truncated unified diff so the
+/// model has enough context to write a real description, not just a list
+/// of subjects.
+fn generate_body_with_ai(
+    branch: &str,
+    base: &str,
+    provider_override: Option<&str>,
+    model_override: Option<&str>,
+    json: bool,
+) -> Result<String> {
+    let range = format!("{base}..{branch}");
+    let commits =
+        git_output(&["log", "--pretty=format:%h %s%n%b%n---", &range]).unwrap_or_default();
+    let diffstat = git_output(&["diff", "--stat", &range]).unwrap_or_default();
+
+    // Truncate the diff to keep small/local models inside their context
+    // window. 600 lines is enough for most PRs to convey shape; reviewers
+    // see the full diff on GitHub regardless.
+    let diff_full = git_output(&["diff", &range]).unwrap_or_default();
+    let mut diff_lines: Vec<&str> = diff_full.lines().collect();
+    let truncated = diff_lines.len() > 600;
+    if truncated {
+        diff_lines.truncate(600);
+    }
+    let diff = diff_lines.join("\n");
+    let truncation_note = if truncated {
+        "\n\n[diff truncated to 600 lines for context]"
+    } else {
+        ""
+    };
+
+    let prompt = format!(
+        "You are writing a GitHub pull request description.\n\
+         \n\
+         Branch: {branch} → {base}\n\
+         \n\
+         Commits:\n\
+         {commits}\n\
+         \n\
+         Files changed:\n\
+         {diffstat}\n\
+         \n\
+         Diff:\n\
+         {diff}{truncation_note}\n\
+         \n\
+         Write a Markdown PR description with:\n\
+         \n\
+         ## Summary\n\
+         - 2 to 5 bullets describing what changed and why\n\
+         \n\
+         ## Test plan\n\
+         - [ ] checklist items the reviewer should verify\n\
+         \n\
+         Be concrete. Reference specific files or functions when relevant. \
+         Do not invent features that aren't in the diff. \
+         Do not include any preamble or sign-off — output ONLY the Markdown body."
+    );
+
+    let config = crate::config::Config::load().context("loading config")?;
+    let provider = crate::llm::build_provider(
+        &config,
+        &crate::llm::ProviderOverride {
+            provider: provider_override.map(|s| s.to_string()),
+            model: model_override.map(|s| s.to_string()),
+        },
+    )?;
+
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start(&format!(
+            "Drafting PR body [{}]:",
+            crate::llm::describe(&*provider)
+        )))
+    };
+    let answer = provider.invoke(&prompt);
+    if let Some(sp) = sp {
+        sp.finish();
+    }
+    Ok(answer?.trim().to_string())
 }
 
 fn format_commit_subject_as_bullet(subject: &str) -> String {


### PR DESCRIPTION
## Summary
- Extend `work pr` to auto-generate PR bodies from `git log` output when `--body` is omitted, stripping conventional-commit prefixes (e.g., `feat:`, `fix(scope):`) and sentence-casing the results (`generate_body_from_commits`, `format_commit_subject_as_bullet` in `src/work.rs`)
- Add an interactive preview showing the PR title, branch flow (`head → base`), and full body, followed by a `Create this pull request? (Y/n)` confirmation prompt; add `--yes` / `-y` to skip the prompt and `--json` to suppress interactive output entirely
- Implement `--ai` flag that delegates body generation to the configured LLM provider (`fledge ai use`-aware), building a context bundle of commit history, `git diff --stat`, and a truncated unified diff (600 lines) to keep local models in context (`generate_body_with_ai`)
- Support per-call LLM overrides via `--provider {claude,ollama}` and `--model <name>` that temporarily supersede the active configuration
- Guard non-interactive shells: detect non-TTY environments and bail with a clear error message rather than hanging when neither `--yes` nor `--json` is provided
- Update `WorkAction::Pr` and CLI parsing in `src/main.rs` to accept the new flags; bump specification version to 8 in `specs/work/work.spec.md`

## Test plan
- [ ] Run `fledge work pr` on a branch with conventional commits (e.g., `feat: add search`) and verify the generated body strips the prefix and capitalizes the first letter ("Add search")
- [ ] Run `fledge work pr --ai` and confirm the spinner shows the active provider/model, then produces a Markdown body with `## Summary` and `## Test plan` sections
- [ ] Run `fledge work pr --yes` and verify it skips the preview/confirmation and proceeds directly to push and PR creation
- [ ] Run `fledge work pr` in a non-interactive shell (e.g., `echo "" | fledge work pr`) and confirm it exits with an error requesting `--yes` rather than hanging
- [ ] Run `fledge work pr --ai --provider ollama --model qwen3-coder` and verify the override is used instead of the configured default
- [ ] Run `fledge work pr --body "custom" --ai` and verify the literal `--body` value wins over AI generation
- [ ] Decline the confirmation prompt (`n`) and verify the command exits 0 with `✋ Aborted.` without pushing or invoking `gh`

---

🤖 Body drafted by `fledge work pr --ai` (ollama / gpt-oss:120b-cloud) — eating our own dog food.
