### PR TITLE
release: prep v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.15.1] - 2026-04-25
+
+**Patch release — symmetric `update --defaults`.**
+
+### Added
+
+- **`fledge plugins update --defaults`** (#257) — symmetric with the v0.15 `install --defaults` flag. Updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, leaving community plugins untouched. Source matching is tolerant of all three forms a plugin's stored `source` can take: `owner/repo` shorthand, normalized URL, and URL without `.git`. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0.
+
+### Spec bumps
+
+- `plugin` v9 → v10
+
 ## [v0.15.0] - 2026-04-24
 
 **The tight-core release.** v0.15 keeps the load-bearing pillars — templates, lanes, plugins, spec-sync, AI (ask/review/multi-model), work, run, release — and removes everything else from the core binary. The signature is now: *one Rust binary, six pillars, spec-driven by default*. Anything ecosystem-specific or platform-specific (GitHub clients, language toolchain probes, lockfile parsers, vanity metrics) belongs in plugins where it can evolve independently and not bloat the binary for users who don't need it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."


### PR DESCRIPTION
## Summary
- Bumped the crate version from **0.15.0** to **0.15.1** in `Cargo.toml` to reflect the new patch release.  
- Added a comprehensive changelog entry for **v0.15.1** in `CHANGELOG.md`, documenting the new symmetric `fledge plugins update --defaults` command and the spec bump (`plugin` v9 → v10).  
- Introduced the `update --defaults` flag (symmetrical to `install --defaults`) which updates only the installed plugins that belong to the curated `DEFAULT_PLUGINS` set, handling all three possible source formats (shorthand `owner/repo`, normalized URL, URL without `.git`). When none of the defaults are installed, the command now suggests `fledge plugins install --defaults` and exits with status 0.

## Test plan
- [ ] Verify that `cargo build` succeeds and the package version reported by `fledge --version` matches **0.15.1**.  
- [ ] Run `fledge plugins update --defaults` with a mix of installed default and community plugins; confirm that only default plugins are updated and community plugins remain untouched.  
- [ ] Test source matching by installing a default plugin using each of the three source notations and then running the update command; ensure the plugin is correctly identified and updated in all cases.  
- [ ] Execute the update command when no default plugins are installed; check that the CLI prints a suggestion to run `fledge plugins install --defaults` and exits with code 0.  
- [ ] Confirm that the new changelog section appears correctly in `CHANGELOG.md` and follows the existing formatting.  
- [ ] Ensure the spec bump (`plugin` v9 → v10) is reflected in the generated documentation/help output for the updated command.