### PR TITLE
fix: sync flake.nix + Homebrew formula with current version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Dev-lifecycle CLI — scaffolding, task running, code review, and the full dev loop from init to changelog. Built in Rust with clap for CLI parsing, Tera for template rendering.
 
+Six pillars: **scaffold** (templates), **run** (run/lanes/watch), **spec** (spec), **AI** (ai/ask/review), **ship** (work/release/changelog), **extend** (plugins/config/introspect/completions/doctor). Anything outside that surface — GitHub-specific commands, polyglot dep audits, code metrics, deeper toolchain probes — lives in plugins (`CorvidLabs/fledge-plugin-*`), installed via `fledge plugins install --defaults`. See `AGENTS.md` for the agent-facing tour.
+
 ## Build & Test
 
 ```bash
@@ -13,40 +15,54 @@ cargo fmt --check
 
 ## Architecture
 
+### Core CLI surface
 - `src/main.rs` — CLI entry point (clap derive)
-- `src/init.rs` — Project initialization logic
-- `src/templates.rs` — Template loading and Tera rendering
-- `src/config.rs` — Global config (~/.config/fledge/config.toml)
-- `src/prompts.rs` — Interactive prompts (dialoguer)
+- `src/init.rs` — Project initialization
 - `src/run.rs` — Task runner (fledge.toml, language detection)
+- `src/lanes.rs` — Composable workflow pipelines
+- `src/watch.rs` — File watcher / re-run on change
+- `src/work.rs` — Work branch and PR workflow
+- `src/release.rs` — Release workflow (bump, changelog, tag, push)
 - `src/changelog.rs` — Changelog generation from git tags
-- `src/checks.rs` — CI/CD status viewer
 - `src/spec.rs` — Spec-sync management
-- `src/work.rs` — Work branch and PR workflow (flexible branch types, configurable format)
-- `src/issues.rs` — GitHub issues
-- `src/prs.rs` — GitHub pull requests
 - `src/review.rs` — AI-powered code review
 - `src/ask.rs` — AI-powered codebase Q&A
-- `src/search.rs` — Template discovery via GitHub
-- `src/publish.rs` — Template publishing to GitHub
-- `src/release.rs` — Release workflow (bump, changelog, tag, push)
-- `src/update.rs` — Template re-application
-- `src/create_template.rs` — Template scaffolding
-- `src/versioning.rs` — Version management
-- `src/github.rs` — Shared GitHub API helpers
-- `src/remote.rs` — Remote template fetching and caching
-- `src/lanes.rs` — Composable workflow pipelines
-- `src/deps.rs` — Cross-language dependency health checker
-- `src/metrics.rs` — Code metrics (LOC, churn, test ratio)
-- `src/plugin.rs` — Plugin system for community extensions
-- `src/validate.rs` — Template validation
+- `src/ai.rs` — General-purpose AI assistant subcommand
 - `src/doctor.rs` — Environment diagnostics
+- `src/introspect.rs` — JSON command-tree dump (for agents/automation)
+
+### Templates
+- `src/templates.rs` — Template loading and Tera rendering
+- `src/create_template.rs` — Template scaffolding
+- `src/validate.rs` — Template validation
+- `src/publish.rs` — Template publishing to GitHub
+- `src/search.rs` — Template discovery via GitHub
+- `src/remote.rs` — Remote template fetching and caching
+
+### Plugins & shared infra
+- `src/plugin.rs` — Plugin install/list/run; lifecycle hooks
+- `src/protocol.rs` — fledge-v1 plugin protocol (long-running plugins)
+- `src/trust.rs` — Plugin trust-tier classification
+- `src/config.rs` — Global config (~/.config/fledge/config.toml)
+- `src/prompts.rs` — Interactive prompts (dialoguer)
+- `src/spinner.rs` — Terminal spinner UI
+- `src/llm.rs` — LLM backend selection
+- `src/github.rs` — Shared GitHub API helpers
+- `src/versioning.rs` — Version parsing/comparison
+- `src/meta.rs` — Project metadata used by introspect
+- `src/utils.rs` — Shared utilities (e.g. non-interactive flag)
+
+### Other directories
 - `specs/` — spec-sync specifications (source of truth)
-- `templates/` — Built-in project templates
+- `templates/` — Built-in project templates (embedded via `include_dir!`)
 - `docs/` — mdBook documentation site
+- `Formula/` — Homebrew formula
+- `flake.nix` — Nix flake
+- `install.sh` — Curl-pipe installer
 
 ## Conventions
 
 - Specs are the source of truth — read before modifying code
 - Run `cargo run -- spec check` before committing
 - No direct commits to main — use feature branches
+- Releases bump `Cargo.toml`, `flake.nix`, and `Formula/fledge.rb` together (see `[release].files` in `fledge.toml`)

--- a/Formula/fledge.rb
+++ b/Formula/fledge.rb
@@ -2,12 +2,12 @@ class Fledge < Formula
   desc "Corvid-themed project scaffolding CLI — get your projects ready to fly"
   homepage "https://github.com/CorvidLabs/fledge"
   license "MIT"
-  version "0.9.0"
+  version "0.15.1"
 
   on_macos do
     on_arm do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-aarch64"
-      sha256 "PLACEHOLDER"
+      sha256 "3895500e0d49d32a5ff0ff027a594ef1fa98fc93731e7c5e612fd72760e1e394"
 
       def install
         bin.install "fledge-macos-aarch64" => "fledge"
@@ -16,7 +16,7 @@ class Fledge < Formula
 
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-x86_64"
-      sha256 "PLACEHOLDER"
+      sha256 "8b2ccd29a84073d4397daa871a76a6284236992ba0add53dee4b71529f5efaba"
 
       def install
         bin.install "fledge-macos-x86_64" => "fledge"
@@ -27,7 +27,7 @@ class Fledge < Formula
   on_linux do
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-linux-x86_64"
-      sha256 "PLACEHOLDER"
+      sha256 "2c51c2ccbb33250133bc97a36329a5173bd832868c81faa6bab7a4c8eaf31120"
 
       def install
         bin.install "fledge-linux-x86_64" => "fledge"

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "0.9.1";
+          version = "0.15.1";
           src = self;
 
           cargoLock = {

--- a/fledge.toml
+++ b/fledge.toml
@@ -53,3 +53,9 @@ steps = ["lint", "fmt", "test", "audit"]
 [lanes.ci-fast]
 description = "CI with parallel static checks (faster on multi-core)"
 steps = [{ parallel = ["fmt", "lint"] }, "test", "build"]
+
+[release]
+# Extra files whose `version "X.Y.Z"` lines should be bumped alongside Cargo.toml.
+# `flake.nix` matches the existing release.rs regex; `Formula/fledge.rb` is
+# handled by a Formula-specific bumper in release.rs (see bump_homebrew_formula).
+files = ["flake.nix", "Formula/fledge.rb"]

--- a/src/release.rs
+++ b/src/release.rs
@@ -420,10 +420,9 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
                                     )
                                     .unwrap();
                                     // Homebrew DSL uses `version "X.Y.Z"` with no `=`.
-                                    let homebrew_re = Regex::new(
-                                        r#"(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")"#,
-                                    )
-                                    .unwrap();
+                                    let homebrew_re =
+                                        Regex::new(r#"(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")"#)
+                                            .unwrap();
                                     let updated = if standard_re.is_match(&content) {
                                         Some(
                                             standard_re
@@ -436,15 +435,10 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
                                         // time. Reset to PLACEHOLDER so whoever cuts the
                                         // release notices and fills them in.
                                         let bumped_version = homebrew_re
-                                            .replace(
-                                                &content,
-                                                format!("${{1}}{new_str}${{3}}"),
-                                            )
+                                            .replace(&content, format!("${{1}}{new_str}${{3}}"))
                                             .into_owned();
-                                        let sha_re = Regex::new(
-                                            r#"sha256\s+"[0-9a-fA-F]{64}""#,
-                                        )
-                                        .unwrap();
+                                        let sha_re =
+                                            Regex::new(r#"sha256\s+"[0-9a-fA-F]{64}""#).unwrap();
                                         Some(
                                             sha_re
                                                 .replace_all(

--- a/src/release.rs
+++ b/src/release.rs
@@ -415,14 +415,49 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
                                     bail!("Release file '{}' escapes project directory", file_name);
                                 }
                                 if let Ok(content) = std::fs::read_to_string(&path) {
-                                    let re = Regex::new(
+                                    let standard_re = Regex::new(
                                         r#"(?m)(version\s*[=:]\s*["']?)(\d+\.\d+\.\d+)"#,
                                     )
                                     .unwrap();
-                                    if re.is_match(&content) {
-                                        let updated =
-                                            re.replace(&content, format!("${{1}}{new_str}"));
-                                        std::fs::write(&path, updated.as_bytes())?;
+                                    // Homebrew DSL uses `version "X.Y.Z"` with no `=`.
+                                    let homebrew_re = Regex::new(
+                                        r#"(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")"#,
+                                    )
+                                    .unwrap();
+                                    let updated = if standard_re.is_match(&content) {
+                                        Some(
+                                            standard_re
+                                                .replace(&content, format!("${{1}}{new_str}"))
+                                                .into_owned(),
+                                        )
+                                    } else if homebrew_re.is_match(&content) {
+                                        // Bumping a Homebrew formula invalidates its sha256s
+                                        // — the new version's binaries don't exist at bump
+                                        // time. Reset to PLACEHOLDER so whoever cuts the
+                                        // release notices and fills them in.
+                                        let bumped_version = homebrew_re
+                                            .replace(
+                                                &content,
+                                                format!("${{1}}{new_str}${{3}}"),
+                                            )
+                                            .into_owned();
+                                        let sha_re = Regex::new(
+                                            r#"sha256\s+"[0-9a-fA-F]{64}""#,
+                                        )
+                                        .unwrap();
+                                        Some(
+                                            sha_re
+                                                .replace_all(
+                                                    &bumped_version,
+                                                    "sha256 \"PLACEHOLDER\"",
+                                                )
+                                                .into_owned(),
+                                        )
+                                    } else {
+                                        None
+                                    };
+                                    if let Some(new_content) = updated {
+                                        std::fs::write(&path, new_content.as_bytes())?;
                                         bumped.push(file_name.to_string());
                                     }
                                 }
@@ -922,6 +957,61 @@ edition = "2021"
         let new_ver = parse_version("0.4.0").unwrap();
         let result = bump_version_files(tmp.path(), &new_ver).unwrap();
         assert!(result.files_bumped.contains(&"pyproject.toml".to_string()));
+    }
+
+    #[test]
+    fn bump_release_files_flake_nix() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(
+            tmp.path(),
+            "Cargo.toml",
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        );
+        commit_file(
+            tmp.path(),
+            "flake.nix",
+            "{ pname = \"x\"; version = \"0.1.0\"; }\n",
+        );
+        commit_file(
+            tmp.path(),
+            "fledge.toml",
+            "[release]\nfiles = [\"flake.nix\"]\n",
+        );
+        let new_ver = parse_version("0.2.0").unwrap();
+        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
+        assert!(result.files_bumped.contains(&"flake.nix".to_string()));
+        let content = fs::read_to_string(tmp.path().join("flake.nix")).unwrap();
+        assert!(content.contains("version = \"0.2.0\""));
+    }
+
+    #[test]
+    fn bump_release_files_homebrew_formula() {
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(tmp.path());
+        commit_file(
+            tmp.path(),
+            "Cargo.toml",
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+        );
+        fs::create_dir_all(tmp.path().join("Formula")).unwrap();
+        let formula = "class T < Formula\n  version \"0.1.0\"\n  sha256 \
+            \"3895500e0d49d32a5ff0ff027a594ef1fa98fc93731e7c5e612fd72760e1e394\"\nend\n";
+        commit_file(tmp.path(), "Formula/t.rb", formula);
+        commit_file(
+            tmp.path(),
+            "fledge.toml",
+            "[release]\nfiles = [\"Formula/t.rb\"]\n",
+        );
+        let new_ver = parse_version("0.2.0").unwrap();
+        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
+        assert!(result.files_bumped.contains(&"Formula/t.rb".to_string()));
+        let content = fs::read_to_string(tmp.path().join("Formula/t.rb")).unwrap();
+        assert!(content.contains("version \"0.2.0\""));
+        // Real shas should be reset to PLACEHOLDER on bump — they'll be wrong
+        // for the new release until updated post-build.
+        assert!(content.contains("sha256 \"PLACEHOLDER\""));
+        assert!(!content.contains("3895500e0d49d32a"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bump `flake.nix` from `0.9.1` → `0.15.1` to match `Cargo.toml`
- Bump `Formula/fledge.rb` from `0.9.0` → `0.15.1` and replace `sha256 "PLACEHOLDER"` with real hashes from the v0.15.1 release artifacts (the formula has never actually installed since it was added)
- Wire both files into release auto-bump via `[release].files` in `fledge.toml`
- Add Homebrew-specific bumper in `src/release.rs` that handles the `version "X"` DSL syntax and resets `sha256` lines to `PLACEHOLDER` on bump (the new version's shas don't exist at bump time)
- Refresh `CLAUDE.md`'s `src/` list — drop six post-v0.15-deleted files (`checks.rs`, `deps.rs`, `metrics.rs`, `issues.rs`, `prs.rs`, `update.rs`), add nine real ones

## Test plan

- [x] `cargo test` (664 passed, 1 ignored)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `cargo run -- spec check` (29 specs, 0 errors)
- [x] New tests `bump_release_files_flake_nix` and `bump_release_files_homebrew_formula` cover the regex split and the sha-reset behavior
- [ ] Manually verify `brew install --build-from-source ./Formula/fledge.rb` works (real shas now in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)