### PR TITLE
feat(1.0): --json coverage across plugins, lanes, templates (tier A + B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .DS_Store
 docs/book/
 .claude/
+.reviews/

--- a/specs/create_template/create_template.spec.md
+++ b/specs/create_template/create_template.spec.md
@@ -1,6 +1,6 @@
 ---
 module: create_template
-version: 1
+version: 2
 status: active
 files:
   - src/create_template.rs
@@ -53,6 +53,7 @@ Scaffolds a new fledge template project with a valid `template.toml` manifest, e
 7. Custom prompts section is only included when user opts in
 8. Scaffolded template includes example `.tera` file demonstrating variable substitution
 9. Scaffolded template includes author-facing README with testing instructions
+10. `--json` emits a single `{schema_version: 1, action: "create", path, name, description, render_patterns, include_hooks, include_prompts, files_created}` envelope on stdout. Prose suppressed; JSON mode implies non-interactive (`yes = true`)
 
 ## Behavioral Examples
 
@@ -109,3 +110,4 @@ Scaffolds a new fledge template project with a valid `template.toml` manifest, e
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-19 | CorvidAgent | Initial spec |
+| 2026-04-25 | 0xLeif | v2: `--json` emits structured envelope (schema_version: 1) for `templates create`; prose suppressed, JSON mode implies non-interactive |

--- a/specs/init/init.spec.md
+++ b/specs/init/init.spec.md
@@ -1,6 +1,6 @@
 ---
 module: init
-version: 7
+version: 8
 status: active
 files:
   - src/init.rs
@@ -31,7 +31,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 
 | Type | Description |
 |------|-------------|
-| `InitOptions` | Options for project creation: name, template, output, author, org, no_git, no_install, refresh, dry_run, yes |
+| `InitOptions` | Options for project creation: name, template, output, author, org, no_git, no_install, refresh, dry_run, yes, json |
 
 ### Traits
 
@@ -52,6 +52,7 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 4. Directory is created before template rendering begins
 5. `.fledge/meta.toml` is written after rendering, before git init, recording template source and file hashes for future `fledge update`
 6. If the template does not include a `fledge.toml`, one is generated from auto-detected project type defaults
+7. `--json` emits a single `{schema_version: 1, action: "init", project, template, variables_used, files_created, git_initialized, hooks_run}` envelope on stdout. Prose progress (template selection, scaffolding, summary) is suppressed; warnings stay on stderr. JSON mode implies non-interactive (`yes = true`) so prompts can't deadlock an agent. Failure paths still exit non-zero — `--json` never silently turns failure into success
 
 ## Behavioral Examples
 
@@ -140,3 +141,4 @@ Orchestrates project creation from a template. Resolves the template, prompts fo
 | 2026-04-18 | CorvidAgent | v3: add remote template support via owner/repo syntax |
 | 2026-04-19 | CorvidAgent | v5: init now writes `.fledge.toml` with template source, variables, and file hashes for `fledge update` |
 | 2026-04-21 | CorvidAgent | v7: add author/org fields to InitOptions, document plugin pre_init hook and versioning check |
+| 2026-04-25 | 0xLeif | v8: `--json` emits structured envelope (schema_version: 1) for `templates init`; prose suppressed, JSON mode implies non-interactive, failure paths still exit non-zero |

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 10
+version: 11
 status: active
 files:
   - src/lanes.rs
@@ -225,6 +225,7 @@ $ fledge lanes run ci --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 11 | 2026-04-25 | Tier B follow-up: `lanes init`, `import`, `publish`, and `create` honour `--json` and emit `{schema_version:1, action, ...}` envelopes. `init` reports `project_type/lanes_added/file`; `import` reports `source/imported/skipped/file`; `publish` reports `repo/lanes_published/topic/import_hint`; `create` reports `path/name/description/files_created`. Failure paths still exit non-zero — `--json` never silently turns failure into success |
 | 10 | 2026-04-25 | Lock parallel-group + `fail_fast` semantics for 1.0: in-flight siblings always finish (no cancellation), `fail_fast` governs only the *next* step. Documents existing behavior — no code change |
 | 9 | 2026-04-23 | Add `--json` flag to `lane run` for structured JSON output |
 | 8 | 2026-04-22 | Add `create` and `validate` subcommands; `publish` now validates before pushing |

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,6 +1,6 @@
 ---
 module: main
-version: 6
+version: 7
 status: active
 files:
   - src/main.rs
@@ -84,11 +84,13 @@ All modules are dependencies — main dispatches to every subcommand module. See
 4. The `--version` and `--help` flags are handled by clap
 5. The top-level `--non-interactive` flag (aliased `--ni`) is a clap `global = true` arg, available on every subcommand. When set, or when `FLEDGE_NON_INTERACTIVE` env var is truthy (`1`/`true`/`yes`/`y`/`on`), `utils::set_non_interactive(true)` is called before dispatch, so every prompt site in the dispatched command observes it
 6. `utils::init_non_interactive_from_env()` runs before `Cli::parse()` so the env var is honored even when users don't pass the flag
+7. Tier-B JSON coverage (#271): `templates list` and `templates publish` (handled inline in `main.rs`) honour `--json` and emit a `{schema_version: 1, ...}` envelope on stdout — matching the same envelope contract as `plugins`, `lanes`, `init`, and `create_template`. `templates list --json` returns `{schema_version: 1, templates: [{name, description, source: "builtin"|"local"|"remote", source_ref, path}, ...]}`. `templates publish --json` returns `{schema_version: 1, action: "publish", repo, template, topic, use_hint}` (or `{cancelled: true}` if the user declines an update prompt). Failure paths still exit non-zero in both cases
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 7 | 2026-04-25 | Tier-B `--json` envelopes for `templates list` and `templates publish` (handled inline in main.rs). Both emit `{schema_version: 1, ...}` matching the contract used by plugins/lanes/init/create_template. Failure paths still exit non-zero. Closes the gap where `templates list --json` previously errored with "unexpected argument" (#271) |
 | 5 | 2026-04-23 | Add `llm` to depends_on for the provider abstraction that powers `fledge ask` and `fledge review`. No new top-level command; dispatch changes are localized to the Ask/Review variants. |
 | 4 | 2026-04-23 | Add `fledge introspect` command that dumps the clap command tree as JSON or a pretty listing. Closes the "how does an agent learn the command surface?" gap. |
 | 3 | 2026-04-23 | Add `--non-interactive` global flag (alias `--ni`) and `FLEDGE_NON_INTERACTIVE` env var. Sets `utils::NON_INTERACTIVE` before dispatch; each subcommand with `--yes`/`--force` auto-promotes it when the flag is set; prompts that have no default bail with a clear error. |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 13
+version: 14
 status: active
 files:
   - src/plugin.rs
@@ -166,7 +166,7 @@ pinned_ref = "v0.2.0"
 8. `plugin audit` shows trust tier, capabilities, lifecycle hooks, and warnings for each plugin
 9. `plugin search` uses GitHub topic search (same as template search)
 10. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
-11. `--json` (the global flag at the `plugins` parent command) outputs structured data for **every** plugin subcommand that mutates state or queries the registry: `list`, `audit`, `search`, `install`, `install --defaults`, `remove`, `update`, `update --defaults`, `validate`. Output is a JSON object on stdout with `schema_version: 1` plus an `action` field describing the operation. Prose, spinners, and capability prompts are suppressed in JSON mode (warnings still go to stderr). Errors continue to surface via stderr with non-zero exit code — JSON mode never silently turns a failure into a success exit code. The mutating commands' JSON shape is `{schema_version, action, scope?, installed?|removed?|results?, summary?}`
+11. `--json` (the global flag at the `plugins` parent command) outputs structured data for **every** plugin subcommand: `list`, `audit`, `search`, `install`, `install --defaults`, `remove`, `update`, `update --defaults`, `create`, `publish`, `validate`. Output is a JSON object on stdout with `schema_version: 1` plus an `action` field describing the operation. Prose, spinners, and capability prompts are suppressed in JSON mode (warnings still go to stderr). Errors continue to surface via stderr with non-zero exit code — JSON mode never silently turns a failure into a success exit code. Mutating-command shape: `{schema_version, action, scope?, installed?|removed?|results?, summary?}`. Scaffold/publish shape: `{schema_version, action, path|repo, name|owner, files_created?|topic?, ...}`
 12. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15.2: `fledge-plugin-{github,deps,metrics}`. The earlier set also included `templates-remote` (re-absorbed into core `templates search`/`publish`) and `doctor` (re-absorbed into core `doctor` as the informational `Toolchains` section)
 13. The `--defaults` install loop reports per-plugin success/failure and continues on error so a single bad repo doesn't block the rest. Exits non-zero if any plugin failed; the trailing summary lists each failure with its error message
 14. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
@@ -288,6 +288,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 14 | 2026-04-25 | Tier B follow-up: `plugins create` and `plugins publish` honour `--json` and emit a `{schema_version:1, action, ...}` envelope. `create` reports `path/name/description/files_created`; `publish` reports `repo/template/topic/install_hint` plus a `cancelled: true` shape on user-declined update prompts. Invariant 11 widened to enumerate `create` and `publish`. |
 | 13 | 2026-04-25 | `--json` now actually emits structured output for `install`, `install --defaults`, `remove`, and `update` (previously the global flag was accepted but silently ignored — agents passing `--json` got ANSI-coloured prose back, a 1.0 footgun caught by the multi-model readiness review). All four emit a `{schema_version: 1, action, ...}` envelope on stdout; warnings stay on stderr; failure paths still exit non-zero so agents can't misclassify them. Invariant 11 rewritten to enumerate the full coverage. |
 | 12 | 2026-04-25 | Set `FLEDGE_PLUGIN_DIR` to the plugin's source directory before exec'ing a plugin binary, lifecycle hook, or fledge-v1 protocol plugin. Closes the dogfooding footgun where a multi-file shell plugin's `dirname "$0"` resolved to the shared `plugins/bin/` symlink dir instead of the plugin's source. The `fledge plugins create` scaffold now emits a starter binary that uses `$FLEDGE_PLUGIN_DIR`. (#266) |
 | 11 | 2026-04-25 | Trim `DEFAULT_PLUGINS` from 5 entries to 3. `fledge-plugin-templates-remote` was duplicating the in-tree `search.rs`/`publish.rs` helpers in shell — re-absorbed into core (`fledge templates search`/`publish`). `fledge-plugin-doctor` was 110 LOC of shell parallel to core doctor — re-absorbed as the informational `Toolchains` section. Default set is now `{github, deps, metrics}`. |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 12
+version: 13
 status: active
 files:
   - src/plugin.rs
@@ -166,7 +166,7 @@ pinned_ref = "v0.2.0"
 8. `plugin audit` shows trust tier, capabilities, lifecycle hooks, and warnings for each plugin
 9. `plugin search` uses GitHub topic search (same as template search)
 10. Plugin commands appear in `fledge --help` via a "Plugin Commands" section when plugins are installed
-11. `--json` outputs structured data for all list/search operations
+11. `--json` (the global flag at the `plugins` parent command) outputs structured data for **every** plugin subcommand that mutates state or queries the registry: `list`, `audit`, `search`, `install`, `install --defaults`, `remove`, `update`, `update --defaults`, `validate`. Output is a JSON object on stdout with `schema_version: 1` plus an `action` field describing the operation. Prose, spinners, and capability prompts are suppressed in JSON mode (warnings still go to stderr). Errors continue to surface via stderr with non-zero exit code — JSON mode never silently turns a failure into a success exit code. The mutating commands' JSON shape is `{schema_version, action, scope?, installed?|removed?|results?, summary?}`
 12. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15.2: `fledge-plugin-{github,deps,metrics}`. The earlier set also included `templates-remote` (re-absorbed into core `templates search`/`publish`) and `doctor` (re-absorbed into core `doctor` as the informational `Toolchains` section)
 13. The `--defaults` install loop reports per-plugin success/failure and continues on error so a single bad repo doesn't block the rest. Exits non-zero if any plugin failed; the trailing summary lists each failure with its error message
 14. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
@@ -288,6 +288,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 13 | 2026-04-25 | `--json` now actually emits structured output for `install`, `install --defaults`, `remove`, and `update` (previously the global flag was accepted but silently ignored — agents passing `--json` got ANSI-coloured prose back, a 1.0 footgun caught by the multi-model readiness review). All four emit a `{schema_version: 1, action, ...}` envelope on stdout; warnings stay on stderr; failure paths still exit non-zero so agents can't misclassify them. Invariant 11 rewritten to enumerate the full coverage. |
 | 12 | 2026-04-25 | Set `FLEDGE_PLUGIN_DIR` to the plugin's source directory before exec'ing a plugin binary, lifecycle hook, or fledge-v1 protocol plugin. Closes the dogfooding footgun where a multi-file shell plugin's `dirname "$0"` resolved to the shared `plugins/bin/` symlink dir instead of the plugin's source. The `fledge plugins create` scaffold now emits a starter binary that uses `$FLEDGE_PLUGIN_DIR`. (#266) |
 | 11 | 2026-04-25 | Trim `DEFAULT_PLUGINS` from 5 entries to 3. `fledge-plugin-templates-remote` was duplicating the in-tree `search.rs`/`publish.rs` helpers in shell — re-absorbed into core (`fledge templates search`/`publish`). `fledge-plugin-doctor` was 110 LOC of shell parallel to core doctor — re-absorbed as the informational `Toolchains` section. Default set is now `{github, deps, metrics}`. |
 | 10 | 2026-04-25 | Add `fledge plugins update --defaults` — symmetric with install. Updates only the installed plugins from `DEFAULT_PLUGINS`, leaving community plugins alone. Mutually exclusive with a positional plugin name. |

--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -11,6 +11,7 @@ pub struct CreateTemplateOptions {
     pub hooks: Option<bool>,
     pub prompts: Option<bool>,
     pub yes: bool,
+    pub json: bool,
 }
 
 struct TemplateAnswers {
@@ -22,7 +23,7 @@ struct TemplateAnswers {
 }
 
 pub fn run(mut options: CreateTemplateOptions) -> Result<()> {
-    if crate::utils::is_non_interactive() {
+    if crate::utils::is_non_interactive() || options.json {
         options.yes = true;
     }
     let target = options.output.join(&options.name);
@@ -43,25 +44,45 @@ pub fn run(mut options: CreateTemplateOptions) -> Result<()> {
     };
     scaffold(&target, &answers)?;
 
-    println!(
-        "\n{} Created template at {}",
-        style("✅").green().bold(),
-        style(target.display()).cyan()
-    );
-    println!(
-        "\n  {} Edit files in {}/",
-        style("1.").dim(),
-        style(&answers.name).green()
-    );
-    println!(
-        "  {} Add .tera extension to files that need variable substitution",
-        style("2.").dim()
-    );
-    println!(
-        "  {} Test locally with: {}",
-        style("3.").dim(),
-        style(format!("fledge init my-project -t ./{}", answers.name)).cyan()
-    );
+    if options.json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "create",
+            "path": target.display().to_string(),
+            "name": answers.name,
+            "description": answers.description,
+            "render_patterns": answers.render_globs,
+            "include_hooks": answers.include_hooks,
+            "include_prompts": answers.include_prompts,
+            "files_created": [
+                "template.toml",
+                "README.md",
+                "README.md.tera",
+                ".gitignore",
+            ],
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "\n{} Created template at {}",
+            style("✅").green().bold(),
+            style(target.display()).cyan()
+        );
+        println!(
+            "\n  {} Edit files in {}/",
+            style("1.").dim(),
+            style(&answers.name).green()
+        );
+        println!(
+            "  {} Add .tera extension to files that need variable substitution",
+            style("2.").dim()
+        );
+        println!(
+            "  {} Test locally with: {}",
+            style("3.").dim(),
+            style(format!("fledge init my-project -t ./{}", answers.name)).cyan()
+        );
+    }
 
     Ok(())
 }
@@ -380,6 +401,7 @@ mod tests {
             hooks: None,
             prompts: None,
             yes: false,
+            json: false,
         };
 
         let result = run(options);

--- a/src/init.rs
+++ b/src/init.rs
@@ -19,10 +19,11 @@ pub struct InitOptions {
     pub refresh: bool,
     pub dry_run: bool,
     pub yes: bool,
+    pub json: bool,
 }
 
 pub fn run(mut opts: InitOptions) -> Result<()> {
-    if crate::utils::is_non_interactive() {
+    if crate::utils::is_non_interactive() || opts.json {
         opts.yes = true;
     }
     crate::plugin::run_lifecycle_hook("pre_init").ok();
@@ -48,7 +49,11 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
         bail!("No templates found. Add templates to the templates/ directory.");
     }
 
-    if opts.template.is_none() && config.template_repos().is_empty() && available.len() <= 2 {
+    if !opts.json
+        && opts.template.is_none()
+        && config.template_repos().is_empty()
+        && available.len() <= 2
+    {
         println!(
             "{} Only built-in starter templates found. Add {} to your config or pass `-t <owner/repo>` to fetch a remote template.",
             style("tip:").yellow().bold(),
@@ -59,11 +64,13 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
     // Resolve which template to use
     let template = resolve_template(&available, opts.template.as_deref())?;
 
-    println!(
-        "{} Using template: {}",
-        style("*").cyan().bold(),
-        style(&template.name).green()
-    );
+    if !opts.json {
+        println!(
+            "{} Using template: {}",
+            style("*").cyan().bold(),
+            style(&template.name).green()
+        );
+    }
 
     check_template_version(&template.manifest)?;
     let reqs_ok = check_template_requirements(&template.manifest, opts.yes)?;
@@ -102,7 +109,9 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
         .with_context(|| format!("creating directory {}", target_dir.display()))?;
 
     // Render template
-    println!("{} Scaffolding project...", style("*").cyan().bold());
+    if !opts.json {
+        println!("{} Scaffolding project...", style("*").cyan().bold());
+    }
     let mut created_files = templates::render_template(template, &target_dir, &variables)?;
 
     // Generate fledge.toml if the template didn't include one
@@ -124,14 +133,67 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
         init_git(&target_dir)?;
     }
 
+    let hooks_run = !opts.no_install && reqs_ok && !template.manifest.hooks.post_create.is_empty();
     // Post-create hooks (local templates are trusted); skip if required tools missing
     if !opts.no_install && reqs_ok {
-        run_post_create_hooks(&template.manifest.hooks.post_create, &target_dir, opts.yes)?;
+        run_post_create_hooks(
+            &template.manifest.hooks.post_create,
+            &target_dir,
+            opts.yes,
+            opts.json,
+        )?;
     }
 
-    // Print summary
-    print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+    if opts.json {
+        emit_init_envelope(
+            &opts.name,
+            &target_dir,
+            template,
+            None,
+            &variables,
+            &created_files,
+            !opts.no_git,
+            hooks_run,
+        )?;
+    } else {
+        print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+    }
 
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_init_envelope(
+    name: &str,
+    target_dir: &Path,
+    template: &Template,
+    remote_ref: Option<&str>,
+    variables: &tera::Context,
+    created_files: &[PathBuf],
+    git_initialized: bool,
+    hooks_run: bool,
+) -> Result<()> {
+    let result = serde_json::json!({
+        "schema_version": 1,
+        "action": "init",
+        "project": {
+            "name": name,
+            "path": target_dir.display().to_string(),
+        },
+        "template": {
+            "name": template.name,
+            "source": remote_ref,
+            "version": template.manifest.template.version,
+        },
+        "variables_used": variables.clone().into_json(),
+        "files_created": created_files
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+        "git_initialized": git_initialized,
+        "hooks_run": hooks_run,
+    });
+    println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }
 
@@ -149,14 +211,16 @@ fn run_remote(
 
     let ref_display = git_ref.map(|r| format!("@{}", r)).unwrap_or_default();
 
-    println!(
-        "{} Fetching template from {}/{}{}{}...",
-        style("*").cyan().bold(),
-        owner,
-        repo,
-        subpath.map(|s| format!("/{}", s)).unwrap_or_default(),
-        ref_display
-    );
+    if !opts.json {
+        println!(
+            "{} Fetching template from {}/{}{}{}...",
+            style("*").cyan().bold(),
+            owner,
+            repo,
+            subpath.map(|s| format!("/{}", s)).unwrap_or_default(),
+            ref_display
+        );
+    }
 
     let template_dir = crate::remote::resolve_template_dir(owner, repo, subpath, token, git_ref)?;
 
@@ -191,21 +255,23 @@ fn run_remote(
     };
 
     let tier = trust::determine_trust_tier(remote_ref);
-    println!(
-        "{} Using template: {} [{}]",
-        style("*").cyan().bold(),
-        style(&template.name).green(),
-        tier.styled_label()
-    );
-    if tier != trust::TrustTier::Official {
+    if !opts.json {
         println!(
-            "  {} Templates can include arbitrary files and post-create hooks.",
-            style("*").yellow()
+            "{} Using template: {} [{}]",
+            style("*").cyan().bold(),
+            style(&template.name).green(),
+            tier.styled_label()
         );
-        println!(
-            "  {} Only use templates from sources you trust.\n",
-            style("*").yellow()
-        );
+        if tier != trust::TrustTier::Official {
+            println!(
+                "  {} Templates can include arbitrary files and post-create hooks.",
+                style("*").yellow()
+            );
+            println!(
+                "  {} Only use templates from sources you trust.\n",
+                style("*").yellow()
+            );
+        }
     }
 
     check_template_version(&template.manifest)?;
@@ -241,7 +307,9 @@ fn run_remote(
     std::fs::create_dir_all(&target_dir)
         .with_context(|| format!("creating directory {}", target_dir.display()))?;
 
-    println!("{} Scaffolding project...", style("*").cyan().bold());
+    if !opts.json {
+        println!("{} Scaffolding project...", style("*").cyan().bold());
+    }
     let mut created_files = templates::render_template(template, &target_dir, &variables)?;
 
     // Generate fledge.toml if the template didn't include one
@@ -262,12 +330,31 @@ fn run_remote(
         init_git(&target_dir)?;
     }
 
+    let hooks_run = !opts.no_install && reqs_ok && !template.manifest.hooks.post_create.is_empty();
     // Remote templates require confirmation before running hooks; skip if required tools missing
     if !opts.no_install && reqs_ok {
-        run_post_create_hooks(&template.manifest.hooks.post_create, &target_dir, opts.yes)?;
+        run_post_create_hooks(
+            &template.manifest.hooks.post_create,
+            &target_dir,
+            opts.yes,
+            opts.json,
+        )?;
     }
 
-    print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+    if opts.json {
+        emit_init_envelope(
+            &opts.name,
+            &target_dir,
+            template,
+            Some(remote_ref),
+            &variables,
+            &created_files,
+            !opts.no_git,
+            hooks_run,
+        )?;
+    } else {
+        print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+    }
 
     Ok(())
 }
@@ -293,27 +380,36 @@ fn print_summary(name: &str, target_dir: &Path, created_files: &[PathBuf], no_gi
     println!("  cd {} && get started!", style(name).cyan());
 }
 
-fn run_post_create_hooks(hooks: &[String], project_dir: &Path, auto_yes: bool) -> Result<()> {
+fn run_post_create_hooks(
+    hooks: &[String],
+    project_dir: &Path,
+    auto_yes: bool,
+    quiet: bool,
+) -> Result<()> {
     if hooks.is_empty() {
         return Ok(());
     }
 
     if !auto_yes {
-        println!();
-        println!(
-            "{} This template wants to run the following post-create hooks:",
-            style("!").yellow().bold()
-        );
-        for cmd in hooks {
-            println!("  {} {}", style("$").yellow(), cmd);
+        if !quiet {
+            println!();
+            println!(
+                "{} This template wants to run the following post-create hooks:",
+                style("!").yellow().bold()
+            );
+            for cmd in hooks {
+                println!("  {} {}", style("$").yellow(), cmd);
+            }
+            println!();
         }
-        println!();
 
         if !crate::utils::is_interactive() {
-            println!(
-                "{} Skipped hooks (non-interactive). Re-run with --yes to allow.",
-                style("*").cyan().bold()
-            );
+            if !quiet {
+                println!(
+                    "{} Skipped hooks (non-interactive). Re-run with --yes to allow.",
+                    style("*").cyan().bold()
+                );
+            }
             return Ok(());
         }
 
@@ -323,18 +419,24 @@ fn run_post_create_hooks(hooks: &[String], project_dir: &Path, auto_yes: bool) -
             .interact()?;
 
         if !confirm {
-            println!(
-                "{} Skipped hooks. Run them manually or re-run with --yes.",
-                style("*").cyan().bold()
-            );
+            if !quiet {
+                println!(
+                    "{} Skipped hooks. Run them manually or re-run with --yes.",
+                    style("*").cyan().bold()
+                );
+            }
             return Ok(());
         }
     }
 
-    println!("{} Running post-create hooks...", style("*").cyan().bold());
+    if !quiet {
+        println!("{} Running post-create hooks...", style("*").cyan().bold());
+    }
 
     for cmd in hooks {
-        println!("  {} {}", style("$").dim(), style(cmd).dim());
+        if !quiet {
+            println!("  {} {}", style("$").dim(), style(cmd).dim());
+        }
 
         if cmd.trim().is_empty() {
             bail!("Empty post-create hook command");
@@ -705,7 +807,7 @@ ignore = ["template.toml"]
         fs::create_dir(&dir).unwrap();
 
         let hooks = vec!["touch hook-ran.txt".to_string()];
-        run_post_create_hooks(&hooks, &dir, true).unwrap();
+        run_post_create_hooks(&hooks, &dir, true, false).unwrap();
 
         assert!(dir.join("hook-ran.txt").exists());
     }
@@ -713,7 +815,7 @@ ignore = ["template.toml"]
     #[test]
     fn run_post_create_hooks_empty_is_noop() {
         let tmp = TempDir::new().unwrap();
-        let result = run_post_create_hooks(&[], tmp.path(), true);
+        let result = run_post_create_hooks(&[], tmp.path(), true, false);
         assert!(result.is_ok());
     }
 
@@ -721,7 +823,7 @@ ignore = ["template.toml"]
     fn run_post_create_hooks_failing_command_errors() {
         let tmp = TempDir::new().unwrap();
         let hooks = vec!["false".to_string()];
-        let result = run_post_create_hooks(&hooks, tmp.path(), true);
+        let result = run_post_create_hooks(&hooks, tmp.path(), true, false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -736,7 +838,7 @@ ignore = ["template.toml"]
         fs::create_dir(&dir).unwrap();
 
         let hooks = vec!["touch hook-ran.txt".to_string()];
-        run_post_create_hooks(&hooks, &dir, true).unwrap();
+        run_post_create_hooks(&hooks, &dir, true, false).unwrap();
 
         assert!(dir.join("hook-ran.txt").exists());
     }

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -107,7 +107,9 @@ pub enum LaneAction {
     List {
         json: bool,
     },
-    Init,
+    Init {
+        json: bool,
+    },
     Search {
         query: Option<String>,
         author: Option<String>,
@@ -116,6 +118,7 @@ pub enum LaneAction {
     Import {
         source: String,
         yes: bool,
+        json: bool,
     },
     Publish {
         path: PathBuf,
@@ -123,12 +126,14 @@ pub enum LaneAction {
         private: bool,
         description: Option<String>,
         yes: bool,
+        json: bool,
     },
     Create {
         name: String,
         output: PathBuf,
         description: Option<String>,
         yes: bool,
+        json: bool,
     },
     Validate {
         path: PathBuf,
@@ -144,21 +149,30 @@ pub fn run(action: LaneAction) -> Result<()> {
             author,
             json,
         } => search_lanes(query.as_deref(), author.as_deref(), json),
-        LaneAction::Import { source, yes } => import_lanes(&source, yes),
-        LaneAction::Init => init_lanes(),
+        LaneAction::Import { source, yes, json } => import_lanes(&source, yes, json),
+        LaneAction::Init { json } => init_lanes(json),
         LaneAction::Publish {
             path,
             org,
             private,
             description,
             yes,
-        } => publish_lanes(&path, org.as_deref(), private, description.as_deref(), yes),
+            json,
+        } => publish_lanes(
+            &path,
+            org.as_deref(),
+            private,
+            description.as_deref(),
+            yes,
+            json,
+        ),
         LaneAction::Create {
             name,
             output,
             description,
             yes,
-        } => create_lane_repo(&name, &output, description.as_deref(), yes),
+            json,
+        } => create_lane_repo(&name, &output, description.as_deref(), yes, json),
         LaneAction::Validate { path, strict, json } => validate_lanes(&path, strict, json),
         LaneAction::List { json } => {
             let config = load_lane_config()?;
@@ -839,7 +853,7 @@ steps = ["build", "test"]
     }
 }
 
-fn init_lanes() -> Result<()> {
+fn init_lanes(json: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = cwd.join("fledge.toml");
 
@@ -860,14 +874,32 @@ fn init_lanes() -> Result<()> {
     let defaults = lane_defaults(project_type);
 
     let new_content = format!("{}{}", content.trim_end(), defaults);
-    std::fs::write(&path, new_content).context("writing fledge.toml")?;
+    std::fs::write(&path, &new_content).context("writing fledge.toml")?;
 
-    println!(
-        "{} Added default lanes to {}",
-        style("✅").green().bold(),
-        style("fledge.toml").cyan()
-    );
-    println!("  Run {} to see them.", style("fledge lane").cyan());
+    // Parse the just-written defaults so we can report which lane names landed.
+    // This is a best-effort parse — if it fails, we still succeed but emit an
+    // empty `lanes_added` list rather than crashing the json path.
+    let lanes_added: Vec<String> = toml::from_str::<FledgeFileWithLanes>(&new_content)
+        .map(|cfg| cfg.lanes.keys().cloned().collect())
+        .unwrap_or_default();
+
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "init",
+            "file": "fledge.toml",
+            "project_type": project_type,
+            "lanes_added": lanes_added,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "{} Added default lanes to {}",
+            style("✅").green().bold(),
+            style("fledge.toml").cyan()
+        );
+        println!("  Run {} to see them.", style("fledge lane").cyan());
+    }
     Ok(())
 }
 
@@ -963,7 +995,7 @@ fn search_lanes(keyword: Option<&str>, author: Option<&str>, json: bool) -> Resu
     Ok(())
 }
 
-fn import_lanes(source: &str, _yes: bool) -> Result<()> {
+fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let local_path = cwd.join("fledge.toml");
 
@@ -994,24 +1026,33 @@ fn import_lanes(source: &str, _yes: bool) -> Result<()> {
     );
 
     let tier = determine_trust_tier(&display_source);
-    println!(
-        "\n{} Importing lanes from: {} [{}]",
-        style("!").yellow().bold(),
-        style(&display_source).cyan(),
-        tier.styled_label()
-    );
-    if tier != crate::trust::TrustTier::Official {
+    if !json {
         println!(
-            "  {} Lanes can execute arbitrary commands on your system.",
-            style("*").yellow()
+            "\n{} Importing lanes from: {} [{}]",
+            style("!").yellow().bold(),
+            style(&display_source).cyan(),
+            tier.styled_label()
         );
-        println!(
-            "  {} Only import lanes from sources you trust.\n",
-            style("*").yellow()
-        );
+        if tier != crate::trust::TrustTier::Official {
+            println!(
+                "  {} Lanes can execute arbitrary commands on your system.",
+                style("*").yellow()
+            );
+            println!(
+                "  {} Only import lanes from sources you trust.\n",
+                style("*").yellow()
+            );
+        }
     }
 
-    let sp = crate::spinner::Spinner::start(&format!("Fetching lanes from {}:", display_source,));
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start(&format!(
+            "Fetching lanes from {}:",
+            display_source,
+        )))
+    };
 
     let ref_param = git_ref.as_deref().unwrap_or("HEAD");
     let remote_path = match &subpath {
@@ -1025,7 +1066,9 @@ fn import_lanes(source: &str, _yes: bool) -> Result<()> {
     )
     .context(format!("fetching {remote_path} from remote repo"))?;
 
-    sp.finish();
+    if let Some(s) = sp {
+        s.finish();
+    }
 
     let content_b64 = body
         .get("content")
@@ -1069,12 +1112,25 @@ fn import_lanes(source: &str, _yes: bool) -> Result<()> {
     }
 
     if imported_lanes.is_empty() {
-        println!(
-            "{} All lanes from {} already exist locally ({})",
-            style("*").cyan().bold(),
-            display_source,
-            skipped.join(", ")
-        );
+        if json {
+            let result = serde_json::json!({
+                "schema_version": 1,
+                "action": "import",
+                "source": display_source,
+                "tier": tier.label(),
+                "imported": [],
+                "skipped": skipped,
+                "file": null,
+            });
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        } else {
+            println!(
+                "{} All lanes from {} already exist locally ({})",
+                style("*").cyan().bold(),
+                display_source,
+                skipped.join(", ")
+            );
+        }
         return Ok(());
     }
 
@@ -1090,29 +1146,43 @@ fn import_lanes(source: &str, _yes: bool) -> Result<()> {
             .map(|p| format!("-{}", p.replace('/', "-").to_lowercase()))
             .unwrap_or_default()
     );
+    let relative_file = format!(".fledge/lanes/{safe_name}.toml");
     let import_path = lanes_dir.join(format!("{safe_name}.toml"));
     std::fs::write(&import_path, import_content.trim_start()).context("writing imported lanes")?;
 
-    println!(
-        "{} Imported {} lane(s) from {}",
-        style("✅").green().bold(),
-        imported_lanes.len(),
-        display_source
-    );
-    for name in &imported_lanes {
-        println!("  {} {}", style("+").green(), style(name).cyan());
-    }
-    println!(
-        "  {} Saved to {}",
-        style("→").dim(),
-        style(format!(".fledge/lanes/{safe_name}.toml")).cyan()
-    );
-    if !skipped.is_empty() {
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "import",
+            "source": display_source,
+            "tier": tier.label(),
+            "imported": imported_lanes,
+            "skipped": skipped,
+            "file": relative_file,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
         println!(
-            "  {} Skipped (already exist): {}",
-            style("*").dim(),
-            skipped.join(", ")
+            "{} Imported {} lane(s) from {}",
+            style("✅").green().bold(),
+            imported_lanes.len(),
+            display_source
         );
+        for name in &imported_lanes {
+            println!("  {} {}", style("+").green(), style(name).cyan());
+        }
+        println!(
+            "  {} Saved to {}",
+            style("→").dim(),
+            style(&relative_file).cyan()
+        );
+        if !skipped.is_empty() {
+            println!(
+                "  {} Skipped (already exist): {}",
+                style("*").dim(),
+                skipped.join(", ")
+            );
+        }
     }
 
     Ok(())
@@ -1212,7 +1282,14 @@ fn base64_decode(input: &str) -> Result<Vec<u8>> {
     Ok(output)
 }
 
-fn create_lane_repo(name: &str, output: &Path, description: Option<&str>, yes: bool) -> Result<()> {
+fn create_lane_repo(
+    name: &str,
+    output: &Path,
+    description: Option<&str>,
+    yes: bool,
+    json: bool,
+) -> Result<()> {
+    let yes = yes || crate::utils::is_non_interactive() || json;
     let target = output.join(name);
 
     if target.exists() {
@@ -1293,26 +1370,44 @@ See [fledge docs](https://github.com/CorvidLabs/fledge) for lane syntax.
     std::fs::write(target.join(".gitignore"), "# OS\n.DS_Store\nThumbs.db\n")
         .context("writing .gitignore")?;
 
-    println!(
-        "\n{} Created lane repo at {}",
-        style("✅").green().bold(),
-        style(target.display()).cyan()
-    );
-    println!(
-        "\n  {} Edit lanes in {}",
-        style("1.").dim(),
-        style("fledge.toml").green()
-    );
-    println!(
-        "  {} Validate with: {}",
-        style("2.").dim(),
-        style(format!("fledge lanes validate ./{name}")).cyan()
-    );
-    println!(
-        "  {} Publish with: {}",
-        style("3.").dim(),
-        style(format!("fledge lanes publish ./{name}")).cyan()
-    );
+    let files_created = vec![
+        "fledge.toml".to_string(),
+        "README.md".to_string(),
+        ".gitignore".to_string(),
+    ];
+
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "create",
+            "path": target.display().to_string(),
+            "name": name,
+            "description": desc,
+            "files_created": files_created,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "\n{} Created lane repo at {}",
+            style("✅").green().bold(),
+            style(target.display()).cyan()
+        );
+        println!(
+            "\n  {} Edit lanes in {}",
+            style("1.").dim(),
+            style("fledge.toml").green()
+        );
+        println!(
+            "  {} Validate with: {}",
+            style("2.").dim(),
+            style(format!("fledge lanes validate ./{name}")).cyan()
+        );
+        println!(
+            "  {} Publish with: {}",
+            style("3.").dim(),
+            style(format!("fledge lanes publish ./{name}")).cyan()
+        );
+    }
 
     Ok(())
 }
@@ -1504,8 +1599,9 @@ fn publish_lanes(
     private: bool,
     description: Option<&str>,
     yes: bool,
+    json: bool,
 ) -> Result<()> {
-    let yes = yes || crate::utils::is_non_interactive();
+    let yes = yes || crate::utils::is_non_interactive() || json;
     let config = crate::config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(
@@ -1542,20 +1638,29 @@ fn publish_lanes(
         None => crate::publish::get_authenticated_user(&token)?,
     };
 
-    let lane_names: Vec<&str> = parsed.lanes.keys().map(|s| s.as_str()).collect();
-    println!(
-        "{} Publishing {} lanes as {}/{}",
-        style("➡️").cyan().bold(),
-        style(lane_names.len()).green(),
-        style(&owner).green(),
-        style(&repo_name).green()
-    );
-    println!("  Lanes: {}", style(lane_names.join(", ")).dim());
+    let lane_names: Vec<String> = parsed.lanes.keys().cloned().collect();
+    if !json {
+        println!(
+            "{} Publishing {} lanes as {}/{}",
+            style("➡️").cyan().bold(),
+            style(lane_names.len()).green(),
+            style(&owner).green(),
+            style(&repo_name).green()
+        );
+        println!("  Lanes: {}", style(lane_names.join(", ")).dim());
+    }
 
-    let sp = crate::spinner::Spinner::start("Checking repository:");
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Checking repository:"))
+    };
     let repo_exists = crate::publish::check_repo_exists(&owner, &repo_name, &token)?;
-    sp.finish();
+    if let Some(s) = sp {
+        s.finish();
+    }
 
+    let mut created_repo = false;
     if repo_exists {
         if !yes {
             crate::utils::require_interactive("yes")?;
@@ -1569,41 +1674,97 @@ fn publish_lanes(
                     .interact()?;
 
             if !confirm {
-                println!("{} Cancelled.", style("*").cyan().bold());
+                if json {
+                    let result = serde_json::json!({
+                        "schema_version": 1,
+                        "action": "publish",
+                        "cancelled": true,
+                        "repo": {
+                            "owner": owner,
+                            "name": repo_name,
+                            "url": format!("https://github.com/{owner}/{repo_name}"),
+                            "exists": true,
+                        },
+                    });
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else {
+                    println!("{} Cancelled.", style("*").cyan().bold());
+                }
                 return Ok(());
             }
         }
     } else {
-        let sp = crate::spinner::Spinner::start("Creating repository:");
+        let sp = if json {
+            None
+        } else {
+            Some(crate::spinner::Spinner::start("Creating repository:"))
+        };
         crate::publish::create_github_repo(&repo_name, desc, private, org, &token)?;
-        sp.finish();
+        if let Some(s) = sp {
+            s.finish();
+        }
+        created_repo = true;
+        if !json {
+            println!(
+                "  {} Created repository {}/{}",
+                style("✅").green().bold(),
+                owner,
+                repo_name
+            );
+        }
+    }
+
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Setting repository topics:"))
+    };
+    crate::publish::set_repo_topic(&owner, &repo_name, "fledge-lane", &token)?;
+    if let Some(s) = sp {
+        s.finish();
+    }
+    if !json {
         println!(
-            "  {} Created repository {}/{}",
+            "  {} Set {} topic",
             style("✅").green().bold(),
-            owner,
-            repo_name
+            style("fledge-lane").cyan()
         );
     }
 
-    let sp = crate::spinner::Spinner::start("Setting repository topics:");
-    crate::publish::set_repo_topic(&owner, &repo_name, "fledge-lane", &token)?;
-    sp.finish();
-    println!(
-        "  {} Set {} topic",
-        style("✅").green().bold(),
-        style("fledge-lane").cyan()
-    );
-
-    let sp = crate::spinner::Spinner::start("Pushing lane files:");
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Pushing lane files:"))
+    };
     crate::publish::push_directory(&path, &owner, &repo_name, &token)?;
-    sp.finish();
-    println!("  {} Pushed lane files", style("✅").green().bold());
+    if let Some(s) = sp {
+        s.finish();
+    }
 
-    println!(
-        "\n{} Published! Import with:\n\n  {}",
-        style("✅").green().bold(),
-        style(format!("fledge lanes import {}/{}", owner, repo_name)).cyan()
-    );
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "publish",
+            "repo": {
+                "owner": owner,
+                "name": repo_name,
+                "url": format!("https://github.com/{owner}/{repo_name}"),
+                "created": created_repo,
+                "private": private,
+            },
+            "lanes_published": lane_names,
+            "topic": "fledge-lane",
+            "import_hint": format!("fledge lanes import {owner}/{repo_name}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("  {} Pushed lane files", style("✅").green().bold());
+        println!(
+            "\n{} Published! Import with:\n\n  {}",
+            style("✅").green().bold(),
+            style(format!("fledge lanes import {}/{}", owner, repo_name)).cyan()
+        );
+    }
 
     Ok(())
 }
@@ -2416,7 +2577,7 @@ steps = ["test"]
     #[test]
     fn create_lane_repo_scaffolds_files() {
         let tmp = tempfile::TempDir::new().unwrap();
-        create_lane_repo("my-lanes", tmp.path(), Some("Test lanes"), true).unwrap();
+        create_lane_repo("my-lanes", tmp.path(), Some("Test lanes"), true, false).unwrap();
 
         let target = tmp.path().join("my-lanes");
         assert!(target.join("fledge.toml").exists());
@@ -2433,7 +2594,7 @@ steps = ["test"]
     fn create_lane_repo_fails_if_exists() {
         let tmp = tempfile::TempDir::new().unwrap();
         std::fs::create_dir(tmp.path().join("existing")).unwrap();
-        let result = create_lane_repo("existing", tmp.path(), None, true);
+        let result = create_lane_repo("existing", tmp.path(), None, true, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,9 @@ enum TemplatesSubcommand {
         /// Skip all confirmation prompts (accept defaults)
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Scaffold a new fledge template
     Create {
@@ -324,6 +327,9 @@ enum TemplatesSubcommand {
         /// Skip all interactive prompts (accept defaults)
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Validate a template or directory of templates
     Validate {
@@ -338,7 +344,11 @@ enum TemplatesSubcommand {
         json: bool,
     },
     /// List available templates
-    List,
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Search GitHub for community templates (fledge-template topic)
     Search {
         /// Keyword to filter results
@@ -370,6 +380,9 @@ enum TemplatesSubcommand {
         /// Skip all confirmation prompts
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -565,7 +578,11 @@ enum LaneSubcommand {
         json: bool,
     },
     /// Add default lanes to fledge.toml
-    Init,
+    Init {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Search GitHub for community lanes
     Search {
         /// Keyword to filter results
@@ -584,6 +601,9 @@ enum LaneSubcommand {
         /// Skip all confirmation prompts
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Publish lanes to GitHub
     Publish {
@@ -602,6 +622,9 @@ enum LaneSubcommand {
         /// Skip all confirmation prompts
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Scaffold a new lane repo
     Create {
@@ -616,6 +639,9 @@ enum LaneSubcommand {
         /// Skip all interactive prompts
         #[arg(short, long)]
         yes: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Validate lane definitions in fledge.toml
     Validate {
@@ -880,7 +906,7 @@ fn run() -> Result<()> {
                     json,
                 },
                 LaneSubcommand::List { json } => lanes::LaneAction::List { json },
-                LaneSubcommand::Init => lanes::LaneAction::Init,
+                LaneSubcommand::Init { json } => lanes::LaneAction::Init { json },
                 LaneSubcommand::Search {
                     query,
                     author,
@@ -890,30 +916,36 @@ fn run() -> Result<()> {
                     author,
                     json,
                 },
-                LaneSubcommand::Import { source, yes } => lanes::LaneAction::Import { source, yes },
+                LaneSubcommand::Import { source, yes, json } => {
+                    lanes::LaneAction::Import { source, yes, json }
+                }
                 LaneSubcommand::Publish {
                     path,
                     org,
                     private,
                     description,
                     yes,
+                    json,
                 } => lanes::LaneAction::Publish {
                     path,
                     org,
                     private,
                     description,
                     yes,
+                    json,
                 },
                 LaneSubcommand::Create {
                     name,
                     output,
                     description,
                     yes,
+                    json,
                 } => lanes::LaneAction::Create {
                     name,
                     output,
                     description,
                     yes,
+                    json,
                 },
                 LaneSubcommand::Validate { path, strict, json } => {
                     lanes::LaneAction::Validate { path, strict, json }
@@ -1125,6 +1157,7 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
             refresh,
             dry_run,
             yes,
+            json,
         } => {
             init::run(init::InitOptions {
                 name,
@@ -1137,6 +1170,7 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
                 refresh,
                 dry_run,
                 yes,
+                json,
             })?;
         }
         TemplatesSubcommand::Create {
@@ -1147,6 +1181,7 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
             hooks,
             prompts,
             yes,
+            json,
         } => {
             create_template::run(create_template::CreateTemplateOptions {
                 name,
@@ -1156,13 +1191,14 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
                 hooks,
                 prompts,
                 yes,
+                json,
             })?;
         }
         TemplatesSubcommand::Validate { path, strict, json } => {
             validate::run(validate::ValidateOptions { path, strict, json })?;
         }
-        TemplatesSubcommand::List => {
-            list_templates()?;
+        TemplatesSubcommand::List { json } => {
+            list_templates(json)?;
         }
         TemplatesSubcommand::Search {
             query,
@@ -1178,8 +1214,16 @@ fn handle_templates(action: TemplatesSubcommand) -> Result<()> {
             private,
             description,
             yes,
+            json,
         } => {
-            publish_template(&path, org.as_deref(), private, description.as_deref(), yes)?;
+            publish_template(
+                &path,
+                org.as_deref(),
+                private,
+                description.as_deref(),
+                yes,
+                json,
+            )?;
         }
     }
     Ok(())
@@ -1375,7 +1419,7 @@ fn install_completions(shell: Option<Shell>) -> Result<()> {
     Ok(())
 }
 
-fn list_templates() -> Result<()> {
+fn list_templates(json: bool) -> Result<()> {
     let config = config::Config::load()?;
     let extra_paths = config.extra_template_paths();
     let token = config.github_token();
@@ -1389,13 +1433,38 @@ fn list_templates() -> Result<()> {
         anyhow::bail!("No templates found. Configure template sources via `fledge config add templates.repos <owner/repo>`, add templates to the templates/ directory, or set templates.paths via `fledge config add templates.paths <path>`.");
     }
 
-    println!("{}", style("Available templates:").bold());
-    for t in &available {
-        println!(
-            "  {:<14} {}",
-            style(&t.name).green(),
-            style(&t.description).dim()
-        );
+    if json {
+        let entries: Vec<serde_json::Value> = available
+            .iter()
+            .map(|t| {
+                let source_kind = match &t.source {
+                    Some(s) if s.starts_with("http") || s.contains('/') => "remote",
+                    Some(_) => "local",
+                    None => "builtin",
+                };
+                serde_json::json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "source": source_kind,
+                    "source_ref": t.source,
+                    "path": t.path.display().to_string(),
+                })
+            })
+            .collect();
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "templates": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("{}", style("Available templates:").bold());
+        for t in &available {
+            println!(
+                "  {:<14} {}",
+                style(&t.name).green(),
+                style(&t.description).dim()
+            );
+        }
     }
 
     Ok(())
@@ -1503,9 +1572,10 @@ fn publish_template(
     private: bool,
     description: Option<&str>,
     yes: bool,
+    json: bool,
 ) -> Result<()> {
     use anyhow::Context as _;
-    let yes = yes || utils::is_non_interactive();
+    let yes = yes || utils::is_non_interactive() || json;
     let config = config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(
@@ -1536,17 +1606,26 @@ fn publish_template(
         None => publish::get_authenticated_user(&token)?,
     };
 
-    println!(
-        "{} Publishing template as {}/{}",
-        style("➡️").cyan().bold(),
-        style(&owner).green(),
-        style(&repo_name).green()
-    );
+    if !json {
+        println!(
+            "{} Publishing template as {}/{}",
+            style("➡️").cyan().bold(),
+            style(&owner).green(),
+            style(&repo_name).green()
+        );
+    }
 
-    let sp = spinner::Spinner::start("Checking repository:");
+    let sp = if json {
+        None
+    } else {
+        Some(spinner::Spinner::start("Checking repository:"))
+    };
     let repo_exists = publish::check_repo_exists(&owner, &repo_name, &token)?;
-    sp.finish();
+    if let Some(s) = sp {
+        s.finish();
+    }
 
+    let mut created_repo = false;
     if repo_exists {
         if !yes {
             utils::require_interactive("yes")?;
@@ -1559,45 +1638,103 @@ fn publish_template(
                     .default(false)
                     .interact()?;
             if !confirm {
-                println!("{} Cancelled.", style("*").cyan().bold());
+                if json {
+                    let result = serde_json::json!({
+                        "schema_version": 1,
+                        "action": "publish",
+                        "cancelled": true,
+                        "repo": {
+                            "owner": owner,
+                            "name": repo_name,
+                            "url": format!("https://github.com/{owner}/{repo_name}"),
+                            "exists": true,
+                        },
+                    });
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else {
+                    println!("{} Cancelled.", style("*").cyan().bold());
+                }
                 return Ok(());
             }
         }
     } else {
-        let sp = spinner::Spinner::start("Creating repository:");
+        let sp = if json {
+            None
+        } else {
+            Some(spinner::Spinner::start("Creating repository:"))
+        };
         publish::create_github_repo(&repo_name, desc, private, org, &token)?;
-        sp.finish();
+        if let Some(s) = sp {
+            s.finish();
+        }
+        created_repo = true;
+        if !json {
+            println!(
+                "  {} Created repository {}/{}",
+                style("✅").green().bold(),
+                owner,
+                repo_name
+            );
+        }
+    }
+
+    let sp = if json {
+        None
+    } else {
+        Some(spinner::Spinner::start("Setting repository topics:"))
+    };
+    publish::set_repo_topic(&owner, &repo_name, "fledge-template", &token)?;
+    if let Some(s) = sp {
+        s.finish();
+    }
+    if !json {
         println!(
-            "  {} Created repository {}/{}",
+            "  {} Set {} topic",
             style("✅").green().bold(),
-            owner,
-            repo_name
+            style("fledge-template").cyan()
         );
     }
 
-    let sp = spinner::Spinner::start("Setting repository topics:");
-    publish::set_repo_topic(&owner, &repo_name, "fledge-template", &token)?;
-    sp.finish();
-    println!(
-        "  {} Set {} topic",
-        style("✅").green().bold(),
-        style("fledge-template").cyan()
-    );
-
-    let sp = spinner::Spinner::start("Pushing template files:");
+    let sp = if json {
+        None
+    } else {
+        Some(spinner::Spinner::start("Pushing template files:"))
+    };
     publish::push_directory(&path, &owner, &repo_name, &token)?;
-    sp.finish();
-    println!("  {} Pushed template files", style("✅").green().bold());
+    if let Some(s) = sp {
+        s.finish();
+    }
 
-    println!(
-        "\n{} Published! Use with:\n\n  {}",
-        style("✅").green().bold(),
-        style(format!(
-            "fledge templates init --template {}/{}",
-            owner, repo_name
-        ))
-        .cyan()
-    );
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "publish",
+            "repo": {
+                "owner": owner,
+                "name": repo_name,
+                "url": format!("https://github.com/{owner}/{repo_name}"),
+                "created": created_repo,
+                "private": private,
+            },
+            "template": {
+                "description": desc,
+            },
+            "topic": "fledge-template",
+            "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("  {} Pushed template files", style("✅").green().bold());
+        println!(
+            "\n{} Published! Use with:\n\n  {}",
+            style("✅").green().bold(),
+            style(format!(
+                "fledge templates init --template {}/{}",
+                owner, repo_name
+            ))
+            .cyan()
+        );
+    }
 
     Ok(())
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -146,9 +146,11 @@ pub fn run(opts: PluginOptions) -> Result<()> {
             source,
             force,
             defaults,
-        } => install_action(source.as_deref(), force, defaults),
-        PluginAction::Remove { name } => remove_plugin(&name),
-        PluginAction::Update { name, defaults } => update_plugins(name.as_deref(), defaults),
+        } => install_action(source.as_deref(), force, defaults, opts.json),
+        PluginAction::Remove { name } => remove_plugin(&name, opts.json),
+        PluginAction::Update { name, defaults } => {
+            update_plugins(name.as_deref(), defaults, opts.json)
+        }
         PluginAction::List => list_plugins(opts.json),
         PluginAction::Audit => audit_plugins(opts.json),
         PluginAction::Search {
@@ -440,96 +442,146 @@ fn validate_plugin_name(name: &str) -> Result<()> {
 /// single-source path from the `--defaults` bulk-install path so each
 /// caller stays simple. Reports a per-plugin pass/fail count when
 /// installing the bundle so a single bad repo doesn't abort the rest.
-fn install_action(source: Option<&str>, force: bool, defaults: bool) -> Result<()> {
+fn install_action(source: Option<&str>, force: bool, defaults: bool, json: bool) -> Result<()> {
     if defaults {
         if source.is_some() {
             bail!("--defaults installs the curated set; do not pass a source ref alongside it.");
         }
-        return install_defaults(force);
+        return install_defaults(force, json);
     }
     let source = source.ok_or_else(|| {
         anyhow::anyhow!(
             "Either pass a source ref (owner/repo[@ref]) or use --defaults to install the curated set."
         )
     })?;
-    install_plugin(source, force)
+    let report = install_plugin(source, force, json)?;
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "install",
+            "scope": "single",
+            "installed": [report],
+            "failed": [],
+            "summary": { "total": 1, "installed": 1, "failed": 0 },
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    }
+    Ok(())
 }
 
 /// Install every entry in `DEFAULT_PLUGINS`. Failures are collected and
 /// reported at the end — one broken default doesn't block the rest, so
 /// users on slow networks or with one transient 403 still get the
 /// remaining plugins installed.
-fn install_defaults(force: bool) -> Result<()> {
-    println!(
-        "{} Installing {} default plugins...",
-        style("*").cyan().bold(),
-        DEFAULT_PLUGINS.len()
-    );
+fn install_defaults(force: bool, json: bool) -> Result<()> {
+    if !json {
+        println!(
+            "{} Installing {} default plugins...",
+            style("*").cyan().bold(),
+            DEFAULT_PLUGINS.len()
+        );
+    }
 
-    let mut installed: Vec<&str> = Vec::new();
+    let mut installed: Vec<serde_json::Value> = Vec::new();
+    let mut installed_sources: Vec<&str> = Vec::new();
     let mut failed: Vec<(&str, String)> = Vec::new();
 
     for source in DEFAULT_PLUGINS {
-        println!();
-        println!("  {} {}", style("→").dim(), style(source).cyan());
-        match install_plugin(source, force) {
-            Ok(()) => installed.push(source),
+        if !json {
+            println!();
+            println!("  {} {}", style("→").dim(), style(source).cyan());
+        }
+        match install_plugin(source, force, json) {
+            Ok(report) => {
+                installed.push(report);
+                installed_sources.push(source);
+            }
             Err(e) => failed.push((source, e.to_string())),
         }
     }
 
-    println!();
-    println!(
-        "{} {} of {} default plugins installed.",
-        if failed.is_empty() {
-            style("✅").green().bold()
-        } else {
-            style("⚠️").yellow().bold()
-        },
-        installed.len(),
-        DEFAULT_PLUGINS.len()
-    );
+    if !json {
+        println!();
+        println!(
+            "{} {} of {} default plugins installed.",
+            if failed.is_empty() {
+                style("✅").green().bold()
+            } else {
+                style("⚠️").yellow().bold()
+            },
+            installed_sources.len(),
+            DEFAULT_PLUGINS.len()
+        );
+
+        if !failed.is_empty() {
+            println!();
+            println!("Failures:");
+            for (source, err) in &failed {
+                println!("  {} {} — {}", style("✗").red(), style(source).cyan(), err);
+            }
+        }
+    }
+
+    if json {
+        let failed_json: Vec<serde_json::Value> = failed
+            .iter()
+            .map(|(source, err)| serde_json::json!({ "source": source, "error": err }))
+            .collect();
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "install",
+            "scope": "defaults",
+            "installed": installed,
+            "failed": failed_json,
+            "summary": {
+                "total": DEFAULT_PLUGINS.len(),
+                "installed": installed_sources.len(),
+                "failed": failed.len(),
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    }
 
     if !failed.is_empty() {
-        println!();
-        println!("Failures:");
-        for (source, err) in &failed {
-            println!("  {} {} — {}", style("✗").red(), style(source).cyan(), err);
-        }
         bail!("{} default plugin(s) failed to install.", failed.len());
     }
 
     Ok(())
 }
 
-fn install_plugin(source: &str, force: bool) -> Result<()> {
-    let force = force || crate::utils::is_non_interactive();
+/// Install a single plugin. Returns a JSON-serializable report describing
+/// what was installed; the caller is responsible for printing the JSON
+/// envelope (so single-install and bulk-install share one shape).
+fn install_plugin(source: &str, force: bool, json: bool) -> Result<serde_json::Value> {
+    let force = force || crate::utils::is_non_interactive() || json;
     let (_, git_ref) = parse_source_ref(source);
     let url = normalize_source(source);
     let repo_name = extract_name_from_source(source);
     validate_plugin_name(&repo_name)?;
 
     let tier = determine_trust_tier(source);
-    println!(
-        "\n{} Installing plugin from: {} [{}]",
-        style("!").yellow().bold(),
-        style(&url).cyan(),
-        tier.styled_label()
-    );
-    if tier == TrustTier::Official {
+    if !json {
         println!(
-            "  {} This is an official CorvidLabs plugin.",
-            style("✓").green()
+            "\n{} Installing plugin from: {} [{}]",
+            style("!").yellow().bold(),
+            style(&url).cyan(),
+            tier.styled_label()
         );
-    } else {
-        println!(
-            "  {} Plugins can execute arbitrary code on your system.",
-            style("*").yellow()
-        );
-        println!(
-            "  {} Only install plugins from sources you trust.\n",
-            style("*").yellow()
-        );
+        if tier == TrustTier::Official {
+            println!(
+                "  {} This is an official CorvidLabs plugin.",
+                style("✓").green()
+            );
+        } else {
+            println!(
+                "  {} Plugins can execute arbitrary code on your system.",
+                style("*").yellow()
+            );
+            println!(
+                "  {} Only install plugins from sources you trust.\n",
+                style("*").yellow()
+            );
+        }
     }
 
     if !force {
@@ -569,11 +621,15 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
         fs::remove_dir_all(&plugin_dir).context("removing existing plugin")?;
     }
 
-    let clone_msg = match git_ref {
-        Some(r) => format!("Cloning {}@{}:", &url, r),
-        None => format!("Cloning {}:", &url),
+    let sp = if json {
+        None
+    } else {
+        let clone_msg = match git_ref {
+            Some(r) => format!("Cloning {}@{}:", &url, r),
+            None => format!("Cloning {}:", &url),
+        };
+        Some(crate::spinner::Spinner::start(&clone_msg))
     };
-    let sp = crate::spinner::Spinner::start(&clone_msg);
 
     let mut clone_args = vec!["clone"];
     if git_ref.is_none() {
@@ -591,7 +647,9 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
 
     let status = cmd.status().context("running git clone")?;
 
-    sp.finish();
+    if let Some(s) = sp {
+        s.finish();
+    }
 
     if !status.success() {
         bail!(
@@ -636,23 +694,25 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
     let caps = &manifest.capabilities;
     let has_caps = caps.exec || caps.store || caps.metadata;
     if has_caps && manifest.plugin.protocol.is_some() {
-        println!("\n  {} Requested capabilities:", style("*").cyan().bold());
-        if caps.exec {
-            println!("    {} exec — run shell commands", style("•").yellow());
+        if !json {
+            println!("\n  {} Requested capabilities:", style("*").cyan().bold());
+            if caps.exec {
+                println!("    {} exec — run shell commands", style("•").yellow());
+            }
+            if caps.store {
+                println!(
+                    "    {} store — persist data between runs",
+                    style("•").yellow()
+                );
+            }
+            if caps.metadata {
+                println!(
+                    "    {} metadata — read project metadata and environment",
+                    style("•").yellow()
+                );
+            }
+            println!();
         }
-        if caps.store {
-            println!(
-                "    {} store — persist data between runs",
-                style("•").yellow()
-            );
-        }
-        if caps.metadata {
-            println!(
-                "    {} metadata — read project metadata and environment",
-                style("•").yellow()
-            );
-        }
-        println!();
         if force {
             eprintln!(
                 "  {} Capabilities auto-granted via --force",
@@ -700,40 +760,50 @@ fn install_plugin(source: &str, force: bool) -> Result<()> {
     };
 
     if let Some(idx) = existing {
-        registry.plugins[idx] = entry;
+        registry.plugins[idx] = entry.clone();
     } else {
-        registry.plugins.push(entry);
+        registry.plugins.push(entry.clone());
     }
     save_registry(&registry)?;
 
-    if let Some(ref pinned) = git_ref {
-        println!(
-            "{} Installed {} v{} (pinned to {})",
-            style("✅").green().bold(),
-            style(&manifest.plugin.name).green(),
-            manifest.plugin.version,
-            style(pinned).cyan()
-        );
-    } else {
-        println!(
-            "{} Installed {} v{}",
-            style("✅").green().bold(),
-            style(&manifest.plugin.name).green(),
-            manifest.plugin.version
-        );
-    }
-    if !command_names.is_empty() {
-        println!("  Commands: {}", style(command_names.join(", ")).cyan());
+    if !json {
+        if let Some(ref pinned) = git_ref {
+            println!(
+                "{} Installed {} v{} (pinned to {})",
+                style("✅").green().bold(),
+                style(&manifest.plugin.name).green(),
+                manifest.plugin.version,
+                style(pinned).cyan()
+            );
+        } else {
+            println!(
+                "{} Installed {} v{}",
+                style("✅").green().bold(),
+                style(&manifest.plugin.name).green(),
+                manifest.plugin.version
+            );
+        }
+        if !command_names.is_empty() {
+            println!("  Commands: {}", style(command_names.join(", ")).cyan());
+        }
     }
 
     if let Some(hook) = &manifest.hooks.post_install {
         run_hook(&plugin_dir, hook, "post_install")?;
     }
 
-    Ok(())
+    Ok(serde_json::json!({
+        "name": entry.name,
+        "source": entry.source,
+        "version": entry.version,
+        "tier": tier.label(),
+        "commands": entry.commands,
+        "pinned_ref": entry.pinned_ref,
+        "capabilities": entry.capabilities,
+    }))
 }
 
-fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
+fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> Result<()> {
     if defaults && name.is_some() {
         bail!("--defaults updates the curated set; do not pass a plugin name alongside it.");
     }
@@ -758,19 +828,34 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
             .filter(|p| is_default(&p.source))
             .collect();
         if matched.is_empty() {
-            println!(
-                "{} No default plugins are installed. Run {} first.",
-                style("*").cyan().bold(),
-                style("fledge plugins install --defaults").cyan()
-            );
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "schema_version": 1,
+                        "action": "update",
+                        "scope": "defaults",
+                        "results": [],
+                        "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
+                    }))?
+                );
+            } else {
+                println!(
+                    "{} No default plugins are installed. Run {} first.",
+                    style("*").cyan().bold(),
+                    style("fledge plugins install --defaults").cyan()
+                );
+            }
             return Ok(());
         }
-        println!(
-            "{} Updating {} of {} default plugins...",
-            style("*").cyan().bold(),
-            matched.len(),
-            DEFAULT_PLUGINS.len()
-        );
+        if !json {
+            println!(
+                "{} Updating {} of {} default plugins...",
+                style("*").cyan().bold(),
+                matched.len(),
+                DEFAULT_PLUGINS.len()
+            );
+        }
         matched
     } else {
         match name {
@@ -784,7 +869,20 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
             }
             None => {
                 if registry.plugins.is_empty() {
-                    println!("{} No plugins installed.", style("*").cyan().bold());
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "schema_version": 1,
+                                "action": "update",
+                                "scope": "all",
+                                "results": [],
+                                "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
+                            }))?
+                        );
+                    } else {
+                        println!("{} No plugins installed.", style("*").cyan().bold());
+                    }
                     return Ok(());
                 }
                 registry.plugins.iter().collect()
@@ -792,15 +890,27 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
         }
     };
 
+    // Collect results in JSON mode for a single structured output at the end.
+    // Each entry has `name`, `status` ("updated" | "skipped" | "failed"),
+    // and a free-form `detail` (e.g. version bumped to, or error reason).
+    let mut results: Vec<serde_json::Value> = Vec::new();
+
     for entry in &targets {
         let plugin_dir = plugins_dir().join(&entry.name);
         if !plugin_dir.exists() {
-            println!(
-                "  {} {} — directory missing, reinstall with {}",
-                style("⚠️").yellow(),
-                style(&entry.name).yellow(),
-                style(format!("fledge plugin install {} --force", entry.source)).cyan()
-            );
+            if !json {
+                println!(
+                    "  {} {} — directory missing, reinstall with {}",
+                    style("⚠️").yellow(),
+                    style(&entry.name).yellow(),
+                    style(format!("fledge plugin install {} --force", entry.source)).cyan()
+                );
+            }
+            results.push(serde_json::json!({
+                "name": entry.name,
+                "status": "failed",
+                "detail": "directory missing — reinstall required",
+            }));
             continue;
         }
 
@@ -808,32 +918,56 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
             let latest = find_latest_tag(&plugin_dir);
             match latest {
                 Some(ref tag) if tag != pinned => {
-                    println!(
-                        "  {} {} — pinned to {}, latest tag is {}. To upgrade:\n    {}",
-                        style("*").cyan().bold(),
-                        style(&entry.name).cyan(),
-                        style(pinned).dim(),
-                        style(tag).green(),
-                        style(format!(
-                            "fledge plugin install {}@{} --force",
-                            entry.source, tag
-                        ))
-                        .cyan()
-                    );
+                    if !json {
+                        println!(
+                            "  {} {} — pinned to {}, latest tag is {}. To upgrade:\n    {}",
+                            style("*").cyan().bold(),
+                            style(&entry.name).cyan(),
+                            style(pinned).dim(),
+                            style(tag).green(),
+                            style(format!(
+                                "fledge plugin install {}@{} --force",
+                                entry.source, tag
+                            ))
+                            .cyan()
+                        );
+                    }
+                    results.push(serde_json::json!({
+                        "name": entry.name,
+                        "status": "skipped",
+                        "detail": format!("pinned to {pinned}, latest tag is {tag} — reinstall to upgrade"),
+                        "pinned_ref": pinned,
+                        "latest_tag": tag,
+                    }));
                 }
                 _ => {
-                    println!(
-                        "  {} {} — pinned to {}, already up to date.",
-                        style("✅").green().bold(),
-                        style(&entry.name).green(),
-                        style(pinned).dim()
-                    );
+                    if !json {
+                        println!(
+                            "  {} {} — pinned to {}, already up to date.",
+                            style("✅").green().bold(),
+                            style(&entry.name).green(),
+                            style(pinned).dim()
+                        );
+                    }
+                    results.push(serde_json::json!({
+                        "name": entry.name,
+                        "status": "skipped",
+                        "detail": format!("pinned to {pinned}, already up to date"),
+                        "pinned_ref": pinned,
+                    }));
                 }
             }
             continue;
         }
 
-        let sp = crate::spinner::Spinner::start(&format!("Updating {}:", &entry.name));
+        let sp = if json {
+            None
+        } else {
+            Some(crate::spinner::Spinner::start(&format!(
+                "Updating {}:",
+                &entry.name
+            )))
+        };
 
         let mut cmd = Command::new("git");
         cmd.args(["pull", "--ff-only"])
@@ -846,15 +980,24 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
             .status()
             .with_context(|| format!("updating {}", entry.name))?;
 
-        sp.finish();
+        if let Some(s) = sp {
+            s.finish();
+        }
 
         if !status.success() {
-            println!(
-                "  {} {} — git pull failed, try reinstalling with {}",
-                style("⚠️").yellow(),
-                style(&entry.name).yellow(),
-                style(format!("fledge plugin install {} --force", entry.source)).cyan()
-            );
+            if !json {
+                println!(
+                    "  {} {} — git pull failed, try reinstalling with {}",
+                    style("⚠️").yellow(),
+                    style(&entry.name).yellow(),
+                    style(format!("fledge plugin install {} --force", entry.source)).cyan()
+                );
+            }
+            results.push(serde_json::json!({
+                "name": entry.name,
+                "status": "failed",
+                "detail": "git pull failed — reinstall required",
+            }));
             continue;
         }
 
@@ -880,17 +1023,59 @@ fn update_plugins(name: Option<&str>, defaults: bool) -> Result<()> {
             let mut reg = load_registry()?;
             if let Some(e) = reg.plugins.iter_mut().find(|p| p.name == entry.name) {
                 e.version = manifest.plugin.version.clone();
-                e.commands = new_cmds;
+                e.commands = new_cmds.clone();
             }
             save_registry(&reg)?;
 
-            println!(
-                "  {} {} → v{}",
-                style("✅").green().bold(),
-                style(&entry.name).green(),
-                manifest.plugin.version
-            );
+            if !json {
+                println!(
+                    "  {} {} → v{}",
+                    style("✅").green().bold(),
+                    style(&entry.name).green(),
+                    manifest.plugin.version
+                );
+            }
+            results.push(serde_json::json!({
+                "name": entry.name,
+                "status": "updated",
+                "version": manifest.plugin.version,
+                "commands": new_cmds,
+            }));
+        } else {
+            results.push(serde_json::json!({
+                "name": entry.name,
+                "status": "updated",
+                "detail": "no plugin.toml — git pull only",
+            }));
         }
+    }
+
+    if json {
+        let total = results.len();
+        let count = |s: &str| results.iter().filter(|r| r["status"] == s).count();
+        let summary = serde_json::json!({
+            "total": total,
+            "updated": count("updated"),
+            "skipped": count("skipped"),
+            "failed": count("failed"),
+        });
+        let scope = if defaults {
+            "defaults"
+        } else if name.is_some() {
+            "single"
+        } else {
+            "all"
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "action": "update",
+                "scope": scope,
+                "results": results,
+                "summary": summary,
+            }))?
+        );
     }
 
     Ok(())
@@ -921,7 +1106,7 @@ fn find_latest_tag(repo_dir: &Path) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn remove_plugin(name: &str) -> Result<()> {
+fn remove_plugin(name: &str, json: bool) -> Result<()> {
     let mut registry = load_registry()?;
     let idx = registry
         .plugins
@@ -971,14 +1156,31 @@ fn remove_plugin(name: &str) -> Result<()> {
     }
 
     let removed_name = entry.name.clone();
+    let removed_source = entry.source.clone();
+    let removed_version = entry.version.clone();
+    let removed_commands = entry.commands.clone();
     registry.plugins.remove(idx);
     save_registry(&registry)?;
 
-    println!(
-        "{} Removed {}",
-        style("✅").green().bold(),
-        style(&removed_name).green()
-    );
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "remove",
+            "removed": {
+                "name": removed_name,
+                "source": removed_source,
+                "version": removed_version,
+                "commands": removed_commands,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "{} Removed {}",
+            style("✅").green().bold(),
+            style(&removed_name).green()
+        );
+    }
 
     Ok(())
 }
@@ -1989,7 +2191,7 @@ mod tests {
 
     #[test]
     fn install_action_rejects_source_with_defaults() {
-        let err = install_action(Some("someone/foo"), false, true)
+        let err = install_action(Some("someone/foo"), false, true, false)
             .unwrap_err()
             .to_string();
         assert!(err.contains("--defaults"));
@@ -1997,13 +2199,17 @@ mod tests {
 
     #[test]
     fn install_action_requires_source_or_defaults() {
-        let err = install_action(None, false, false).unwrap_err().to_string();
+        let err = install_action(None, false, false, false)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("--defaults"));
     }
 
     #[test]
     fn update_plugins_rejects_name_with_defaults() {
-        let err = update_plugins(Some("foo"), true).unwrap_err().to_string();
+        let err = update_plugins(Some("foo"), true, false)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("--defaults"));
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -165,13 +165,20 @@ pub fn run(opts: PluginOptions) -> Result<()> {
             private,
             description,
             yes,
-        } => publish_plugin(&path, org.as_deref(), private, description.as_deref(), yes),
+        } => publish_plugin(
+            &path,
+            org.as_deref(),
+            private,
+            description.as_deref(),
+            yes,
+            opts.json,
+        ),
         PluginAction::Create {
             name,
             output,
             description,
             yes,
-        } => create_plugin(&name, &output, description.as_deref(), yes),
+        } => create_plugin(&name, &output, description.as_deref(), yes, opts.json),
         PluginAction::Validate { path, strict, json } => validate_plugin(&path, strict, json),
     }
 }
@@ -1740,8 +1747,14 @@ fn make_executable(_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn create_plugin(name: &str, output: &Path, description: Option<&str>, yes: bool) -> Result<()> {
-    let yes = yes || crate::utils::is_non_interactive();
+fn create_plugin(
+    name: &str,
+    output: &Path,
+    description: Option<&str>,
+    yes: bool,
+    json: bool,
+) -> Result<()> {
+    let yes = yes || crate::utils::is_non_interactive() || json;
     let target = output.join(name);
 
     if target.exists() {
@@ -1855,26 +1868,45 @@ See [fledge plugin docs](https://github.com/CorvidLabs/fledge) for the full plug
     )
     .context("writing .gitignore")?;
 
-    println!(
-        "\n{} Created plugin at {}",
-        style("✅").green().bold(),
-        style(target.display()).cyan()
-    );
-    println!(
-        "\n  {} Edit manifest in {}",
-        style("1.").dim(),
-        style("plugin.toml").green()
-    );
-    println!(
-        "  {} Validate with: {}",
-        style("2.").dim(),
-        style(format!("fledge plugins validate ./{name}")).cyan()
-    );
-    println!(
-        "  {} Publish with: {}",
-        style("3.").dim(),
-        style(format!("fledge plugins publish ./{name}")).cyan()
-    );
+    let files_created = vec![
+        "plugin.toml".to_string(),
+        format!("bin/{name}"),
+        "README.md".to_string(),
+        ".gitignore".to_string(),
+    ];
+
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "create",
+            "path": target.display().to_string(),
+            "name": name,
+            "description": desc,
+            "files_created": files_created,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "\n{} Created plugin at {}",
+            style("✅").green().bold(),
+            style(target.display()).cyan()
+        );
+        println!(
+            "\n  {} Edit manifest in {}",
+            style("1.").dim(),
+            style("plugin.toml").green()
+        );
+        println!(
+            "  {} Validate with: {}",
+            style("2.").dim(),
+            style(format!("fledge plugins validate ./{name}")).cyan()
+        );
+        println!(
+            "  {} Publish with: {}",
+            style("3.").dim(),
+            style(format!("fledge plugins publish ./{name}")).cyan()
+        );
+    }
 
     Ok(())
 }
@@ -2026,8 +2058,9 @@ fn publish_plugin(
     private: bool,
     description: Option<&str>,
     yes: bool,
+    json: bool,
 ) -> Result<()> {
-    let yes = yes || crate::utils::is_non_interactive();
+    let yes = yes || crate::utils::is_non_interactive() || json;
     let config = crate::config::Config::load()?;
     let token = config.github_token().ok_or_else(|| {
         anyhow::anyhow!(
@@ -2055,18 +2088,27 @@ fn publish_plugin(
         None => crate::publish::get_authenticated_user(&token)?,
     };
 
-    println!(
-        "{} Publishing plugin {} as {}/{}",
-        style("➡️").cyan().bold(),
-        style(path.display()).dim(),
-        style(&owner).green(),
-        style(repo_name).green()
-    );
+    if !json {
+        println!(
+            "{} Publishing plugin {} as {}/{}",
+            style("➡️").cyan().bold(),
+            style(path.display()).dim(),
+            style(&owner).green(),
+            style(repo_name).green()
+        );
+    }
 
-    let sp = crate::spinner::Spinner::start("Checking repository:");
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Checking repository:"))
+    };
     let repo_exists = crate::publish::check_repo_exists(&owner, repo_name, &token)?;
-    sp.finish();
+    if let Some(s) = sp {
+        s.finish();
+    }
 
+    let mut created_repo = false;
     if repo_exists {
         if !yes {
             crate::utils::require_interactive("yes")?;
@@ -2080,41 +2122,101 @@ fn publish_plugin(
                     .interact()?;
 
             if !confirm {
-                println!("{} Cancelled.", style("*").cyan().bold());
+                if json {
+                    let result = serde_json::json!({
+                        "schema_version": 1,
+                        "action": "publish",
+                        "cancelled": true,
+                        "repo": {
+                            "owner": owner,
+                            "name": repo_name,
+                            "url": format!("https://github.com/{owner}/{repo_name}"),
+                            "exists": true,
+                        },
+                    });
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else {
+                    println!("{} Cancelled.", style("*").cyan().bold());
+                }
                 return Ok(());
             }
         }
     } else {
-        let sp = crate::spinner::Spinner::start("Creating repository:");
+        let sp = if json {
+            None
+        } else {
+            Some(crate::spinner::Spinner::start("Creating repository:"))
+        };
         crate::publish::create_github_repo(repo_name, desc, private, org, &token)?;
-        sp.finish();
+        if let Some(s) = sp {
+            s.finish();
+        }
+        created_repo = true;
+        if !json {
+            println!(
+                "  {} Created repository {}/{}",
+                style("✅").green().bold(),
+                owner,
+                repo_name
+            );
+        }
+    }
+
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Setting repository topics:"))
+    };
+    crate::publish::set_repo_topic(&owner, repo_name, "fledge-plugin", &token)?;
+    if let Some(s) = sp {
+        s.finish();
+    }
+    if !json {
         println!(
-            "  {} Created repository {}/{}",
+            "  {} Set {} topic",
             style("✅").green().bold(),
-            owner,
-            repo_name
+            style("fledge-plugin").cyan()
         );
     }
 
-    let sp = crate::spinner::Spinner::start("Setting repository topics:");
-    crate::publish::set_repo_topic(&owner, repo_name, "fledge-plugin", &token)?;
-    sp.finish();
-    println!(
-        "  {} Set {} topic",
-        style("✅").green().bold(),
-        style("fledge-plugin").cyan()
-    );
-
-    let sp = crate::spinner::Spinner::start("Pushing plugin files:");
+    let sp = if json {
+        None
+    } else {
+        Some(crate::spinner::Spinner::start("Pushing plugin files:"))
+    };
     crate::publish::push_directory(&path, &owner, repo_name, &token)?;
-    sp.finish();
-    println!("  {} Pushed plugin files", style("✅").green().bold());
+    if let Some(s) = sp {
+        s.finish();
+    }
 
-    println!(
-        "\n{} Published! Install with:\n\n  {}",
-        style("✅").green().bold(),
-        style(format!("fledge plugins install {}/{}", owner, repo_name)).cyan()
-    );
+    if json {
+        let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "publish",
+            "repo": {
+                "owner": owner,
+                "name": repo_name,
+                "url": format!("https://github.com/{owner}/{repo_name}"),
+                "created": created_repo,
+                "private": private,
+            },
+            "plugin": {
+                "name": manifest.plugin.name,
+                "version": manifest.plugin.version,
+                "description": desc,
+            },
+            "topic": "fledge-plugin",
+            "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("  {} Pushed plugin files", style("✅").green().bold());
+        println!(
+            "\n{} Published! Install with:\n\n  {}",
+            style("✅").green().bold(),
+            style(format!("fledge plugins install {}/{}", owner, repo_name)).cyan()
+        );
+    }
 
     Ok(())
 }
@@ -2719,7 +2821,7 @@ version = "0.1.0"
     #[test]
     fn create_plugin_scaffolds_files() {
         let tmp = tempfile::TempDir::new().unwrap();
-        create_plugin("my-plugin", tmp.path(), Some("Test plugin"), true).unwrap();
+        create_plugin("my-plugin", tmp.path(), Some("Test plugin"), true, false).unwrap();
 
         let target = tmp.path().join("my-plugin");
         assert!(target.join("plugin.toml").exists());
@@ -2739,7 +2841,7 @@ version = "0.1.0"
     fn create_plugin_fails_if_exists() {
         let tmp = tempfile::TempDir::new().unwrap();
         fs::create_dir(tmp.path().join("existing")).unwrap();
-        let result = create_plugin("existing", tmp.path(), None, true);
+        let result = create_plugin("existing", tmp.path(), None, true, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
     }
@@ -2747,7 +2849,7 @@ version = "0.1.0"
     #[test]
     fn validate_valid_plugin() {
         let tmp = tempfile::TempDir::new().unwrap();
-        create_plugin("test-plugin", tmp.path(), Some("Test"), true).unwrap();
+        create_plugin("test-plugin", tmp.path(), Some("Test"), true, false).unwrap();
 
         let result = validate_plugin(&tmp.path().join("test-plugin"), false, false);
         assert!(result.is_ok());
@@ -2835,7 +2937,7 @@ build = "cargo build --release"
     #[test]
     fn validate_json_output() {
         let tmp = tempfile::TempDir::new().unwrap();
-        create_plugin("json-test", tmp.path(), Some("Test"), true).unwrap();
+        create_plugin("json-test", tmp.path(), Some("Test"), true, false).unwrap();
 
         let result = validate_plugin(&tmp.path().join("json-test"), false, true);
         assert!(result.is_ok());

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -673,6 +673,44 @@ fn cli_plugin_update_help() {
     assert!(stdout.contains("Update installed plugins"));
 }
 
+#[test]
+fn cli_plugin_update_json_emits_envelope() {
+    // Isolate HOME to a tmpdir so we don't actually update the user's
+    // real plugins — and so the registry is empty and we get the
+    // "no plugins installed" envelope shape.
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = cargo_bin();
+    let output = std::process::Command::new(&bin)
+        .args(["plugin", "update", "--json"])
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "plugins update --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("update"));
+    assert!(parsed["results"].is_array());
+    assert!(parsed["summary"]["total"].is_u64());
+}
+
+#[test]
+fn cli_plugin_remove_json_error_path_returns_nonzero() {
+    // Errors still go to stderr (anyhow); --json should not turn an
+    // error into a success exit code. This guards against silent
+    // misclassification by agents that only check exit codes.
+    let output = run_fledge(&["plugin", "remove", "definitely-not-installed", "--json"]);
+    assert!(
+        !output.status.success(),
+        "remove of nonexistent plugin must exit nonzero even with --json"
+    );
+}
+
 // ──────────────────────────────────────────────────────────
 
 // MARK: - external / unknown subcommand

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -711,6 +711,173 @@ fn cli_plugin_remove_json_error_path_returns_nonzero() {
     );
 }
 
+// MARK: - tier B: --json envelopes for plugins create, lanes init/create,
+// and templates list. (publish/import paths require GitHub network and live
+// state — out of scope for the cheap-to-run integration suite.)
+
+#[test]
+fn cli_plugin_create_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge(&[
+        "plugin",
+        "create",
+        "json-test-plug",
+        "--output",
+        tmp.path().to_str().unwrap(),
+        "--yes",
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "plugin create --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("create"));
+    assert_eq!(parsed["name"].as_str(), Some("json-test-plug"));
+    assert!(parsed["files_created"].is_array());
+}
+
+#[test]
+fn cli_lanes_create_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge(&[
+        "lane",
+        "create",
+        "json-test-lanes",
+        "--output",
+        tmp.path().to_str().unwrap(),
+        "--yes",
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "lane create --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("create"));
+    assert_eq!(parsed["name"].as_str(), Some("json-test-lanes"));
+}
+
+#[test]
+fn cli_lanes_init_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[tasks]\ntest = \"echo test\"\n",
+    )
+    .unwrap();
+    let output = run_fledge_in(tmp.path(), &["lane", "init", "--json"]);
+    assert!(
+        output.status.success(),
+        "lane init --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("init"));
+    assert_eq!(parsed["file"].as_str(), Some("fledge.toml"));
+    assert!(parsed["lanes_added"].is_array());
+}
+
+#[test]
+fn cli_lanes_init_json_error_path_returns_nonzero() {
+    // No fledge.toml — lane init must exit nonzero even with --json.
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge_in(tmp.path(), &["lane", "init", "--json"]);
+    assert!(
+        !output.status.success(),
+        "lane init in dir without fledge.toml must exit nonzero even with --json"
+    );
+}
+
+#[test]
+fn cli_templates_list_json_emits_envelope() {
+    let output = run_fledge(&["templates", "list", "--json"]);
+    assert!(
+        output.status.success(),
+        "templates list --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert!(parsed["templates"].is_array());
+    let templates = parsed["templates"].as_array().unwrap();
+    assert!(!templates.is_empty(), "expected built-in templates");
+    // Built-in templates have source: "builtin"
+    assert!(templates.iter().any(|t| t["source"] == "builtin"));
+}
+
+#[test]
+fn cli_templates_create_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge(&[
+        "templates",
+        "create",
+        "json-test-tpl",
+        "--output",
+        tmp.path().to_str().unwrap(),
+        "--yes",
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "templates create --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("create"));
+    assert_eq!(parsed["name"].as_str(), Some("json-test-tpl"));
+    assert!(parsed["files_created"].is_array());
+}
+
+#[test]
+fn cli_templates_init_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge(&[
+        "templates",
+        "init",
+        "json-test-init",
+        "--template",
+        "rust-cli",
+        "--output",
+        tmp.path().to_str().unwrap(),
+        "--no-git",
+        "--no-install",
+        "--yes",
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "templates init --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("init"));
+    assert_eq!(parsed["project"]["name"].as_str(), Some("json-test-init"));
+    assert_eq!(parsed["template"]["name"].as_str(), Some("rust-cli"));
+    assert_eq!(parsed["git_initialized"].as_bool(), Some(false));
+    assert!(parsed["files_created"].is_array());
+    assert!(!parsed["files_created"].as_array().unwrap().is_empty());
+}
+
 // ──────────────────────────────────────────────────────────
 
 // MARK: - external / unknown subcommand


### PR DESCRIPTION
Tier A + Tier B from the multi-model 1.0 readiness review. Closes the JSON-coverage fragmentation flagged by gpt-oss/kimi/minimax (see \`.reviews/review.html\`, gitignored).

## Tier A — bug fix (commit fb181d9)

\`fledge plugins\` had a global \`--json\` that \`install\`, \`remove\`, and \`update\` silently ignored. Agents passing \`--json\` got back ANSI prose. Now each emits \`{schema_version: 1, action, ...}\` envelopes.

## Tier B — additive coverage (commit 523fe33)

10 more subcommands gained \`--json\`. Notably **\`templates list --json\` previously errored with \"unexpected argument\"** — fixed.

| Pillar | Commands now honoring --json |
|---|---|
| plugins | create, publish |
| lanes | init, import, publish, create |
| templates | init, create, **list**, publish |

All emit \`{schema_version: 1, action, ...}\` (or \`{schema_version: 1, <resource>: [...]}\` for \`list\`). Pattern matches the introspect contract from #270.

## Common contract (now uniform across the three pillars)

- Stdout = JSON only in JSON mode
- Stderr = warnings/progress (not suppressed — visible in interactive contexts, ignored by agents)
- JSON mode implies non-interactive (\`force = yes = true\`) — capability/confirmation prompts can't deadlock an agent
- Failure paths still bubble via anyhow → stderr with non-zero exit code
- Cancelled-by-user paths emit \`{cancelled: true}\` for \`publish\` commands (vs. erroring)

## Spec bumps

| Spec | Old → New | What changed |
|---|---|---|
| plugin | v13 → v14 | invariant 11 enumerates create + publish |
| lanes | v10 → v11 | init/import/publish/create JSON shapes documented |
| init | v7 → v8 | new invariant 7 documents JSON envelope contract |
| create_template | v1 → v2 | new invariant 10 documents JSON envelope |
| main | v6 → v7 | templates list/publish JSON shapes (live in main.rs) |

## Tests added

\`tests/main.rs\` — 7 new integration tests covering envelope shape and exit-code contracts:
- cli_plugin_create_json_emits_envelope
- cli_lanes_init_json_emits_envelope (+ error path)
- cli_lanes_create_json_emits_envelope
- cli_templates_list_json_emits_envelope (regression — was erroring)
- cli_templates_create_json_emits_envelope
- cli_templates_init_json_emits_envelope

\`*publish\` and \`lanes import\` would need a live GitHub network + state — out of scope for the cheap integration suite.

## Out of scope (still blocking 1.0)

**Tier C (#272)** — breaking envelope migration: wrapping existing top-level arrays (\`plugins list/audit/search\`, \`lanes list/run/search\`, \`templates search\`) as \`{schema_version: 1, <resource>: [...]}\`. **Last chance to break the shape before 1.0 freezes it.** Should land before tagging 1.0 and ship with an AGENTS.md / docs sweep.

## Pre-existing flake (NOT this PR)

\`src/lanes.rs::tests\` has 7 tests that fail under default \`--test-threads=8\` because one test mutates process cwd. Reproduces on main. Not introduced by this PR; filing separately.

## Test plan

- [x] cargo build, cargo fmt --check, cargo clippy --all-targets -- -D warnings — all clean
- [x] cargo test — 679 unit + 79 integration + per-spec suites, **0 failures** (with --test-threads=1 to avoid pre-existing lanes flake)
- [x] fledge spec check --strict — 29/29 clean
- [x] Manual smoke test of every new --json path
- [ ] Reviewer to spot-check \`fledge templates list --json | jq '.schema_version'\` returns \`1\`
- [ ] Reviewer to confirm \`fledge plugins remove nonexistent --json\` exits non-zero (tier A invariant)
- [ ] After merge: re-run multi-model panel via \`.reviews/run_focused.sh <model>\` for each of qwen3-coder/gpt-oss/kimi/minimax and confirm verdict moves toward GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)