### PR TITLE
feat: fledge plugins update --defaults

### DIFF
--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 9
+version: 10
 status: active
 files:
   - src/plugin.rs
@@ -157,6 +157,7 @@ pinned_ref = "v0.2.0"
 10. `--json` outputs structured data for all list/search operations
 11. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15: `fledge-plugin-{github,deps,metrics,templates-remote,doctor}` — the plugins that took over commands removed from core in the tight-core refactor
 12. The `--defaults` install loop reports per-plugin success/failure and continues on error so a single bad repo doesn't block the rest. Exits non-zero if any plugin failed; the trailing summary lists each failure with its error message
+13. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
 
 ## Behavioral Examples
 
@@ -275,6 +276,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 10 | 2026-04-25 | Add `fledge plugins update --defaults` — symmetric with install. Updates only the installed plugins from `DEFAULT_PLUGINS`, leaving community plugins alone. Mutually exclusive with a positional plugin name. |
 | 9 | 2026-04-25 | Add `fledge plugins install --defaults` for one-command bulk install of the curated `DEFAULT_PLUGINS` set. Source positional becomes optional when --defaults is used. Per-plugin failures don't abort the bulk install. |
 | 8 | 2026-04-23 | Add trust tiers (official/community/unverified) and `audit` subcommand; trust tier shown in list, install, and JSON output |
 | 7 | 2026-04-22 | Add `create` and `validate` subcommands; `publish` now validates before pushing |

--- a/src/main.rs
+++ b/src/main.rs
@@ -621,6 +621,9 @@ enum PluginSubcommand {
     Update {
         /// Plugin name (omit to update all)
         name: Option<String>,
+        /// Update only fledge's curated default plugins (skip community plugins)
+        #[arg(long, conflicts_with = "name")]
+        defaults: bool,
     },
     /// List installed plugins
     List,
@@ -924,7 +927,9 @@ fn run() -> Result<()> {
                     defaults,
                 },
                 PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },
