### PR TITLE
feat: re-absorb templates-remote and doctor plugins into core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ If you are about to run `npm`, `cargo`, `make`, `git checkout -b`, or `gh pr cre
 
 ```bash
 export FLEDGE_NON_INTERACTIVE=1               # silence every prompt
-fledge plugins install --defaults             # curated plugin set: github, deps, metrics, templates-remote, doctor
+fledge plugins install --defaults             # curated plugin set: github, deps, metrics
 fledge introspect --json                       # dump the full command tree (incl. plugin commands)
 fledge spec list --json                        # orient to the codebase via specs
 ```
@@ -75,10 +75,8 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge prs --json` / `fledge prs view <n> --json` | `fledge-plugin-github` | GitHub PRs — list or one |
 | `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, …) |
 | `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` | LOC summary (tokei), per-file churn, test/source ratio |
-| `fledge templates-search --json` / `templates-publish` | `fledge-plugin-templates-remote` | GitHub registry of fledge templates |
-| `fledge doctor-tools --json` | `fledge-plugin-doctor` | Array of `{tool, group, status, version}` for installed toolchains |
 
-Commands **without** `--json` (pretty output only): `init`, `spec init`, `spec new`, `run`, `templates publish` (plugin), `templates create`, `watch`, `release`, `ai use`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
+Commands **without** `--json` (pretty output only): `init`, `spec init`, `spec new`, `run`, `templates publish`, `templates create`, `watch`, `release`, `ai use`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
 
 ## Non-interactive mode (the one-switch answer)
 
@@ -102,7 +100,7 @@ When non-interactive mode is active, every command that would otherwise prompt b
 | `fledge plugins publish` | Skip confirmations |
 | `fledge plugins create` | Skip scaffolding prompts |
 | `fledge lane publish` | Skip description prompt |
-| `fledge templates-publish` (plugin) | Skip the confirmation prompt |
+| `fledge templates publish` | Skip the confirmation prompt |
 
 Prompts that have **no sensible default** (e.g. `fledge ai use` being asked to pick a provider when none was specified) fail fast with a clear error naming the flag to pass instead. No silent hangs.
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ fledge plugins install --defaults
 | [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) | `checks`, `issues`, `prs` | the GitHub-specific browsing trio |
 | [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) | `deps` | polyglot lockfile audits |
 | [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics` | LOC/churn/test-ratio (now via `tokei` + `git`) |
