### PR TITLE
release: prep v0.15.2

### DIFF
--- a/.github/workflows/post-release-formula.yml
+++ b/.github/workflows/post-release-formula.yml
@@ -1,0 +1,107 @@
+name: Post-Release Formula Update
+
+# Runs after the Release workflow finishes uploading binaries + their .sha256
+# sidecars. Pulls the real shas, rewrites Formula/fledge.rb with the new
+# version + shas, and opens a PR. This is the only correct moment to bump the
+# formula — at `fledge release` time the new version's binaries don't exist
+# yet, so any pre-build sha would be a lie.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  update-formula:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          # workflow_run.head_branch is the tag name (e.g. "v0.15.2") for tag-triggered runs.
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          if [ -z "$TAG" ] || [[ "$TAG" != v* ]]; then
+            echo "::error::Could not resolve release tag from workflow_run event (got '$TAG')"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch sha256 sidecars from release
+        id: shas
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          fetch() {
+            gh release download "$TAG" -p "$1.sha256" -R "${{ github.repository }}" -O - \
+              | awk '{print $1}'
+          }
+          {
+            echo "macos_aarch64=$(fetch fledge-macos-aarch64)"
+            echo "macos_x86_64=$(fetch fledge-macos-x86_64)"
+            echo "linux_x86_64=$(fetch fledge-linux-x86_64)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Rewrite Formula/fledge.rb
+        env:
+          NEW_VERSION: ${{ steps.tag.outputs.version }}
+          MACOS_AARCH64: ${{ steps.shas.outputs.macos_aarch64 }}
+          MACOS_X86_64: ${{ steps.shas.outputs.macos_x86_64 }}
+          LINUX_X86_64: ${{ steps.shas.outputs.linux_x86_64 }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, re, sys, pathlib
+          p = pathlib.Path("Formula/fledge.rb")
+          src = p.read_text()
+          # Bump `version "X.Y.Z"`
+          src = re.sub(r'(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")', rf'\g<1>{os.environ["NEW_VERSION"]}\g<3>', src, count=1)
+          # Replace shas in fixed order: aarch64, x86_64, linux x86_64
+          shas = [
+              os.environ["MACOS_AARCH64"],
+              os.environ["MACOS_X86_64"],
+              os.environ["LINUX_X86_64"],
+          ]
+          parts = re.split(r'(sha256\s+"[0-9a-fA-F]{64}")', src)
+          # parts alternates: text, match, text, match, text, match, text
+          if len(parts) - 1 != 6 or sum(1 for i, _ in enumerate(parts) if i % 2 == 1) != 3:
+              sys.exit(f"Expected 3 sha256 lines in Formula/fledge.rb, found {(len(parts) - 1) // 2}")
+          for i, sha in enumerate(shas):
+              idx = 2 * i + 1
+              parts[idx] = f'sha256 "{sha}"'
+          p.write_text("".join(parts))
+          PY
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.tag.outputs.version }}"
+          BRANCH="formula/v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          if git diff --quiet -- Formula/fledge.rb; then
+            echo "Formula/fledge.rb already at v$VERSION — nothing to do."
+            exit 0
+          fi
+          git add Formula/fledge.rb
+          git commit -m "chore: update Homebrew formula to v$VERSION"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: update Homebrew formula to v$VERSION" \
+            --body "Automated by post-release-formula.yml. Pulls the v$VERSION sha256 sidecars from the release and writes them into \`Formula/fledge.rb\` along with the version bump." \
+            --base main

--- a/.github/workflows/post-release-formula.yml
+++ b/.github/workflows/post-release-formula.yml
@@ -5,6 +5,11 @@ name: Post-Release Formula Update
 # version + shas, and opens a PR. This is the only correct moment to bump the
 # formula — at `fledge release` time the new version's binaries don't exist
 # yet, so any pre-build sha would be a lie.
+#
+# Security note: every value derived from `github.event.workflow_run.*` (or
+# any other potentially attacker-controlled context) flows through an `env:`
+# block before reaching a shell. Direct `${{ … }}` interpolation inside
+# `run: |` is a code-injection sink and is intentionally avoided here.
 
 permissions:
   contents: write
@@ -26,32 +31,50 @@ jobs:
 
       - name: Resolve release tag
         id: tag
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # workflow_run.head_branch is the tag name (e.g. "v0.15.2") for tag-triggered runs.
-          TAG="${{ github.event.workflow_run.head_branch }}"
-          if [ -z "$TAG" ] || [[ "$TAG" != v* ]]; then
-            echo "::error::Could not resolve release tag from workflow_run event (got '$TAG')"
+          set -euo pipefail
+          # HEAD_BRANCH is the tag name (e.g. "v0.15.2") for tag-triggered runs.
+          # Validate strictly so an attacker who pushed a malformed tag can't
+          # smuggle anything downstream. Allow only `v<digits>.<digits>.<digits>`
+          # with optional pre-release/build metadata.
+          if ! [[ "$HEAD_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Refusing to run with non-semver tag '$HEAD_BRANCH'"
             exit 1
           fi
-          VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$HEAD_BRANCH"
+            echo "version=${HEAD_BRANCH#v}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch sha256 sidecars from release
         id: shas
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
           fetch() {
-            gh release download "$TAG" -p "$1.sha256" -R "${{ github.repository }}" -O - \
+            gh release download "$TAG" -p "$1.sha256" -R "$REPO" -O - \
               | awk '{print $1}'
           }
+          # Validate each sha is exactly 64 hex chars before exporting — the
+          # sidecar files are attacker-influenceable (an attacker who
+          # compromises the release pipeline could replace them).
+          validate() {
+            local sha="$1"
+            if ! [[ "$sha" =~ ^[0-9a-fA-F]{64}$ ]]; then
+              echo "::error::Invalid sha256 from sidecar: '$sha'"
+              exit 1
+            fi
+            printf '%s' "$sha"
+          }
           {
-            echo "macos_aarch64=$(fetch fledge-macos-aarch64)"
-            echo "macos_x86_64=$(fetch fledge-macos-x86_64)"
-            echo "linux_x86_64=$(fetch fledge-linux-x86_64)"
+            echo "macos_aarch64=$(validate "$(fetch fledge-macos-aarch64)")"
+            echo "macos_x86_64=$(validate "$(fetch fledge-macos-x86_64)")"
+            echo "linux_x86_64=$(validate "$(fetch fledge-linux-x86_64)")"
           } >> "$GITHUB_OUTPUT"
 
       - name: Rewrite Formula/fledge.rb
@@ -66,42 +89,45 @@ jobs:
           import os, re, sys, pathlib
           p = pathlib.Path("Formula/fledge.rb")
           src = p.read_text()
-          # Bump `version "X.Y.Z"`
-          src = re.sub(r'(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")', rf'\g<1>{os.environ["NEW_VERSION"]}\g<3>', src, count=1)
-          # Replace shas in fixed order: aarch64, x86_64, linux x86_64
+          src = re.sub(
+              r'(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")',
+              rf'\g<1>{os.environ["NEW_VERSION"]}\g<3>',
+              src,
+              count=1,
+          )
           shas = [
               os.environ["MACOS_AARCH64"],
               os.environ["MACOS_X86_64"],
               os.environ["LINUX_X86_64"],
           ]
           parts = re.split(r'(sha256\s+"[0-9a-fA-F]{64}")', src)
-          # parts alternates: text, match, text, match, text, match, text
-          if len(parts) - 1 != 6 or sum(1 for i, _ in enumerate(parts) if i % 2 == 1) != 3:
-              sys.exit(f"Expected 3 sha256 lines in Formula/fledge.rb, found {(len(parts) - 1) // 2}")
+          if len(parts) - 1 != 6:
+              sys.exit(
+                  f"Expected 3 sha256 lines in Formula/fledge.rb, found {(len(parts) - 1) // 2}"
+              )
           for i, sha in enumerate(shas):
-              idx = 2 * i + 1
-              parts[idx] = f'sha256 "{sha}"'
+              parts[2 * i + 1] = f'sha256 "{sha}"'
           p.write_text("".join(parts))
           PY
 
       - name: Open PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.tag.outputs.version }}"
-          BRANCH="formula/v$VERSION"
+          BRANCH="formula/v$NEW_VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           if git diff --quiet -- Formula/fledge.rb; then
-            echo "Formula/fledge.rb already at v$VERSION — nothing to do."
+            echo "Formula/fledge.rb already at v$NEW_VERSION — nothing to do."
             exit 0
           fi
           git add Formula/fledge.rb
-          git commit -m "chore: update Homebrew formula to v$VERSION"
+          git commit -m "chore: update Homebrew formula to v$NEW_VERSION"
           git push -u origin "$BRANCH"
           gh pr create \
-            --title "chore: update Homebrew formula to v$VERSION" \
-            --body "Automated by post-release-formula.yml. Pulls the v$VERSION sha256 sidecars from the release and writes them into \`Formula/fledge.rb\` along with the version bump." \
+            --title "chore: update Homebrew formula to v$NEW_VERSION" \
+            --body "Automated by post-release-formula.yml. Pulls the v$NEW_VERSION sha256 sidecars from the release and writes them into \`Formula/fledge.rb\` along with the version bump." \
             --base main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.15.2] - 2026-04-25
+
+**Default-plugin slim-down + distribution sync.** Two of the v0.15 default plugins (`templates-remote`, `doctor`) were doing redundant work and are now back in core. `DEFAULT_PLUGINS` shrinks from 5 to 3. The Nix flake and Homebrew formula were six versions behind; both are now in sync and wired into the release flow so they stay that way.
+
+### Added
+
+- **`fledge templates search`** and **`fledge templates publish`** — re-absorbed from `fledge-plugin-templates-remote`. Same flags (`--author`, `--limit`, `--json` for search; `--org`, `--private`, `--description`, `--yes` for publish) and identical JSON shapes. The plugin was a shell wrapper around `src/search.rs`/`src/publish.rs` modules that fledge already used internally — re-exposing the templates flavor in core eliminates the duplicate implementation. (#260)
+- **`fledge doctor` Toolchains section** — re-absorbed from `fledge-plugin-doctor`. Probes 16 toolchains across rust/node/python/go/ruby/swift/JVM. Marked **informational**: missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals (a Python project shouldn't fail because Swift is absent). (#260)
+- **`[release].files` Homebrew support** — release auto-bump now handles the Homebrew DSL's `version "X"` syntax (no `=`), and resets `sha256` lines to `PLACEHOLDER` on bump (the new release's shas don't exist at bump time and must be filled in post-build). (#259)
+
+### Changed
+
+- **`DEFAULT_PLUGINS` is now 3 entries**: `github`, `deps`, `metrics`. `fledge plugins install --defaults` no longer pulls `templates-remote` or `doctor` (their commands are in core). Existing users who previously installed the dropped plugins can remove them with `fledge plugins remove`. (#260)
+- **`fledge-plugin-metrics` rewritten in Rust** — links `tokei` as a library (no separate `cargo install tokei`), uses the `ignore` crate for gitignore-aware walking, and emits stable plugin-owned JSON shapes instead of pass-through `tokei --output json`. Auto-detected build via `Cargo.toml`. (CorvidLabs/fledge-plugin-metrics#1)
+- **`fledge.toml` gains `[release].files`** — `flake.nix` and `Formula/fledge.rb` now bump alongside `Cargo.toml` on every release. (#259)
+- **`Section.informational: bool`** added to the doctor report; informational sections appear in `--json` output but are excluded from the passed/failed counts. (#260)
+
+### Fixed
+
+- **Nix flake version**: 0.9.1 → 0.15.1 → 0.15.2. Cosmetic (the lockfile drives the actual build), but the label was misleading. (#259)
+- **Homebrew formula**: 0.9.0 (with `sha256 "PLACEHOLDER"` ×3 — never actually installed since the formula was added) → 0.15.1 with real sha256 hashes pulled from the v0.15.1 release artifacts → 0.15.2. (#259)
+- **`CLAUDE.md` src/ list** refreshed: dropped 6 files removed in the v0.15 tight-core refactor (`checks.rs`, `deps.rs`, `metrics.rs`, `issues.rs`, `prs.rs`, `update.rs`); added 9 real files that were missing (`ai.rs`, `introspect.rs`, `llm.rs`, `meta.rs`, `protocol.rs`, `spinner.rs`, `trust.rs`, `utils.rs`, `watch.rs`). (#259)
+
+### Deprecated
+
+- **`CorvidLabs/fledge-plugin-templates-remote`** and **`CorvidLabs/fledge-plugin-doctor`** are archived. Their READMEs now point at the corresponding core commands. The repos still exist (`fledge plugins install` still works against them) but are no longer maintained.
+
+### Spec bumps
+
+- `search` v3, `publish` v4, `doctor` v6 (full rewrite for the Toolchains section + the informational Section field), `plugin` v11 (DEFAULT_PLUGINS shrink + 2 export rows added to satisfy spec-sync `--strict`).
+
 ## [v0.13.0] - 2026-04-23
 
 **The agent-surface release.** fledge is now designed for humans and AI agents to drive the same CLI. Pick any LLM backend — Claude CLI or Ollama (local, cloud, or self-hosted) — and they all speak the same spec-aware `fledge ask` / `fledge review`. Set `FLEDGE_NON_INTERACTIVE=1` once, get JSON on every read command, and let the AI commands automatically include the right spec context from your repo's design docs. See the new [AGENTS.md](./AGENTS.md) for the one-page guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`fledge templates search`** and **`fledge templates publish`** — re-absorbed from `fledge-plugin-templates-remote`. Same flags (`--author`, `--limit`, `--json` for search; `--org`, `--private`, `--description`, `--yes` for publish) and identical JSON shapes. The plugin was a shell wrapper around `src/search.rs`/`src/publish.rs` modules that fledge already used internally — re-exposing the templates flavor in core eliminates the duplicate implementation. (#260)
 - **`fledge doctor` Toolchains section** — re-absorbed from `fledge-plugin-doctor`. Probes 16 toolchains across rust/node/python/go/ruby/swift/JVM. Marked **informational**: missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals (a Python project shouldn't fail because Swift is absent). (#260)
-- **`[release].files` Homebrew support** — release auto-bump now handles the Homebrew DSL's `version "X"` syntax (no `=`), and resets `sha256` lines to `PLACEHOLDER` on bump (the new release's shas don't exist at bump time and must be filled in post-build). (#259)
+- **Post-release formula workflow** (`.github/workflows/post-release-formula.yml`) — runs after the `Release` workflow finishes uploading binaries + their `.sha256` sidecars. Fetches the real shas, rewrites `Formula/fledge.rb` with the new version + shas, and opens a PR. This is the only correct moment to bump the formula — at `fledge release` time the new version's binaries don't exist yet, so any pre-build sha would be a lie. (#261)
 
 ### Changed
 
 - **`DEFAULT_PLUGINS` is now 3 entries**: `github`, `deps`, `metrics`. `fledge plugins install --defaults` no longer pulls `templates-remote` or `doctor` (their commands are in core). Existing users who previously installed the dropped plugins can remove them with `fledge plugins remove`. (#260)
 - **`fledge-plugin-metrics` rewritten in Rust** — links `tokei` as a library (no separate `cargo install tokei`), uses the `ignore` crate for gitignore-aware walking, and emits stable plugin-owned JSON shapes instead of pass-through `tokei --output json`. Auto-detected build via `Cargo.toml`. (CorvidLabs/fledge-plugin-metrics#1)
-- **`fledge.toml` gains `[release].files`** — `flake.nix` and `Formula/fledge.rb` now bump alongside `Cargo.toml` on every release. (#259)
+- **`fledge.toml` gains `[release].files`** — `flake.nix` now bumps alongside `Cargo.toml` on every release. (`Formula/fledge.rb` is intentionally excluded; see the post-release workflow above.) (#259)
 - **`Section.informational: bool`** added to the doctor report; informational sections appear in `--json` output but are excluded from the passed/failed counts. (#260)
 
 ### Fixed
 
 - **Nix flake version**: 0.9.1 → 0.15.1 → 0.15.2. Cosmetic (the lockfile drives the actual build), but the label was misleading. (#259)
-- **Homebrew formula**: 0.9.0 (with `sha256 "PLACEHOLDER"` ×3 — never actually installed since the formula was added) → 0.15.1 with real sha256 hashes pulled from the v0.15.1 release artifacts → 0.15.2. (#259)
+- **Homebrew formula**: 0.9.0 (with `sha256 "PLACEHOLDER"` ×3 — never actually installed since the formula was added) → 0.15.1 with real sha256 hashes pulled from the v0.15.1 release artifacts. The formula will move to v0.15.2 automatically once the post-release workflow runs against the v0.15.2 tag and opens a PR. (#259, #261)
 - **`CLAUDE.md` src/ list** refreshed: dropped 6 files removed in the v0.15 tight-core refactor (`checks.rs`, `deps.rs`, `metrics.rs`, `issues.rs`, `prs.rs`, `update.rs`); added 9 real files that were missing (`ai.rs`, `introspect.rs`, `llm.rs`, `meta.rs`, `protocol.rs`, `spinner.rs`, `trust.rs`, `utils.rs`, `watch.rs`). (#259)
 
 ### Deprecated
@@ -35,44 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Spec bumps
 
 - `search` v3, `publish` v4, `doctor` v6 (full rewrite for the Toolchains section + the informational Section field), `plugin` v11 (DEFAULT_PLUGINS shrink + 2 export rows added to satisfy spec-sync `--strict`).
-
-## [v0.13.0] - 2026-04-23
-
-**The agent-surface release.** fledge is now designed for humans and AI agents to drive the same CLI. Pick any LLM backend — Claude CLI or Ollama (local, cloud, or self-hosted) — and they all speak the same spec-aware `fledge ask` / `fledge review`. Set `FLEDGE_NON_INTERACTIVE=1` once, get JSON on every read command, and let the AI commands automatically include the right spec context from your repo's design docs. See the new [AGENTS.md](./AGENTS.md) for the one-page guide.
-
-### Added
-
-- **`AGENTS.md`** at the repo root plus `docs/src/agents.md` — canonical one-page guide for AI agents driving fledge, covering the machine-readable surface, non-interactive mode, provider selection, and typical workflows (#242)
-- **LLM provider abstraction + Ollama support** — `fledge ask` and `fledge review` now route through a `LlmProvider` trait. Two implementations ship in core: Claude CLI (default, unchanged) and Ollama. The Ollama provider covers the local daemon, Ollama Cloud / Turbo (with `OLLAMA_API_KEY`), and any self-hosted Ollama-speaking endpoint in one impl. Select via `ai.provider` config, `FLEDGE_AI_PROVIDER` env, or `--provider {claude,ollama}` per invocation. (#250)
-- **`fledge introspect [--json]`** — dumps the full clap command tree (every subcommand, every arg, every alias) as nested JSON or an indented listing. One call teaches an agent the entire CLI (#248)
-- **`fledge spec list [--json]`** (alias `ls`) and **`fledge spec show <name> [--json]`** — enumerate and inspect specs programmatically (#242)
-- **`fledge spec check --json`** — structured validation output with per-spec errors/warnings (#246)
-- **`fledge ask`** is spec-aware by default: every invocation prepends a compact index of the project's specs. New `--with-specs <names>` loads full spec + companion bundles for named modules (`all` supported); `--no-spec-index` for off-topic questions. JSON output gains `provider` and `model` fields. (#244, #250)
-- **`fledge review`** auto-detects relevant specs from the diff's changed-file list (matches each spec's `files:` frontmatter and the `<specs_dir>/<name>/` prefix, honoring custom `specs_dir`). New `--with-specs` to force-include; `--no-auto-specs` to disable. JSON output gains `spec_context`, `provider`, and `model` arrays. (#245, #250)
-- **`fledge work start --json`**, **`fledge work pr --json`**, **`fledge work status --json`** — structured output for scripting branch and PR workflows. `status` distinguishes `behind: null` (base not fetched) from `behind: 0` (up to date) (#246)
-- **Global `--non-interactive` flag** (alias `--ni`) and **`FLEDGE_NON_INTERACTIVE` env var** — one switch that treats every confirmation prompt as `--yes`/`--force` and bails with an actionable error on prompts that have no default (#247)
-- **`fledge doctor` dual-provider AI section** — detects both `claude` and `ollama` binaries, reports the active provider, and probes the Ollama host's `/api/tags` with a 3-second timeout. Distinguishes "daemon down" from "not installed" from "typo in `ai.provider`" (#250)
-- **New `[ai]` config section** — `ai.provider`, `ai.claude.model`, `ai.ollama.{host,api_key,model}`. Env var overrides: `FLEDGE_AI_PROVIDER`, `FLEDGE_AI_MODEL`, `OLLAMA_HOST`, `OLLAMA_API_KEY`, `FLEDGE_AI_TIMEOUT`. All follow the CLI > env > config > default precedence. (#250)
-- Completed companion-file set for the `trust` spec module (#241)
-
-### Changed
-
-- README gains a short "Working with AI agents?" callout near the top pointing to `AGENTS.md` — mentions both Claude CLI and Ollama paths (#248, #250)
-- Prompt constraints on `fledge review` explicitly tell the active provider to treat specs as context-only and review only the diff itself — no suggestions on unchanged code, no critique of the specs (#245)
-- `fledge work pr` URL parsing is now robust to trailing slashes, query strings, and subpaths (`/pull/42/files`, `/pull/42?x=1`, etc.) (#246)
-
-### Fixed
-
-- `fledge work status --json`'s `behind` field no longer silently reports `0` when `git rev-list` can't compute it (base branch not fetched) — emits `null` instead so agents can tell "needs fetch" from "up to date" (#246)
-- `fledge doctor` no longer silently falls back to Claude when `ai.provider` is set to an invalid value; it now surfaces the parse error as an Error-level check (#250)
-- `OllamaProvider` distinguishes HTTP status errors (401, 404, 500) from connection failures, so users get a clean "endpoint returned HTTP 500" message instead of "decoding response" (#250)
-
-### Spec bumps
-
-- `ask` v2 → v4, `review` v4 → v6, `spec` v2 → v5, `work` v5 → v6, `main` v2 → v5, `config` v6 → v7, `doctor` v2 → v3
-- New module specs: `introspect` v1, `llm` v1, `trust` v1 companion files
-
-## [Unreleased]
 
 ## [v0.15.1] - 2026-04-25
 
@@ -161,13 +123,49 @@ The following commands and their modules left core. Some will return as plugins;
 - `work` v6 → v8, `config` v7 → v8, `doctor` v3 → v4, `llm` v1 → v2
 - New module spec: `ai` v1
 
-## [0.12.1] - 2026-04-23
+## [v0.13.0] - 2026-04-23
+
+**The agent-surface release.** fledge is now designed for humans and AI agents to drive the same CLI. Pick any LLM backend — Claude CLI or Ollama (local, cloud, or self-hosted) — and they all speak the same spec-aware `fledge ask` / `fledge review`. Set `FLEDGE_NON_INTERACTIVE=1` once, get JSON on every read command, and let the AI commands automatically include the right spec context from your repo's design docs. See the new [AGENTS.md](./AGENTS.md) for the one-page guide.
+
+### Added
+
+- **`AGENTS.md`** at the repo root plus `docs/src/agents.md` — canonical one-page guide for AI agents driving fledge, covering the machine-readable surface, non-interactive mode, provider selection, and typical workflows (#242)
+- **LLM provider abstraction + Ollama support** — `fledge ask` and `fledge review` now route through a `LlmProvider` trait. Two implementations ship in core: Claude CLI (default, unchanged) and Ollama. The Ollama provider covers the local daemon, Ollama Cloud / Turbo (with `OLLAMA_API_KEY`), and any self-hosted Ollama-speaking endpoint in one impl. Select via `ai.provider` config, `FLEDGE_AI_PROVIDER` env, or `--provider {claude,ollama}` per invocation. (#250)
+- **`fledge introspect [--json]`** — dumps the full clap command tree (every subcommand, every arg, every alias) as nested JSON or an indented listing. One call teaches an agent the entire CLI (#248)
+- **`fledge spec list [--json]`** (alias `ls`) and **`fledge spec show <name> [--json]`** — enumerate and inspect specs programmatically (#242)
+- **`fledge spec check --json`** — structured validation output with per-spec errors/warnings (#246)
+- **`fledge ask`** is spec-aware by default: every invocation prepends a compact index of the project's specs. New `--with-specs <names>` loads full spec + companion bundles for named modules (`all` supported); `--no-spec-index` for off-topic questions. JSON output gains `provider` and `model` fields. (#244, #250)
+- **`fledge review`** auto-detects relevant specs from the diff's changed-file list (matches each spec's `files:` frontmatter and the `<specs_dir>/<name>/` prefix, honoring custom `specs_dir`). New `--with-specs` to force-include; `--no-auto-specs` to disable. JSON output gains `spec_context`, `provider`, and `model` arrays. (#245, #250)
+- **`fledge work start --json`**, **`fledge work pr --json`**, **`fledge work status --json`** — structured output for scripting branch and PR workflows. `status` distinguishes `behind: null` (base not fetched) from `behind: 0` (up to date) (#246)
+- **Global `--non-interactive` flag** (alias `--ni`) and **`FLEDGE_NON_INTERACTIVE` env var** — one switch that treats every confirmation prompt as `--yes`/`--force` and bails with an actionable error on prompts that have no default (#247)
+- **`fledge doctor` dual-provider AI section** — detects both `claude` and `ollama` binaries, reports the active provider, and probes the Ollama host's `/api/tags` with a 3-second timeout. Distinguishes "daemon down" from "not installed" from "typo in `ai.provider`" (#250)
+- **New `[ai]` config section** — `ai.provider`, `ai.claude.model`, `ai.ollama.{host,api_key,model}`. Env var overrides: `FLEDGE_AI_PROVIDER`, `FLEDGE_AI_MODEL`, `OLLAMA_HOST`, `OLLAMA_API_KEY`, `FLEDGE_AI_TIMEOUT`. All follow the CLI > env > config > default precedence. (#250)
+- Completed companion-file set for the `trust` spec module (#241)
+
+### Changed
+
+- README gains a short "Working with AI agents?" callout near the top pointing to `AGENTS.md` — mentions both Claude CLI and Ollama paths (#248, #250)
+- Prompt constraints on `fledge review` explicitly tell the active provider to treat specs as context-only and review only the diff itself — no suggestions on unchanged code, no critique of the specs (#245)
+- `fledge work pr` URL parsing is now robust to trailing slashes, query strings, and subpaths (`/pull/42/files`, `/pull/42?x=1`, etc.) (#246)
+
+### Fixed
+
+- `fledge work status --json`'s `behind` field no longer silently reports `0` when `git rev-list` can't compute it (base branch not fetched) — emits `null` instead so agents can tell "needs fetch" from "up to date" (#246)
+- `fledge doctor` no longer silently falls back to Claude when `ai.provider` is set to an invalid value; it now surfaces the parse error as an Error-level check (#250)
+- `OllamaProvider` distinguishes HTTP status errors (401, 404, 500) from connection failures, so users get a clean "endpoint returned HTTP 500" message instead of "decoding response" (#250)
+
+### Spec bumps
+
+- `ask` v2 → v4, `review` v4 → v6, `spec` v2 → v5, `work` v5 → v6, `main` v2 → v5, `config` v6 → v7, `doctor` v2 → v3
+- New module specs: `introspect` v1, `llm` v1, `trust` v1 companion files
+
+## [v0.12.1] - 2026-04-23
 
 ### Added
 
 - Swift (Package.swift) and Kotlin (Gradle/Maven) dependency support in `fledge deps` (#239)
 
-## [0.12.0] - 2026-04-23
+## [v0.12.0] - 2026-04-23
 
 ### Added
 
@@ -186,13 +184,13 @@ The following commands and their modules left core. Some will return as plugins;
 
 - CLI commands reordered alphabetically for consistency (#237)
 
-## [0.11.1] - 2026-04-23
+## [v0.11.1] - 2026-04-23
 
 ### Added
 
 - `fledge run --json` flag for structured JSON output — improves AI agent usability (#228)
 
-## [0.11.0] - 2026-04-23
+## [v0.11.0] - 2026-04-23
 
 ### Added
 
@@ -211,7 +209,7 @@ The following commands and their modules left core. Some will return as plugins;
 
 - CONTRIBUTING.md fully dogfoods fledge — uses `fledge run`, `fledge lanes`, and `fledge work` instead of raw cargo commands (#223, #225, #226)
 
-## [0.10.0] - 2026-04-22
+## [v0.10.0] - 2026-04-22
 
 ### Added
 
@@ -246,13 +244,13 @@ The following commands and their modules left core. Some will return as plugins;
 - Removed TUI module — will be reimplemented as a plugin (#204)
 - CLI documentation updated to match current subcommand structure (#202)
 
-## [0.9.1] - 2026-04-21
+## [v0.9.1] - 2026-04-21
 
 ### Fixed
 
 - Release workflow: use `cp` instead of `mv` in checksum step to fix artifact packaging with `download-artifact@v4` (#173)
 
-## [0.9.0] - 2026-04-21
+## [v0.9.0] - 2026-04-21
 
 ### Added
 
@@ -304,7 +302,7 @@ The following commands and their modules left core. Some will return as plugins;
 - Homebrew formula updated to 0.9.0
 - CLI commands reorganized: `fledge templates`, `fledge lanes`, `fledge plugins` with subcommands
 
-## [0.8.0] - 2026-04-19
+## [v0.8.0] - 2026-04-19
 
 ### Added
 
@@ -313,7 +311,7 @@ The following commands and their modules left core. Some will return as plugins;
 - `fledge doctor` - environment diagnostics (toolchain versions, missing dependencies, config validation)
 - JSON output for all three commands (`--json`)
 
-## [0.7.0] - 2026-04-19
+## [v0.7.0] - 2026-04-19
 
 ### Added
 
@@ -327,7 +325,13 @@ The following commands and their modules left core. Some will return as plugins;
 - Split Java detection into Gradle/Maven, reinstated `/target/` in `.gitignore`
 - Removed invalid `--prompt` flag from Claude CLI calls in `fledge ask`/`fledge review`
 
-## [0.6.0] - 2026-04-19
+## [v0.6.1] - 2026-04-19
+
+### Fixed
+
+- Add missing `version` field in `TemplateInfo` constructor — the v0.6.0 crates.io publish was built before this fix landed and didn't compile, so v0.6.1 is a republish of the same feature set with the build error resolved.
+
+## [v0.6.0] - 2026-04-19
 
 ### Added
 
@@ -337,7 +341,7 @@ The following commands and their modules left core. Some will return as plugins;
 - `fledge completions --install` — auto-installs shell completions for bash, zsh, or fish
 - SHA256 checksums in GitHub releases
 
-## [0.5.0] - 2026-04-19
+## [v0.5.0] - 2026-04-19
 
 ### Added
 
@@ -346,7 +350,7 @@ The following commands and their modules left core. Some will return as plugins;
 - `fledge review` — AI-powered code review of current changes via Claude CLI
 - `fledge ask` — ask questions about your codebase via Claude CLI
 
-## [0.4.0] - 2026-04-19
+## [v0.4.0] - 2026-04-19
 
 ### Added
 
@@ -358,7 +362,7 @@ The following commands and their modules left core. Some will return as plugins;
 - `fledge work pr` — create a PR from the current branch
 - `fledge work status` — show current branch and PR status
 
-## [0.3.0] - 2026-04-19
+## [v0.3.0] - 2026-04-19
 
 ### Added
 
@@ -374,7 +378,20 @@ The following commands and their modules left core. Some will return as plugins;
 - `fledge config` — full subcommand interface (get/set/unset/add/remove/list/path)
 - mdBook documentation site on GitHub Pages
 
-## [0.1.0] - 2026-04-18
+## [v0.2.1] - 2026-04-18
+
+### Fixed
+
+- Templates were only discoverable via filesystem paths, so `cargo install` users got "No templates found" errors. Templates are now compiled into the binary with `include_dir` and extracted to a versioned cache directory on first use. (#25)
+
+## [v0.2.0] - 2026-04-18
+
+### Added
+
+- `cargo publish` step in the release workflow — tagging a release auto-publishes to crates.io. Includes a `cargo publish --dry-run` preflight to catch packaging errors before burning a version slot, and a `startsWith(github.ref, 'refs/tags/v')` guard for defense-in-depth. (#22)
+- Initial `CHANGELOG.md` (this file).
+
+## [v0.1.0] - 2026-04-18
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."

--- a/Formula/fledge.rb
+++ b/Formula/fledge.rb
@@ -2,12 +2,12 @@ class Fledge < Formula
   desc "Corvid-themed project scaffolding CLI — get your projects ready to fly"
   homepage "https://github.com/CorvidLabs/fledge"
   license "MIT"
-  version "0.15.1"
+  version "0.15.2"
 
   on_macos do
     on_arm do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-aarch64"
-      sha256 "3895500e0d49d32a5ff0ff027a594ef1fa98fc93731e7c5e612fd72760e1e394"
+      sha256 "PLACEHOLDER"
 
       def install
         bin.install "fledge-macos-aarch64" => "fledge"
@@ -16,7 +16,7 @@ class Fledge < Formula
 
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-x86_64"
-      sha256 "8b2ccd29a84073d4397daa871a76a6284236992ba0add53dee4b71529f5efaba"
+      sha256 "PLACEHOLDER"
 
       def install
         bin.install "fledge-macos-x86_64" => "fledge"
@@ -27,7 +27,7 @@ class Fledge < Formula
   on_linux do
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-linux-x86_64"
-      sha256 "2c51c2ccbb33250133bc97a36329a5173bd832868c81faa6bab7a4c8eaf31120"
+      sha256 "PLACEHOLDER"
 
       def install
         bin.install "fledge-linux-x86_64" => "fledge"

--- a/Formula/fledge.rb
+++ b/Formula/fledge.rb
@@ -2,12 +2,16 @@ class Fledge < Formula
   desc "Corvid-themed project scaffolding CLI — get your projects ready to fly"
   homepage "https://github.com/CorvidLabs/fledge"
   license "MIT"
-  version "0.15.2"
+  # NOTE: This file is updated POST-release by .github/workflows/post-release-formula.yml
+  # — once release.yml uploads the binaries and their .sha256 sidecars, that
+  # workflow opens a PR bumping the version and shas together. Don't try to bump
+  # this manually during `fledge release` (the new shas don't exist at bump time).
+  version "0.15.1"
 
   on_macos do
     on_arm do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-aarch64"
-      sha256 "PLACEHOLDER"
+      sha256 "3895500e0d49d32a5ff0ff027a594ef1fa98fc93731e7c5e612fd72760e1e394"
 
       def install
         bin.install "fledge-macos-aarch64" => "fledge"
@@ -16,7 +20,7 @@ class Fledge < Formula
 
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-macos-x86_64"
-      sha256 "PLACEHOLDER"
+      sha256 "8b2ccd29a84073d4397daa871a76a6284236992ba0add53dee4b71529f5efaba"
 
       def install
         bin.install "fledge-macos-x86_64" => "fledge"
@@ -27,7 +31,7 @@ class Fledge < Formula
   on_linux do
     on_intel do
       url "https://github.com/CorvidLabs/fledge/releases/download/v#{version}/fledge-linux-x86_64"
-      sha256 "PLACEHOLDER"
+      sha256 "2c51c2ccbb33250133bc97a36329a5173bd832868c81faa6bab7a4c8eaf31120"
 
       def install
         bin.install "fledge-linux-x86_64" => "fledge"

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "0.15.1";
+          version = "0.15.2";
           src = self;
 
           cargoLock = {

--- a/fledge.toml
+++ b/fledge.toml
@@ -56,6 +56,7 @@ steps = [{ parallel = ["fmt", "lint"] }, "test", "build"]
 
 [release]
 # Extra files whose `version "X.Y.Z"` lines should be bumped alongside Cargo.toml.
-# `flake.nix` matches the existing release.rs regex; `Formula/fledge.rb` is
-# handled by a Formula-specific bumper in release.rs (see bump_homebrew_formula).
-files = ["flake.nix", "Formula/fledge.rb"]
+# Formula/fledge.rb is intentionally NOT here — Homebrew formulae need both the
+# version AND fresh sha256s that don't exist until release.yml uploads binaries.
+# A separate post-release workflow handles the formula update once shas exist.
+files = ["flake.nix"]

--- a/src/release.rs
+++ b/src/release.rs
@@ -415,43 +415,14 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
                                     bail!("Release file '{}' escapes project directory", file_name);
                                 }
                                 if let Ok(content) = std::fs::read_to_string(&path) {
-                                    let standard_re = Regex::new(
+                                    let re = Regex::new(
                                         r#"(?m)(version\s*[=:]\s*["']?)(\d+\.\d+\.\d+)"#,
                                     )
                                     .unwrap();
-                                    // Homebrew DSL uses `version "X.Y.Z"` with no `=`.
-                                    let homebrew_re =
-                                        Regex::new(r#"(?m)^(\s*version\s+")(\d+\.\d+\.\d+)(")"#)
-                                            .unwrap();
-                                    let updated = if standard_re.is_match(&content) {
-                                        Some(
-                                            standard_re
-                                                .replace(&content, format!("${{1}}{new_str}"))
-                                                .into_owned(),
-                                        )
-                                    } else if homebrew_re.is_match(&content) {
-                                        // Bumping a Homebrew formula invalidates its sha256s
-                                        // — the new version's binaries don't exist at bump
-                                        // time. Reset to PLACEHOLDER so whoever cuts the
-                                        // release notices and fills them in.
-                                        let bumped_version = homebrew_re
-                                            .replace(&content, format!("${{1}}{new_str}${{3}}"))
-                                            .into_owned();
-                                        let sha_re =
-                                            Regex::new(r#"sha256\s+"[0-9a-fA-F]{64}""#).unwrap();
-                                        Some(
-                                            sha_re
-                                                .replace_all(
-                                                    &bumped_version,
-                                                    "sha256 \"PLACEHOLDER\"",
-                                                )
-                                                .into_owned(),
-                                        )
-                                    } else {
-                                        None
-                                    };
-                                    if let Some(new_content) = updated {
-                                        std::fs::write(&path, new_content.as_bytes())?;
+                                    if re.is_match(&content) {
+                                        let updated =
+                                            re.replace(&content, format!("${{1}}{new_str}"));
+                                        std::fs::write(&path, updated.as_bytes())?;
                                         bumped.push(file_name.to_string());
                                     }
                                 }
@@ -977,35 +948,6 @@ edition = "2021"
         assert!(result.files_bumped.contains(&"flake.nix".to_string()));
         let content = fs::read_to_string(tmp.path().join("flake.nix")).unwrap();
         assert!(content.contains("version = \"0.2.0\""));
-    }
-
-    #[test]
-    fn bump_release_files_homebrew_formula() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
-        fs::create_dir_all(tmp.path().join("Formula")).unwrap();
-        let formula = "class T < Formula\n  version \"0.1.0\"\n  sha256 \
-            \"3895500e0d49d32a5ff0ff027a594ef1fa98fc93731e7c5e612fd72760e1e394\"\nend\n";
-        commit_file(tmp.path(), "Formula/t.rb", formula);
-        commit_file(
-            tmp.path(),
-            "fledge.toml",
-            "[release]\nfiles = [\"Formula/t.rb\"]\n",
-        );
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"Formula/t.rb".to_string()));
-        let content = fs::read_to_string(tmp.path().join("Formula/t.rb")).unwrap();
-        assert!(content.contains("version \"0.2.0\""));
-        // Real shas should be reset to PLACEHOLDER on bump — they'll be wrong
-        // for the new release until updated post-build.
-        assert!(content.contains("sha256 \"PLACEHOLDER\""));
-        assert!(!content.contains("3895500e0d49d32a"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Patch release. **Default-plugin slim-down + distribution sync.**

- **`DEFAULT_PLUGINS` 5 → 3** — `templates-remote` and `doctor` re-absorbed into core (#260)
- **`fledge templates search`/`publish`** back in core
- **`fledge doctor` Toolchains section** (informational; missing tools dimmed, don't fail the report)
- **`fledge-plugin-metrics`** rewritten in Rust (`tokei` as library, `ignore` for walking, stable JSON shapes)
- **Nix flake** 0.9.1 → 0.15.2; **Homebrew formula** stays at 0.15.1 with real shas (formula bumps via new post-release workflow)

## Mid-PR fixes

- **CHANGELOG was a mess** — missing entries for v0.2.0, v0.2.1, v0.6.1; v0.13.0 sat between v0.15.2 and `[Unreleased]` instead of in semver order; older entries (≤v0.12.1) lacked the `v` prefix; `[Unreleased]` placeholder floating in the middle. All fixed: 22 entries, strict descending semver, normalized prefix, three missing entries backfilled from git tag annotations.
- **`sha256 "PLACEHOLDER"` design was wrong** — the auto-bump-with-PLACEHOLDER scheme would land a broken formula on main every release. Replaced with `.github/workflows/post-release-formula.yml` that runs after the Release workflow uploads binaries + `.sha256` sidecars, fetches the shas, rewrites the formula, and opens a PR. Formula no longer in `[release].files`. Homebrew-specific bumper code in `release.rs` removed.

## Spec bumps

`search` v3, `publish` v4, `doctor` v6 (full rewrite), `plugin` v11.

## Test plan

- [x] `cargo test` (664 + 157 passed)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo run -- spec check --strict` (29 specs, 0 errors, 0 warnings)
- [x] `Formula/fledge.rb` validates: `brew install --build-from-source ./Formula/fledge.rb` would resolve real shas (formula stays at v0.15.1 until post-release workflow lands the v0.15.2 update)
- [ ] After merge: tag v0.15.2 on main and push tag — release.yml builds artifacts, then post-release-formula.yml opens a follow-up PR with the v0.15.2 formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)