### PR TITLE
feat(plugin): set FLEDGE_PLUGIN_DIR for plugin commands and hooks

### DIFF
--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 11
+version: 12
 status: active
 files:
   - src/plugin.rs
@@ -120,6 +120,16 @@ Plugins are discovered via:
 ### Plugin Installation
 
 `fledge plugins install <repo>[@ref]` clones the repo to `~/.config/fledge/plugins/<name>/`, optionally checks out a pinned git ref (tag, branch, or commit), reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks them.
+
+### Plugin Runtime Environment
+
+When fledge invokes a plugin command (or runs any of its lifecycle/build hooks, or spawns a fledge-v1 protocol plugin), it sets the following environment variables before exec:
+
+| Variable | Value | Why it exists |
+|----------|-------|---------------|
+| `FLEDGE_PLUGIN_DIR` | Absolute path to the plugin's source directory (the cloned repo, e.g. `~/.config/fledge/plugins/fledge-plugin-foo`) | The declared `[[commands]].binary` is symlinked into a shared `plugins/bin/` dir, so `dirname "$0"` in a shell plugin resolves to the shared dir, not the plugin's source. `FLEDGE_PLUGIN_DIR` lets a plugin reach sibling helpers, hooks, and fixtures regardless of how it was invoked. |
+
+Plugin authors writing multi-file shell plugins should reference siblings via `"$FLEDGE_PLUGIN_DIR/bin/<helper>"`, not `"$(dirname "$0")/<helper>"`. The `fledge plugins create` scaffold ships a comment + dispatcher example that uses `$FLEDGE_PLUGIN_DIR`.
 
 ### Version Pinning
 
@@ -278,6 +288,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 12 | 2026-04-25 | Set `FLEDGE_PLUGIN_DIR` to the plugin's source directory before exec'ing a plugin binary, lifecycle hook, or fledge-v1 protocol plugin. Closes the dogfooding footgun where a multi-file shell plugin's `dirname "$0"` resolved to the shared `plugins/bin/` symlink dir instead of the plugin's source. The `fledge plugins create` scaffold now emits a starter binary that uses `$FLEDGE_PLUGIN_DIR`. (#266) |
 | 11 | 2026-04-25 | Trim `DEFAULT_PLUGINS` from 5 entries to 3. `fledge-plugin-templates-remote` was duplicating the in-tree `search.rs`/`publish.rs` helpers in shell — re-absorbed into core (`fledge templates search`/`publish`). `fledge-plugin-doctor` was 110 LOC of shell parallel to core doctor — re-absorbed as the informational `Toolchains` section. Default set is now `{github, deps, metrics}`. |
 | 10 | 2026-04-25 | Add `fledge plugins update --defaults` — symmetric with install. Updates only the installed plugins from `DEFAULT_PLUGINS`, leaving community plugins alone. Mutually exclusive with a positional plugin name. |
 | 9 | 2026-04-25 | Add `fledge plugins install --defaults` for one-command bulk install of the curated `DEFAULT_PLUGINS` set. Source positional becomes optional when --defaults is used. Per-plugin failures don't abort the bulk install. |

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1354,8 +1354,12 @@ fn run_plugin(name: &str, args: &[String]) -> Result<()> {
         );
     }
 
-    let status = Command::new(&bin_path)
-        .args(args)
+    let mut cmd = Command::new(&bin_path);
+    cmd.args(args);
+    if let Some(plugin_dir) = resolve_plugin_source_dir(&bin_path) {
+        cmd.env("FLEDGE_PLUGIN_DIR", &plugin_dir);
+    }
+    let status = cmd
         .status()
         .with_context(|| format!("running plugin '{name}'"))?;
 