-| [`fledge-plugin-templates-remote`](https://github.com/CorvidLabs/fledge-plugin-templates-remote) | `templates-search`, `templates-publish` | GitHub template registry |
-| [`fledge-plugin-doctor`](https://github.com/CorvidLabs/fledge-plugin-doctor) | `doctor-tools` | toolchain probes (rust/node/python/swift/...) |
 
-Why split them out? Because not every fledge user is on GitHub, runs a polyglot project, or cares about LOC counts. The core stays tight; you opt in to what you need.
+Why split them out? Because not every fledge user is on GitHub or runs a polyglot project. The core stays tight; you opt in to what you need.
+
+(`fledge-plugin-templates-remote` and `fledge-plugin-doctor` were dropped from the default set in v0.15.2 and re-absorbed into core: `fledge templates search`/`publish` and the `Toolchains` section of `fledge doctor`. The standalone plugin repos still exist but are no longer part of `--defaults`.)
 
 ## Built-in Templates
 

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -1,13 +1,12 @@
 ---
 module: doctor
-version: 4
+version: 6
 status: active
 files:
   - src/doctor.rs
 
 db_tables: []
 depends_on:
-  - run
   - config
   - llm
 ---
@@ -16,7 +15,7 @@ depends_on:
 
 ## Purpose
 
-Diagnoses project environment health by checking toolchain availability, dependency state, and git configuration. Provides actionable fix suggestions for each failing check.
+Diagnoses fledge's own environment health: validates that fledge config loads, git is configured, the AI provider is reachable, and (informationally) which language toolchains are present. Provides actionable fix suggestions for failing checks.
 
 ## Public API
 
@@ -33,6 +32,7 @@ Diagnoses project environment health by checking toolchain availability, depende
 |------|-------------|
 | `DoctorOptions` | CLI options: `json` |
 | `DoctorReport` | Serializable report with all check results |
+| `Section` | A named group of checks; `informational` sections are excluded from pass/fail totals |
 | `CheckResult` | Individual check: name, status, version, fix suggestion |
 | `CheckStatus` | Enum: `Ok`, `Missing`, `Error` |
 
@@ -42,47 +42,62 @@ Diagnoses project environment health by checking toolchain availability, depende
 |----------|-----------|-------------|
 | `run` | `(DoctorOptions) -> Result<()>` | Main entry — run checks, print report |
 
+## Sections
+
+The report has four sections, in this order:
+
+| Section | Informational? | What it checks |
+|---------|---------------|---------------|
+| `fledge` | no | `fledge config` loads cleanly |
+| `Git` | no | `git` installed; repository initialized; remote configured; working tree clean |
+| `AI` | no | Claude CLI present; Ollama binary present; the active provider's reachability (probes Ollama's `/api/tags` when active) |
+| `Toolchains` | **yes** | Probes for rust (rustc/cargo), node (node/npm/pnpm/bun/yarn), python (python3/uv/poetry), go, ruby, swift, and JVM (java/gradle/mvn) |
+
 ## Invariants
 
-1. Project type is detected via `run::detect_project_type`
-2. Toolchain checks verify required tools exist and capture their version strings
-3. Dependency state checks verify lock files and install directories exist
-4. Git checks verify git is installed, repo is initialized, and remote is configured
-5. AI checks verify Claude CLI is installed and report availability of AI commands (fledge review, fledge ask); when Ollama is the active provider, the displayed `model` honors the same `FLEDGE_AI_MODEL` env override that `build_provider` uses, so doctor's report matches what `ask` / `review` will actually send
-6. Each failing check includes an actionable fix command
-7. `--json` outputs a structured `DoctorReport`
-8. Exit summary shows count of passed checks and issues found
-9. Tool version is extracted by running `<tool> --version` and parsing first version-like string
-10. Supported project types: rust, node, go, python, ruby, java-gradle, java-maven, swift, generic
+1. The `fledge`, `Git`, and `AI` sections contribute to the passed/failed totals; the `Toolchains` section does not (`section.informational == true` excludes it from counting and renders missing tools dimmed rather than as failures, since not every project uses every language).
+2. Toolchain probes capture the tool's version string when present; missing tools render as `· <name> (not installed)` and carry no fix hint (environmental, not project errors).
+3. AI checks verify Claude CLI is installed and Ollama (when configured as active) is reachable; when Ollama is the active provider the displayed `model` honors the `FLEDGE_AI_MODEL` env override so doctor's report matches what `ask` / `review` will actually send.
+4. Each failing check in a non-informational section includes an actionable fix command.
+5. `--json` outputs a structured `DoctorReport` with all sections (informational sections still appear in the JSON, with `informational: true`).
+6. Exit summary shows count of passed checks and issues found, computed only over non-informational sections.
+7. Tool version is extracted by running `<tool> --version` (or `version` for `go`, `-version` for `java`) and parsing the first version-like token, stripping `v` and `go` prefixes.
+8. The `check_tool` helper enforces a 10-second per-probe timeout to keep `fledge doctor` fast even when a hung binary is in `PATH`.
 
 ## Behavioral Examples
 
 ```
 $ fledge doctor
 
-  Toolchain
-    ✓ rustc 1.78.0
-    ✓ cargo 1.78.0
-    ✗ cargo-clippy — not found
-      → rustup component add clippy
-
-  Dependencies
-    ✓ Cargo.lock found
-    ✓ target/ exists
+  fledge
+    ✅ fledge config 0.15.1 — loaded
 
   Git
-    ✓ git 2.44.0
-    ✓ remote: origin → https://github.com/...
-    ✗ uncommitted changes (3 files)
+    ✅ git 2.50.1
+    ✅ repository — initialized
+    ✅ remote — origin ➡️ git@github.com:CorvidLabs/fledge.git
+    ✅ working tree — clean
 
   AI
-    ✓ claude 1.x.x
-    ✓ AI commands — fledge review, fledge ask available
+    ✅ claude 2.1.119
+    ✅ ollama 0.21.2
+    ✅ Active provider: ollama — ollama is the active provider (model: gpt-oss:120b-cloud, host: http://localhost:11434)
 
-  3 checks passed, 2 issues found
+  Toolchains
+    ✅ rustc 1.93.0
+    ✅ cargo 1.93.0
+    ✅ node 25.5.0
+    ✅ bun 1.3.12
+    · pnpm (not installed)
+    · yarn (not installed)
+    ✅ python3 3.14.3
+    ✅ swift 6.3
+    · go (not installed)
+
+  7 checks passed, 0 issues found
 
 $ fledge doctor --json
-{ "project_type": "rust", "sections": [...], "passed": 3, "failed": 2 }
+{ "sections": [...], "passed": 7, "failed": 0 }
 ```
 
 ## Error Cases
@@ -90,10 +105,10 @@ $ fledge doctor --json
 | Error | When | Behavior |
 |-------|------|----------|
 | Cannot detect cwd | Current dir inaccessible | anyhow error |
+| Tool probe times out | `<tool> --version` hangs more than 10s | Killed; reported as `Error` with `timed out after 10s` |
 
 ## Dependencies
 
-- `run::detect_project_type` for ecosystem detection
 - `std::process::Command` for running tool version checks
 - `config` module — reads `ai.provider` and `ai.ollama.host` to determine the active LLM provider
 - `llm` module — `resolve_provider_kind` for active-provider selection, `ProviderKind` for display
@@ -105,7 +120,9 @@ $ fledge doctor --json
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 4 | 2026-04-24 | Active-Ollama display honors `FLEDGE_AI_MODEL` env override (previously only `OLLAMA_HOST` was honored), so doctor's reported model matches what `build_provider` will actually use |
-| 3 | 2026-04-23 | AI section now reports both Claude CLI and Ollama binary presence, the active provider (from config / env), and probes the Ollama host's `/api/tags` endpoint for reachability so "daemon down" vs "not installed" are distinguishable |
+| 6 | 2026-04-25 | Re-absorbed `fledge-plugin-doctor` toolchain probes into core as a new informational `Toolchains` section. Missing toolchain entries render dimmed and don't pollute the pass/fail totals because environmental availability isn't a project error. Plugin dropped from `DEFAULT_PLUGINS`. |
+| 5 | 2026-04-25 | v0.15 tight-core: stripped `Project Type`, `Toolchain`, and `Dependencies` sections. Self-check only: fledge config, git, AI provider. Toolchain probes deferred to `fledge-plugin-doctor`. |
+| 4 | 2026-04-24 | Active-Ollama display honors `FLEDGE_AI_MODEL` env override (previously only `OLLAMA_HOST` was honored) |
+| 3 | 2026-04-23 | AI section reports both Claude CLI and Ollama binary presence, the active provider (from config / env), and probes the Ollama host's `/api/tags` endpoint for reachability |
 | 2 | 2026-04-21 | Add swift to supported project types |
 | 1 | 2026-04-20 | Initial spec |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 10
+version: 11
 status: active
 files:
   - src/plugin.rs
@@ -155,7 +155,7 @@ pinned_ref = "v0.2.0"
 9. `plugin search` uses GitHub topic search (same as template search)
 9. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
 10. `--json` outputs structured data for all list/search operations
-11. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15: `fledge-plugin-{github,deps,metrics,templates-remote,doctor}` — the plugins that took over commands removed from core in the tight-core refactor
+11. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15.2: `fledge-plugin-{github,deps,metrics}`. The earlier set also included `templates-remote` (re-absorbed into core `templates search`/`publish`) and `doctor` (re-absorbed into core `doctor` as the informational `Toolchains` section)
 12. The `--defaults` install loop reports per-plugin success/failure and continues on error so a single bad repo doesn't block the rest. Exits non-zero if any plugin failed; the trailing summary lists each failure with its error message
 13. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
 
@@ -276,6 +276,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 11 | 2026-04-25 | Trim `DEFAULT_PLUGINS` from 5 entries to 3. `fledge-plugin-templates-remote` was duplicating the in-tree `search.rs`/`publish.rs` helpers in shell — re-absorbed into core (`fledge templates search`/`publish`). `fledge-plugin-doctor` was 110 LOC of shell parallel to core doctor — re-absorbed as the informational `Toolchains` section. Default set is now `{github, deps, metrics}`. |
 | 10 | 2026-04-25 | Add `fledge plugins update --defaults` — symmetric with install. Updates only the installed plugins from `DEFAULT_PLUGINS`, leaving community plugins alone. Mutually exclusive with a positional plugin name. |
 | 9 | 2026-04-25 | Add `fledge plugins install --defaults` for one-command bulk install of the curated `DEFAULT_PLUGINS` set. Source positional becomes optional when --defaults is used. Per-plugin failures don't abort the bulk install. |
 | 8 | 2026-04-23 | Add trust tiers (official/community/unverified) and `audit` subcommand; trust tier shown in list, install, and JSON output |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -29,6 +29,8 @@ Plugin system for community extensions. Plugins are external executables that re
 | `DEFAULT_PLUGINS` | Curated list of plugin sources installed by `fledge plugins install --defaults` |
 | `PluginOptions` | Options for the plugin subcommand |
 | `PluginAction` | Enum of plugin operations: Install, Remove, Update, List, Search, Run, Publish, Create, Validate, Audit |
+| `PluginEntry` | Installed plugin record (name, source, version, installed date, commands, pinned_ref) |
+| `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 
 ### Structs & Enums
 

--- a/specs/publish/publish.spec.md
+++ b/specs/publish/publish.spec.md
@@ -1,6 +1,6 @@
 ---
 module: publish
-version: 3
+version: 4
 status: active
 files:
   - src/publish.rs
@@ -14,7 +14,7 @@ depends_on:
 
 ## Purpose
 
-Shared GitHub-publishing helpers used by `lanes publish` and `plugins publish`: authenticate to GitHub, create or check a repo, set topics, and push a directory. As of v0.15 this module is a *library* — the user-facing `templates publish` command moved out to `fledge-plugin-templates-remote`, so the publish module no longer exposes a `run`/`PublishOptions` entry point or `validate_template`. Other modules consume the lower-level helpers directly.
+Shared GitHub-publishing helpers used by `templates publish`, `lanes publish`, and `plugins publish`: authenticate to GitHub, create or check a repo, set topics, and push a directory. The module is a library of helpers — there is no `run`/`PublishOptions` entry point; each caller drives the flow itself with the topic and validation that suit it.
 
 ## Public API
 
@@ -46,7 +46,7 @@ Shared GitHub-publishing helpers used by `lanes publish` and `plugins publish`: 
 2. `create_github_repo` returns a clear error message for the common failure modes — 422 (name conflict / invalid name), 403 (insufficient scope) — so callers don't have to interpret raw HTTP codes
 3. `push_directory` uses an in-memory `http.extraheader` env-injection trick to avoid embedding the token in the persisted git remote; the remote is reset to a clean URL after the push
 4. `set_repo_topic` is additive — it merges the new topic into the existing topic set rather than replacing the whole list
-5. Caller modules (`lanes publish`, `plugins publish`, `fledge-plugin-templates-remote`) are responsible for the user-facing concerns: validating template/lane/plugin manifests, prompting for confirmation, formatting output
+5. Caller modules (`templates publish`, `lanes publish`, `plugins publish`) are responsible for the user-facing concerns: validating template/lane/plugin manifests, prompting for confirmation, formatting output
 
 ## Behavioral Examples
 
@@ -93,6 +93,7 @@ set_repo_topic("CorvidLabs", "my-template", "fledge-template", token)?;
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 3 | 2026-04-25 | v0.15 tight-core: removed the `run` / `PublishOptions` / `validate_template` / `set_repo_topics` exports. The user-facing `templates publish` command now lives in `fledge-plugin-templates-remote`; this module is a library of shared helpers for the remaining in-core publish callers (`lanes publish`, `plugins publish`). |
+| 4 | 2026-04-25 | `templates publish` re-absorbed into core (`main.rs::publish_template`); `fledge-plugin-templates-remote` was duplicating these helpers in shell and is dropped from `DEFAULT_PLUGINS`. Module remains a library of helpers consumed by `templates publish`, `lanes publish`, and `plugins publish`. |
+| 3 | 2026-04-25 | v0.15 tight-core: removed the `run` / `PublishOptions` / `validate_template` / `set_repo_topics` exports. The user-facing `templates publish` command lived in `fledge-plugin-templates-remote` then. |
 | 2 | 2026-04-22 | Updated exports for plugin/lane publish support; document newly-public helpers |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/search/search.spec.md
+++ b/specs/search/search.spec.md
@@ -1,6 +1,6 @@
 ---
 module: search
-version: 2
+version: 3
 status: active
 files:
   - src/search.rs
@@ -13,9 +13,9 @@ depends_on: []
 
 ## Purpose
 
-Library helpers for GitHub topic-based discovery. As of v0.15 this module is *internal* — the user-facing `templates search` command moved out to `fledge-plugin-templates-remote`. The remaining helpers are still consumed by `lanes search` (lane discovery), `plugins search` (plugin discovery), and `github_api_get` (URL encoding).
+Library helpers for GitHub topic-based discovery. Consumed by `templates search` (template discovery), `lanes search` (lane discovery), `plugins search` (plugin discovery), and `github_api_get` (URL encoding).
 
-The split is intentional: discovering "GitHub repos tagged with topic X" is a generic mechanism, but each consumer (templates, lanes, plugins) wires it to a different topic and renders results differently. Keeping the mechanism here as a library and the user-facing surfaces in their respective callers means a future GitLab-search backend can swap this module out without touching the callers.
+The split is intentional: discovering "GitHub repos tagged with topic X" is a generic mechanism, but each consumer wires it to a different topic and renders results differently. Keeping the mechanism here as a library and the user-facing surfaces in their respective callers means a future GitLab-search backend can swap this module out without touching the callers.
 
 ## Public API
 
@@ -98,6 +98,7 @@ urlencod("topic:fledge-template")  // "topic%3Afledge-template"
 
 | Module | What is used |
 |--------|-------------|
+| `main` | `build_search_query_ex`, `parse_search_response`, `format_stars` for `fledge templates search` |
 | `lanes` | `build_search_query_ex`, `parse_search_response`, `format_stars` for `fledge lanes search` |
 | `plugin` | `build_search_query_ex` for `fledge plugins search` |
 | `github` | `urlencod` for `github_api_get` query parameters |
@@ -106,5 +107,6 @@ urlencod("topic:fledge-template")  // "topic%3Afledge-template"
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 2 | 2026-04-25 | v0.15 tight-core: removed `run`, `SearchOptions`, and `search_github_ex` — the user-facing `templates search` command lives in `fledge-plugin-templates-remote` now. This module is a library of query/parse helpers consumed by `lanes`, `plugins`, and `github`. |
+| 3 | 2026-04-25 | `templates search` re-absorbed into core (`main.rs::search_templates`); the `fledge-plugin-templates-remote` plugin was redundant with the existing helpers and is dropped from `DEFAULT_PLUGINS`. Module remains a library of query/parse helpers consumed by `main`, `lanes`, `plugins`, and `github`. |
+| 2 | 2026-04-25 | v0.15 tight-core: removed `run`, `SearchOptions`, and `search_github_ex` — the user-facing `templates search` command lived in `fledge-plugin-templates-remote` then. |
 | 1 | 2026-04-19 | Initial spec |

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -20,6 +20,11 @@ struct DoctorReport {
 struct Section {
     name: String,
     checks: Vec<CheckResult>,
+    /// Sections like `toolchains` are informational — missing entries are not
+    /// project errors (a Python project doesn't fail because Swift is absent).
+    /// Informational sections are excluded from the passed/failed totals.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    informational: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -31,7 +36,7 @@ struct CheckResult {
     fix: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 enum CheckStatus {
     Ok,
@@ -42,15 +47,22 @@ enum CheckStatus {
 pub fn run(opts: DoctorOptions) -> Result<()> {
     let project_dir = std::env::current_dir().context("getting current directory")?;
 
-    let sections = vec![check_fledge_self(), check_git(&project_dir), check_ai()];
+    let sections = vec![
+        check_fledge_self(),
+        check_git(&project_dir),
+        check_ai(),
+        check_toolchains(),
+    ];
 
     let passed: usize = sections
         .iter()
+        .filter(|s| !s.informational)
         .flat_map(|s| &s.checks)
         .filter(|c| c.status == CheckStatus::Ok)
         .count();
     let failed: usize = sections
         .iter()
+        .filter(|s| !s.informational)
         .flat_map(|s| &s.checks)
         .filter(|c| c.status != CheckStatus::Ok)
         .count();
@@ -82,6 +94,14 @@ pub fn run(opts: DoctorOptions) -> Result<()> {
                     };
                     println!("    {} {}", style("✅").green().bold(), label);
                 }
+                CheckStatus::Missing if section.informational => {
+                    println!(
+                        "    {} {} {}",
+                        style("·").dim(),
+                        style(&check.name).dim(),
+                        style("(not installed)").dim(),
+                    );
+                }
                 CheckStatus::Missing => {
                     let detail = check.detail.as_deref().unwrap_or("not found");
                     println!(
@@ -96,12 +116,12 @@ pub fn run(opts: DoctorOptions) -> Result<()> {
                 }
                 CheckStatus::Error => {
                     let detail = check.detail.as_deref().unwrap_or("error");
-                    println!(
-                        "    {} {} — {}",
-                        style("❌").red().bold(),
-                        check.name,
-                        detail
-                    );
+                    let symbol = if section.informational {
+                        style("·").dim()
+                    } else {
+                        style("❌").red().bold()
+                    };
+                    println!("    {} {} — {}", symbol, check.name, detail);
                     if let Some(fix) = &check.fix {
                         println!("      {} {}", style("➡️").dim(), style(fix).cyan());
                     }
@@ -229,10 +249,9 @@ fn extract_version(text: &str) -> Option<String> {
     })
 }
 
-/// Self-check: things only fledge knows about its own state. Replaces the
-/// pre-v0.15 toolchain probes (rust/node/python/swift/...) which are slated
-/// to move to dedicated `fledge-plugin-doctor-*` plugins. Keep this small —
-/// the test is "would removing this hide a real fledge problem?"
+/// Self-check: things only fledge knows about its own state. Keep this
+/// small — the test is "would removing this hide a real fledge problem?"
+/// (Toolchain probes live in `check_toolchains` as an informational section.)
 fn check_fledge_self() -> Section {
     let mut checks = Vec::new();
 
@@ -256,6 +275,7 @@ fn check_fledge_self() -> Section {
     Section {
         name: "fledge".to_string(),
         checks,
+        informational: false,
     }
 }
 
@@ -357,6 +377,7 @@ fn check_git(dir: &Path) -> Section {
     Section {
         name: "Git".to_string(),
         checks,
+        informational: false,
     }
 }
 
@@ -398,12 +419,13 @@ fn check_ai() -> Section {
             return Section {
                 name: "AI".to_string(),
                 checks,
+                informational: false,
             };
         }
     };
 
     let active_status = match active {
-        crate::llm::ProviderKind::Claude => claude.status.clone(),
+        crate::llm::ProviderKind::Claude => claude.status,
         crate::llm::ProviderKind::Ollama => {
             // Ollama can be a remote endpoint; the CLI check above doesn't tell
             // us whether the configured host responds. Probe `/api/tags`.
@@ -473,6 +495,64 @@ fn check_ai() -> Section {
     Section {
         name: "AI".to_string(),
         checks,
+        informational: false,
+    }
+}
+
+/// Toolchain probes — informational. Missing tools don't fail the report
+/// because not every project uses every language. Replaces the v0.15
+/// `fledge-plugin-doctor` shell-based probe set, re-absorbed into core.
+fn check_toolchains() -> Section {
+    let probes: &[(&str, &[&str])] = &[
+        // Rust
+        ("rustc", &["--version"]),
+        ("cargo", &["--version"]),
+        // Node.js ecosystem
+        ("node", &["--version"]),
+        ("npm", &["--version"]),
+        ("pnpm", &["--version"]),
+        ("bun", &["--version"]),
+        ("yarn", &["--version"]),
+        // Python
+        ("python3", &["--version"]),
+        ("uv", &["--version"]),
+        ("poetry", &["--version"]),
+        // Go
+        ("go", &["version"]),
+        // Ruby
+        ("ruby", &["--version"]),
+        // Swift
+        ("swift", &["--version"]),
+        // JVM
+        ("java", &["-version"]),
+        ("gradle", &["--version"]),
+        ("mvn", &["--version"]),
+    ];
+
+    let checks = probes
+        .iter()
+        .map(|(name, args)| {
+            let result = check_tool(name, args, "");
+            // Strip the fix hint and rewrite the missing detail to read as
+            // info, not failure — this section is environmental.
+            let detail = match result.status {
+                CheckStatus::Missing => Some("not installed".to_string()),
+                _ => result.detail,
+            };
+            CheckResult {
+                name: result.name,
+                status: result.status,
+                version: result.version,
+                detail,
+                fix: None,
+            }
+        })
+        .collect();
+
+    Section {
+        name: "Toolchains".to_string(),
+        checks,
+        informational: true,
     }
 }
 
@@ -568,6 +648,7 @@ mod tests {
                     detail: None,
                     fix: None,
                 }],
+                informational: false,
             }],
             passed: 1,
             failed: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1157,7 +1157,12 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
         TemplatesSubcommand::List => {
             list_templates()?;
         }
-        TemplatesSubcommand::Search { query, author, limit, json } => {
+        TemplatesSubcommand::Search {
+            query,
+            author,
+            limit,
+            json,
+        } => {
             search_templates(query.as_deref(), author.as_deref(), limit, json)?;
         }
         TemplatesSubcommand::Publish {
@@ -1420,7 +1425,9 @@ fn search_templates(
             println!(
                 "{} No community templates found{}.",
                 style("*").cyan().bold(),
-                query.map(|q| format!(" matching '{q}'")).unwrap_or_default()
+                query
+                    .map(|q| format!(" matching '{q}'"))
+                    .unwrap_or_default()
             );
         }
         return Ok(());
@@ -1447,7 +1454,11 @@ fn search_templates(
     }
 
     println!("{}\n", style("Community templates on GitHub:").bold());
-    let max_name = results.iter().map(|r| r.full_name().len()).max().unwrap_or(0);
+    let max_name = results
+        .iter()
+        .map(|r| r.full_name().len())
+        .max()
+        .unwrap_or(0);
     for r in &results {
         let tier = trust::determine_trust_tier_from_owner(&r.owner);
         let stars = search::format_stars(r.stars);
@@ -1532,13 +1543,14 @@ fn publish_template(
     if repo_exists {
         if !yes {
             utils::require_interactive("yes")?;
-            let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
-                .with_prompt(format!(
-                    "Repository {}/{} already exists. Push update?",
-                    owner, repo_name
-                ))
-                .default(false)
-                .interact()?;
+            let confirm =
+                dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+                    .with_prompt(format!(
+                        "Repository {}/{} already exists. Push update?",
+                        owner, repo_name
+                    ))
+                    .default(false)
+                    .interact()?;
             if !confirm {
                 println!("{} Cancelled.", style("*").cyan().bold());
                 return Ok(());
@@ -1573,7 +1585,11 @@ fn publish_template(
     println!(
         "\n{} Published! Use with:\n\n  {}",
         style("✅").green().bold(),
-        style(format!("fledge templates init --template {}/{}", owner, repo_name)).cyan()
+        style(format!(
+            "fledge templates init --template {}/{}",
+            owner, repo_name
+        ))
+        .cyan()
     );
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ enum Commands {
         #[command(subcommand)]
         action: SpecSubcommand,
     },
-    /// Manage templates (init, create, validate, list)
+    /// Manage templates (init, create, validate, list, search, publish)
     #[command(alias = "template")]
     Templates {
         #[command(subcommand)]
@@ -334,6 +334,38 @@ enum TemplatesSubcommand {
     },
     /// List available templates
     List,
+    /// Search GitHub for community templates (fledge-template topic)
+    Search {
+        /// Keyword to filter results
+        query: Option<String>,
+        /// Filter by author/owner
+        #[arg(short, long)]
+        author: Option<String>,
+        /// Maximum number of results
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Publish a template directory to GitHub
+    Publish {
+        /// Path to the template directory
+        #[arg(default_value = ".")]
+        path: PathBuf,
+        /// Publish under a GitHub organization
+        #[arg(long)]
+        org: Option<String>,
+        /// Create as a private repository
+        #[arg(long)]
+        private: bool,
+        /// Override the repository description
+        #[arg(long)]
+        description: Option<String>,
+        /// Skip all confirmation prompts
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]
@@ -1125,6 +1157,18 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
         TemplatesSubcommand::List => {
             list_templates()?;
         }
+        TemplatesSubcommand::Search { query, author, limit, json } => {
+            search_templates(query.as_deref(), author.as_deref(), limit, json)?;
+        }
+        TemplatesSubcommand::Publish {
+            path,
+            org,
+            private,
+            description,
+            yes,
+        } => {
+            publish_template(&path, org.as_deref(), private, description.as_deref(), yes)?;
+        }
     }
     Ok(())
 }
@@ -1341,6 +1385,196 @@ fn list_templates() -> Result<()> {
             style(&t.description).dim()
         );
     }
+
+    Ok(())
+}
+
+fn search_templates(
+    query: Option<&str>,
+    author: Option<&str>,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
+    use anyhow::Context as _;
+    let config = config::Config::load()?;
+    let token = config.github_token();
+    let q = search::build_search_query_ex(query, author, "fledge-template");
+    let per_page = limit.clamp(1, 100).to_string();
+
+    let sp = spinner::Spinner::start("Searching GitHub for community templates:");
+    let body = github::github_api_get(
+        "/search/repositories",
+        token.as_deref(),
+        &[("q", &q), ("sort", "stars"), ("per_page", &per_page)],
+    )
+    .context("searching GitHub for template repos")?;
+    sp.finish();
+
+    let mut results = search::parse_search_response(&body)?;
+    results.truncate(limit);
+
+    if results.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!(
+                "{} No community templates found{}.",
+                style("*").cyan().bold(),
+                query.map(|q| format!(" matching '{q}'")).unwrap_or_default()
+            );
+        }
+        return Ok(());
+    }
+
+    if json {
+        let entries: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                let tier = trust::determine_trust_tier_from_owner(&r.owner);
+                serde_json::json!({
+                    "owner": r.owner,
+                    "name": r.name,
+                    "description": r.description,
+                    "stars": r.stars,
+                    "url": r.url,
+                    "topics": r.topics,
+                    "trust_tier": tier.label(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    println!("{}\n", style("Community templates on GitHub:").bold());
+    let max_name = results.iter().map(|r| r.full_name().len()).max().unwrap_or(0);
+    for r in &results {
+        let tier = trust::determine_trust_tier_from_owner(&r.owner);
+        let stars = search::format_stars(r.stars);
+        let desc = if r.description.chars().count() > 60 {
+            let truncated: String = r.description.chars().take(57).collect();
+            format!("{truncated}...")
+        } else {
+            r.description.clone()
+        };
+        let topic_str = if r.topics.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", r.topics.join(", "))
+        };
+        println!(
+            "  {:<width$}  [{}]  {}  {}{}",
+            style(&r.full_name()).green(),
+            tier.styled_label(),
+            style(format!("(⭐ {})", stars)).dim(),
+            style(&desc).dim(),
+            style(&topic_str).cyan(),
+            width = max_name,
+        );
+    }
+    println!(
+        "\n{}",
+        style("Use with: fledge templates init --template <owner/repo>").dim()
+    );
+    Ok(())
+}
+
+fn publish_template(
+    path: &std::path::Path,
+    org: Option<&str>,
+    private: bool,
+    description: Option<&str>,
+    yes: bool,
+) -> Result<()> {
+    use anyhow::Context as _;
+    let yes = yes || utils::is_non_interactive();
+    let config = config::Config::load()?;
+    let token = config.github_token().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No GitHub token configured. Run: fledge config set github.token <your-token>"
+        )
+    })?;
+
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", path.display()))?;
+
+    // Validate the template before publishing — same gate `fledge templates validate` uses.
+    validate::run(validate::ValidateOptions {
+        path: path.clone(),
+        strict: false,
+        json: false,
+    })?;
+
+    let dir_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("fledge-template");
+    let repo_name = dir_name.to_string();
+    let desc = description.unwrap_or("A fledge template");
+
+    let owner = match org {
+        Some(o) => o.to_string(),
+        None => publish::get_authenticated_user(&token)?,
+    };
+
+    println!(
+        "{} Publishing template as {}/{}",
+        style("➡️").cyan().bold(),
+        style(&owner).green(),
+        style(&repo_name).green()
+    );
+
+    let sp = spinner::Spinner::start("Checking repository:");
+    let repo_exists = publish::check_repo_exists(&owner, &repo_name, &token)?;
+    sp.finish();
+
+    if repo_exists {
+        if !yes {
+            utils::require_interactive("yes")?;
+            let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+                .with_prompt(format!(
+                    "Repository {}/{} already exists. Push update?",
+                    owner, repo_name
+                ))
+                .default(false)
+                .interact()?;
+            if !confirm {
+                println!("{} Cancelled.", style("*").cyan().bold());
+                return Ok(());
+            }
+        }
+    } else {
+        let sp = spinner::Spinner::start("Creating repository:");
+        publish::create_github_repo(&repo_name, desc, private, org, &token)?;
+        sp.finish();
+        println!(
+            "  {} Created repository {}/{}",
+            style("✅").green().bold(),
+            owner,
+            repo_name
+        );
+    }
+
+    let sp = spinner::Spinner::start("Setting repository topics:");
+    publish::set_repo_topic(&owner, &repo_name, "fledge-template", &token)?;
+    sp.finish();
+    println!(
+        "  {} Set {} topic",
+        style("✅").green().bold(),
+        style("fledge-template").cyan()
+    );
+
+    let sp = spinner::Spinner::start("Pushing template files:");
+    publish::push_directory(&path, &owner, &repo_name, &token)?;
+    sp.finish();
+    println!("  {} Pushed template files", style("✅").green().bold());
+
+    println!(
+        "\n{} Published! Use with:\n\n  {}",
+        style("✅").green().bold(),
+        style(format!("fledge templates init --template {}/{}", owner, repo_name)).cyan()
+    );
 
     Ok(())
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -18,8 +18,6 @@ pub const DEFAULT_PLUGINS: &[&str] = &[
     "CorvidLabs/fledge-plugin-github",
     "CorvidLabs/fledge-plugin-deps",
     "CorvidLabs/fledge-plugin-metrics",
-    "CorvidLabs/fledge-plugin-templates-remote",
-    "CorvidLabs/fledge-plugin-doctor",
 ];
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

Two of the five v0.15 default plugins were doing redundant work:

- **`fledge-plugin-templates-remote`** duplicated `src/search.rs` and `src/publish.rs` in shell. Those modules are still in core (used internally by lanes/plugins). Exposing `fledge templates search/publish` costs ~190 LOC in `main.rs` and removes a whole plugin repo from the default set.
- **`fledge-plugin-doctor`** was 110 lines of shell parallel to core \`fledge doctor\`, registered as the sibling command \`doctor-tools\` with a misleading description claiming to \"extend fledge doctor\". It didn't extend anything. Re-absorbed as an informational \`Toolchains\` section.

## Changes

- **`src/main.rs`** — \`TemplatesSubcommand\` gains \`Search\` and \`Publish\`; inline handlers \`search_templates\`/\`publish_template\` modeled on \`search_lanes\`/\`publish_lanes\`.
- **`src/doctor.rs`** — new \`check_toolchains()\` informational \`Section\`. \`Section.informational: bool\` excludes the section from the passed/failed totals (a Python project shouldn't fail because Swift is absent). Missing entries render dimmed: \`· tool (not installed)\`. \`CheckStatus\` now derives \`Copy\`.
- **`src/plugin.rs`** — \`DEFAULT_PLUGINS\` trimmed from 5 to 3 (now: \`github\`, \`deps\`, \`metrics\`).
- Specs bumped: \`search\` v3, \`publish\` v4, \`doctor\` v6 (full rewrite), \`plugin\` v11.
- \`AGENTS.md\` and \`README.md\` drop the two plugin rows; \`templates-search\` (hyphenated) → \`templates search\` (subcommand).

## Test plan

- [x] \`cargo test\` (664 passed, 1 ignored)
- [x] \`cargo clippy -- -D warnings\` (clean)
- [x] \`cargo run -- spec check\` (29 specs, 0 errors)
- [x] Manual: \`fledge templates --help\` shows \`search\` and \`publish\`
- [x] Manual: \`fledge doctor\` shows the new \`Toolchains\` section with dimmed missing entries
- [ ] After merge: archive \`fledge-plugin-templates-remote\` and \`fledge-plugin-doctor\` repos with deprecation README pointing to the core commands

## Stacking

Stacks on #259 (distribution sync — no logical dependency, but \`flake.nix\`/\`Formula\`/\`CLAUDE.md\` overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)