### PR TITLE
fix(json): tighten lanes import + templates list envelopes

### DIFF
--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 13
+version: 14
 status: active
 files:
   - src/lanes.rs
@@ -225,6 +225,7 @@ $ fledge lanes run ci --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 14 | 2026-04-26 | `lanes import --json` envelope tightened: `file` is now always the computed `.fledge/lanes/<safe_name>.toml` path (string, never null), and a new `written: bool` field signals whether the file was actually created (false when every lane was skipped). Previously `file: null` in the all-skipped case implied the path wasn't computable, but it's a pure function of source — null was misleading |
 | 13 | 2026-04-25 | Fix `lanes run --json` prose leak: fledge's own progress prints AND each spawned task's stdout/stderr were going to the agent's stdout, interleaving with the JSON envelope and breaking `--json | jq`. Threaded a `quiet` flag through `execute_task_with_deps` / `execute_inline` / `execute_parallel` / `execute_single_task` / `execute_task_recursive`. In JSON mode prose is suppressed and spawned commands' stdout/stderr are redirected to `/dev/null`. Trade-off: per-step output isn't captured into the JSON record (consumers needing it re-run without `--json`). New regression test `cli_lane_run_json_stdout_is_clean` guards the contract |
 | 12 | 2026-04-25 | **Breaking (tier C, #272):** `lanes list --json`, `lanes search --json`, `lanes run --json`, `lanes validate --json` migrated to `{schema_version: 1, <resource>: [...]}` (or flattened with `schema_version` at top for run/validate). `lanes` for list, `results` for search, run/validate get the field added to the existing object. Last-chance shape break before 1.0 |
 | 11 | 2026-04-25 | Tier B follow-up: `lanes init`, `import`, `publish`, and `create` honour `--json` and emit `{schema_version:1, action, ...}` envelopes. `init` reports `project_type/lanes_added/file`; `import` reports `source/imported/skipped/file`; `publish` reports `repo/lanes_published/topic/import_hint`; `create` reports `path/name/description/files_created`. Failure paths still exit non-zero — `--json` never silently turns failure into success |

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,6 +1,6 @@
 ---
 module: main
-version: 8
+version: 9
 status: active
 files:
   - src/main.rs
@@ -85,11 +85,13 @@ All modules are dependencies — main dispatches to every subcommand module. See
 5. The top-level `--non-interactive` flag (aliased `--ni`) is a clap `global = true` arg, available on every subcommand. When set, or when `FLEDGE_NON_INTERACTIVE` env var is truthy (`1`/`true`/`yes`/`y`/`on`), `utils::set_non_interactive(true)` is called before dispatch, so every prompt site in the dispatched command observes it
 6. `utils::init_non_interactive_from_env()` runs before `Cli::parse()` so the env var is honored even when users don't pass the flag
 7. Tier-B JSON coverage (#271): `templates list` and `templates publish` (handled inline in `main.rs`) honour `--json` and emit a `{schema_version: 1, ...}` envelope on stdout — matching the same envelope contract as `plugins`, `lanes`, `init`, and `create_template`. `templates list --json` returns `{schema_version: 1, templates: [{name, description, source: "builtin"|"local"|"remote", source_ref, path}, ...]}`. `templates publish --json` returns `{schema_version: 1, action: "publish", repo, template, topic, use_hint}` (or `{cancelled: true}` if the user declines an update prompt). Failure paths still exit non-zero in both cases
+8. **Empty-list semantics for `templates list`:** when no templates are configured, both modes succeed (exit 0). JSON mode emits `{schema_version: 1, templates: [], hint: "..."}` with the configuration hint as a string field; non-JSON mode prints a friendly "No templates configured" message followed by the same hint. Previously both modes errored with non-zero exit, which forced agents to special-case a list query into an error path
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 9 | 2026-04-26 | `templates list` empty case now exits 0 in both modes. JSON mode emits `{schema_version: 1, templates: [], hint}`; non-JSON prints "No templates configured" + hint. Previously both bailed with non-zero exit, breaking agents that call `templates list --json` defensively |
 | 8 | 2026-04-25 | **Breaking (tier C, #272):** `templates search --json` migrated from bare top-level array to `{schema_version: 1, results: [...]}`. Last-chance shape break before 1.0 |
 | 7 | 2026-04-25 | Tier-B `--json` envelopes for `templates list` and `templates publish` (handled inline in main.rs). Both emit `{schema_version: 1, ...}` matching the contract used by plugins/lanes/init/create_template. Failure paths still exit non-zero. Closes the gap where `templates list --json` previously errored with "unexpected argument" (#271) |
 | 5 | 2026-04-23 | Add `llm` to depends_on for the provider abstraction that powers `fledge ask` and `fledge review`. No new top-level command; dispatch changes are localized to the Ask/Review variants. |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -1149,6 +1149,17 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
         imported_lanes.push(lane_name.clone());
     }
 
+    let safe_name = format!(
+        "{}-{}{}",
+        owner.to_lowercase(),
+        repo.to_lowercase(),
+        subpath
+            .as_ref()
+            .map(|p| format!("-{}", p.replace('/', "-").to_lowercase()))
+            .unwrap_or_default()
+    );
+    let relative_file = format!(".fledge/lanes/{safe_name}.toml");
+
     if imported_lanes.is_empty() {
         if json {
             let result = serde_json::json!({
@@ -1158,7 +1169,8 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
                 "tier": tier.label(),
                 "imported": [],
                 "skipped": skipped,
-                "file": null,
+                "file": relative_file,
+                "written": false,
             });
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
@@ -1175,16 +1187,6 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
     let lanes_dir = cwd.join(".fledge").join("lanes");
     std::fs::create_dir_all(&lanes_dir).context("creating .fledge/lanes directory")?;
 
-    let safe_name = format!(
-        "{}-{}{}",
-        owner.to_lowercase(),
-        repo.to_lowercase(),
-        subpath
-            .as_ref()
-            .map(|p| format!("-{}", p.replace('/', "-").to_lowercase()))
-            .unwrap_or_default()
-    );
-    let relative_file = format!(".fledge/lanes/{safe_name}.toml");
     let import_path = lanes_dir.join(format!("{safe_name}.toml"));
     std::fs::write(&import_path, import_content.trim_start()).context("writing imported lanes")?;
 
@@ -1197,6 +1199,7 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
             "imported": imported_lanes,
             "skipped": skipped,
             "file": relative_file,
+            "written": true,
         });
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1429,9 +1429,7 @@ fn list_templates(json: bool) -> Result<()> {
         token.as_deref(),
     )?;
 
-    if available.is_empty() {
-        anyhow::bail!("No templates found. Configure template sources via `fledge config add templates.repos <owner/repo>`, add templates to the templates/ directory, or set templates.paths via `fledge config add templates.paths <path>`.");
-    }
+    let hint = "Configure template sources via `fledge config add templates.repos <owner/repo>`, add templates to the templates/ directory, or set templates.paths via `fledge config add templates.paths <path>`.";
 
     if json {
         let entries: Vec<serde_json::Value> = available
@@ -1451,11 +1449,20 @@ fn list_templates(json: bool) -> Result<()> {
                 })
             })
             .collect();
-        let result = serde_json::json!({
+        let mut result = serde_json::json!({
             "schema_version": 1,
             "templates": entries,
         });
+        if available.is_empty() {
+            result["hint"] = serde_json::Value::String(hint.to_string());
+        }
         println!("{}", serde_json::to_string_pretty(&result)?);
+    } else if available.is_empty() {
+        println!(
+            "{} No templates configured.\n\n  {}",
+            style("*").cyan().bold(),
+            style(hint).dim()
+        );
     } else {
         println!("{}", style("Available templates:").bold());
         for t in &available {


### PR DESCRIPTION
## Summary

Two follow-ups from the multi-model review on #275 (which is otherwise redundant with already-merged #273 — see closure note there).

- **`lanes import --json`**: always emit a string `file` path (the computed `.fledge/lanes/<safe>.toml` target) instead of `null` when every lane was skipped. New `written: bool` field distinguishes the no-op case. The path is a pure function of source owner/repo/subpath, so `null` was misleading — the file is *where* this import targets, not *what* was written.
- **`templates list`**: empty case now exits 0 in both modes. JSON returns `{schema_version: 1, templates: [], hint}`; CLI prints a friendly "No templates configured" message + the same hint. Previously both modes bailed non-zero, forcing agents to special-case a list query into an error path.

## Spec bumps

- `lanes` v13 → v14: documents the `file` (always-string) + `written: bool` invariant
- `main` v8 → v9: documents the `templates list` empty-list semantics

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test main` — 79/79 pass
- [x] `cargo test --test lanes` — 8/8 pass
- [x] `cargo test --test templates` — 17/17 pass
- [x] `cargo test --bin fledge -- lanes::` — 57/57 pass
- [x] `fledge spec check --strict` — 29/29 clean
- [x] Manual smoke: `fledge templates list --json` returns `schema_version: 1` envelope with builtin templates

## Why not part of #275?

PR #275 conflicts with `main` (mergeStateStatus: DIRTY) because the same tier-B JSON coverage shipped in #273. Resolving 25 files of overlap to land these two small fixes would be churn. Direct fix on `main` is cleaner; #275 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)