-                PluginSubcommand::Update { name } => plugin::PluginAction::Update { name },
+                PluginSubcommand::Update { name, defaults } => {
+                    plugin::PluginAction::Update { name, defaults }
+                }
                 PluginSubcommand::List => plugin::PluginAction::List,
                 PluginSubcommand::Audit => plugin::PluginAction::Audit,
                 PluginSubcommand::Search {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -108,6 +108,8 @@ pub enum PluginAction {
     },
     Update {
         name: Option<String>,
+        /// Update only the curated set of default plugins (DEFAULT_PLUGINS) — skip community plugins
+        defaults: bool,
     },
     List,
     Audit,
@@ -148,7 +150,7 @@ pub fn run(opts: PluginOptions) -> Result<()> {
             defaults,
         } => install_action(source.as_deref(), force, defaults),
         PluginAction::Remove { name } => remove_plugin(&name),
-        PluginAction::Update { name } => update_plugins(name.as_deref()),
+        PluginAction::Update { name, defaults } => update_plugins(name.as_deref(), defaults),
         PluginAction::List => list_plugins(opts.json),
         PluginAction::Audit => audit_plugins(opts.json),
         PluginAction::Search {
@@ -733,24 +735,62 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn update_plugins(name: Option<&str>) -> Result<()> {
+fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
+    if defaults && name.is_some() {
+        bail!("--defaults updates the curated set; do not pass a plugin name alongside it.");
+    }
     let registry = load_registry()?;
 
-    let targets: Vec<&PluginEntry> = match name {
-        Some(n) => {
-            let entry = registry
-                .plugins
-                .iter()
-                .find(|p| p.name == n || p.name == format!("fledge-{n}"))
-                .ok_or_else(|| anyhow::anyhow!("Plugin '{n}' is not installed."))?;
-            vec![entry]
+    let targets: Vec<&PluginEntry> = if defaults {
+        // Match each installed plugin's source against the DEFAULT_PLUGINS
+        // list. Stored sources use either the shorthand `owner/repo` form
+        // (the install-time input) or the normalized URL — accept both.
+        // Plugins from the curated set get updated; every community plugin
+        // (figma, weather, e2e, ...) is left alone.
+        let is_default = |source: &str| -> bool {
+            DEFAULT_PLUGINS.iter().any(|d| {
+                source == *d
+                    || source == normalize_source(d)
+                    || source.trim_end_matches(".git").ends_with(d)
+            })
+        };
+        let matched: Vec<&PluginEntry> = registry
+            .plugins
+            .iter()
+            .filter(|p| is_default(&p.source))
+            .collect();
+        if matched.is_empty() {
+            println!(
+                "{} No default plugins are installed. Run {} first.",
+                style("*").cyan().bold(),
+                style("fledge plugins install --defaults").cyan()
+            );
+            return Ok(());
         }
-        None => {
-            if registry.plugins.is_empty() {
-                println!("{} No plugins installed.", style("*").cyan().bold());
-                return Ok(());
+        println!(
+            "{} Updating {} of {} default plugins...",
+            style("*").cyan().bold(),
+            matched.len(),
+            DEFAULT_PLUGINS.len()
+        );
+        matched
+    } else {
+        match name {
+            Some(n) => {
+                let entry = registry
+                    .plugins
+                    .iter()
+                    .find(|p| p.name == n || p.name == format!("fledge-{n}"))
+                    .ok_or_else(|| anyhow::anyhow!("Plugin '{n}' is not installed."))?;
+                vec![entry]
             }
-            registry.plugins.iter().collect()
+            None => {
+                if registry.plugins.is_empty() {
+                    println!("{} No plugins installed.", style("*").cyan().bold());
+                    return Ok(());
+                }
+                registry.plugins.iter().collect()
+            }
         }
     };
 
@@ -1869,6 +1909,37 @@ mod tests {
     fn install_action_requires_source_or_defaults() {
         let err = install_action(None, false, false).unwrap_err().to_string();
         assert!(err.contains("--defaults"));
+    }
+
+    #[test]
+    fn update_plugins_rejects_name_with_defaults() {
+        let err = update_plugins(Some("foo"), true).unwrap_err().to_string();
+        assert!(err.contains("--defaults"));
+    }
+
+    #[test]
+    fn default_source_match_recognizes_shorthand() {
+        // The matcher used by `update_plugins(.., defaults=true)` must
+        // recognize stored sources in any of three forms: bare shorthand,
+        // normalized URL, or URL without `.git`. This duplicates the
+        // closure in `update_plugins` to test the matching logic in
+        // isolation — keep the two in sync.
+        let is_default = |source: &str| -> bool {
+            DEFAULT_PLUGINS.iter().any(|d| {
+                source == *d
+                    || source == normalize_source(d)
+                    || source.trim_end_matches(".git").ends_with(d)
+            })
+        };
+        assert!(is_default("CorvidLabs/fledge-plugin-github"));
+        assert!(is_default(
+            "https://github.com/CorvidLabs/fledge-plugin-github.git"
+        ));
+        assert!(is_default(
+            "https://github.com/CorvidLabs/fledge-plugin-github"
+        ));
+        assert!(!is_default("CorvidLabs/fledge-plugin-figma"));
+        assert!(!is_default("someone/random-plugin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Introduced a `--defaults` flag for `fledge plugins update` (see `src/main.rs` and the new `defaults` field in `PluginSubcommand::Update`) to symmetrically update only the curated `DEFAULT_PLUGINS` set.
- Enforced mutual exclusion between `--defaults` and a positional plugin name via Clap (`conflicts_with = "name"`) and a runtime guard in `src/plugin.rs::update_plugins`, which now bails with an error if both are supplied.
- Added logic to match installed plugins against `DEFAULT_PLUGINS` by source string, accepting the shorthand (`owner/repo`), the normalized URL, or the URL without the trailing `.git`. Community plugins are left untouched, and a helpful suggestion is printed when no defaults are installed.
- Bumped the specification version to **10** and documented the new command and its behavior in `specs/plugin/plugin.spec.md`.
- Added two new unit tests in `src/plugin.rs` covering the mutual‑exclusion guard and the source‑shape matching logic.

## Test plan
- [ ] Run `fledge plugins update --defaults` in a fresh environment with all default plugins installed and verify that each default plugin is updated and the console output matches the example (`✅ fledge-plugin‑github → v0.1.0`, etc.).
- [ ] Execute `fledge plugins update foo --defaults` and confirm the command fails with an error containing `--defaults`.
- [ ] Remove all default plugins, run `fledge plugins update --defaults`, and check that the suggestion `fledge plugins install --defaults` is printed and the command exits with status 0.
- [ ] Run `fledge plugins update <plugin-name>` for a non‑default plugin and ensure the original update path (single‑plugin update) still works unchanged.
- [ ] Run the full test suite (`cargo test`) and verify that the new tests `update_plugins_rejects_name_with_defaults` and `default_source_match_recognizes_shorthand` pass.