@@ -1365,6 +1369,22 @@ fn run_plugin(name: &str, args: &[String]) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Compute the plugin's source directory from the resolved binary path.
+///
+/// `bin_path` is typically the symlink at `~/.config/fledge/plugins/bin/<cmd>`,
+/// which resolves to `~/.config/fledge/plugins/<plugin>/bin/<cmd>` (or
+/// similar). The plugin's source dir is two levels up from the resolved
+/// binary — that's the location where multi-file shell plugins keep their
+/// helpers, and what `FLEDGE_PLUGIN_DIR` should point to.
+///
+/// Returns `None` if the path can't be resolved (in which case we just don't
+/// set the env var — plugins that don't rely on it work as before).
+fn resolve_plugin_source_dir(bin_path: &Path) -> Option<PathBuf> {
+    let resolved = std::fs::canonicalize(bin_path).ok()?;
+    // <plugin_dir>/<bin_subdir>/<binary> — take parent twice.
+    resolved.parent()?.parent().map(|p| p.to_path_buf())
 }
 
 fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
@@ -1388,6 +1408,7 @@ fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
         make_executable(&hook_path)?;
         Command::new(&hook_path)
             .current_dir(plugin_dir)
+            .env("FLEDGE_PLUGIN_DIR", plugin_dir)
             .status()
             .with_context(|| format!("running {event} hook"))?
     } else {
@@ -1398,6 +1419,7 @@ fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
         Command::new(parts[0])
             .args(&parts[1..])
             .current_dir(plugin_dir)
+            .env("FLEDGE_PLUGIN_DIR", plugin_dir)
             .status()
             .with_context(|| format!("running {event} hook"))?
     };
@@ -1561,7 +1583,26 @@ metadata = false
     );
     fs::write(target.join("plugin.toml"), plugin_toml).context("writing plugin.toml")?;
 
-    let script = format!("#!/usr/bin/env bash\necho \"{name} plugin running with args: $@\"\n");
+    let script = format!(
+        r#"#!/usr/bin/env bash
+# fledge plugin entry point.
+#
+# fledge sets FLEDGE_PLUGIN_DIR to this plugin's source directory before
+# invoking your binary. Use it to reach sibling files in `bin/`, hooks,
+# fixtures, etc. Don't use `dirname "$0"` — the binary fledge invokes is
+# a symlink in a shared bin/, so $0 won't point to your repo.
+set -euo pipefail
+PLUGIN_DIR="${{FLEDGE_PLUGIN_DIR:?FLEDGE_PLUGIN_DIR not set — fledge >= 0.15.3 sets it automatically}}"
+
+echo "{name} plugin running with args: $@"
+echo "(plugin dir: $PLUGIN_DIR)"
+
+# To dispatch to sibling helpers in the same `bin/` (a common multi-subcommand
+# pattern), use:
+#
+#   exec "$PLUGIN_DIR/bin/{name}-${{1?missing subcommand}}" "${{@:2}}"
+"#
+    );
     let script_path = target.join("bin").join(name);
     fs::write(&script_path, script).context("writing bin script")?;
 
@@ -1879,6 +1920,52 @@ fn publish_plugin(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_plugin_source_dir_walks_symlink_to_plugin_root() {
+        // Mirror the post-install layout:
+        //   <root>/plugins/my-plugin/bin/fledge-my-plugin     ← real binary
+        //   <root>/plugins/bin/fledge-my-plugin               ← shared symlink
+        //
+        // resolve_plugin_source_dir(<symlink>) should return
+        //   <root>/plugins/my-plugin
+        let tmp = tempfile::TempDir::new().unwrap();
+        let plugin_root = tmp.path().join("plugins").join("my-plugin");
+        let plugin_bin_dir = plugin_root.join("bin");
+        std::fs::create_dir_all(&plugin_bin_dir).unwrap();
+        let real_binary = plugin_bin_dir.join("fledge-my-plugin");
+        std::fs::write(&real_binary, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let shared_bin_dir = tmp.path().join("plugins").join("bin");
+        std::fs::create_dir_all(&shared_bin_dir).unwrap();
+        let symlink = shared_bin_dir.join("fledge-my-plugin");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_binary, &symlink).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&real_binary, &symlink).unwrap();
+
+        let resolved = resolve_plugin_source_dir(&symlink).expect("resolve should succeed");
+        // Canonicalize the expected path because TempDir may live under /tmp,
+        // which is itself a symlink to /private/tmp on macOS.
+        let expected = std::fs::canonicalize(&plugin_root).unwrap();
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_plugin_source_dir_handles_non_symlink_path() {
+        // Direct PATH-resolved fledge-<name> binaries (not installed via
+        // `fledge plugins install`) still get a sensible plugin dir — the
+        // parent of the parent of the binary.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bin_dir = tmp.path().join("project").join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let bin = bin_dir.join("fledge-direct");
+        std::fs::write(&bin, "").unwrap();
+
+        let resolved = resolve_plugin_source_dir(&bin).expect("should resolve");
+        let expected = std::fs::canonicalize(tmp.path().join("project")).unwrap();
+        assert_eq!(resolved, expected);
+    }
 
     #[test]
     fn default_plugins_are_well_formed() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -144,6 +144,7 @@ pub fn run_protocol_plugin(
     capabilities: &crate::plugin::PluginCapabilities,
 ) -> Result<()> {
     let mut child = Command::new(bin_path)
+        .env("FLEDGE_PLUGIN_DIR", plugin_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
Closes #266.

## Problem

Multi-file shell plugins (the dogfooding example: \`fledge-plugin-github\` v0.2.0, which nests \`checks\`/\`issues\`/\`prs\` under one declared \`github\` command via a thin dispatcher) hit a quiet contract:

\`\`\`
$ fledge github checks
.../plugins/bin/fledge-github: line 34: \\
  .../plugins/bin/fledge-github-checks: No such file or directory
\`\`\`

\`\`\`bash
DIR="$(cd "$(dirname "$0")" && pwd)"   # ← shared bin dir, not the plugin's
exec "${DIR}/fledge-github-${SUB}" "$@"
\`\`\`

\`fledge plugins install\` symlinks only the declared \`[[commands]].binary\` into the shared \`plugins/bin/\` dir, so \`dirname \"$0\"\` resolves there — where the helpers don't exist. Workaround is the standard \`BASH_SOURCE\` + \`readlink\` symlink walk, which works but is a trap every multi-file shell plugin author has to rediscover.

## Fix

Set **\`FLEDGE_PLUGIN_DIR\`** to the plugin's source directory (canonicalized, absolute) before exec'ing the binary, lifecycle hook, or fledge-v1 protocol plugin. Plugin authors then write:

\`\`\`bash
exec "$FLEDGE_PLUGIN_DIR/bin/fledge-github-${SUB}" "$@"
\`\`\`

Explicit. No namespace risk. No symlink-walking. No regression for plugins that don't use it.

This is option (5) from the issue's suggested fixes, plus option (2) (scaffold guidance) — the \`fledge plugins create\` template now ships a starter binary that references \`$FLEDGE_PLUGIN_DIR\`.

## Changes

- **\`src/plugin.rs\`**:
  - \`run_plugin\` resolves the binary's parent-of-parent (after canonicalizing the symlink) and exports \`FLEDGE_PLUGIN_DIR\`.
  - \`run_hook\` already has \`plugin_dir\` in scope; passes it as env.
  - \`create_plugin\` scaffold generates a starter that uses \`\${FLEDGE_PLUGIN_DIR:?...}\` (fails fast on older fledge versions) and includes a commented dispatcher example.
- **\`src/protocol.rs\`**: \`run_protocol_plugin\` exports the same env var.
- **\`specs/plugin/plugin.spec.md\`** v11 → v12 with a new \"Plugin Runtime Environment\" section documenting the contract.

## Test plan

- [x] \`cargo test\` — 672 unit (+2 new) + 157 integration
- [x] \`cargo clippy --tests -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo run -- spec check --strict\` (29 specs, 0/0)
- [x] New tests cover the symlink walk and the non-symlink fallback
- [ ] After merge: real \`fledge-plugin-github\` repo can drop the BASH_SOURCE workaround and use \`\$FLEDGE_PLUGIN_DIR\` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)