### PR TITLE
fix(lanes): honor --json on dry-run path (1.0 contract)

### DIFF
--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 14
+version: 15
 status: active
 files:
   - src/lanes.rs
@@ -188,9 +188,13 @@ $ fledge lanes publish
 ✅ . — valid (2 lanes)
 ➡️ Publishing 2 lanes as owner/my-lanes
 
-# Run a lane with JSON output
+# Run a lane with JSON output (each step record has step/name/success/duration_ms/error)
 $ fledge lanes run ci --json
-{"lane": "ci", "description": "Full CI pipeline", "total_steps": 3, "success": true, "duration_ms": 4733, "fail_fast": true, "steps": [...], "failures": []}
+{"schema_version": 1, "lane": "ci", "description": "Full CI pipeline", "total_steps": 3, "success": true, "duration_ms": 4733, "fail_fast": true, "steps": [{"step": 1, "name": "lint", "success": true, "duration_ms": 245, "error": null}, ...], "failures": []}
+
+# Dry-run with JSON (plan only — no duration_ms, includes dry_run: true)
+$ fledge lanes run ci --json --dry-run
+{"schema_version": 1, "lane": "ci", "description": "Full CI pipeline", "total_steps": 3, "fail_fast": true, "dry_run": true, "steps": [{"step": 1, "kind": "task", "name": "lint"}, {"step": 2, "kind": "parallel", "items": [{"kind": "task", "name": "fmt"}]}, ...]}
 ```
 
 ## Error Cases
@@ -225,6 +229,7 @@ $ fledge lanes run ci --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 15 | 2026-04-26 | `lanes run --json --dry-run` now emits a `{schema_version: 1, lane, description, total_steps, fail_fast, dry_run: true, steps: [{step, kind, name, items?}]}` envelope. Previously it ignored `--json` and printed prose, breaking the contract that `--json` always means parseable stdout. Per-step `duration_ms` is omitted in dry-run mode (no execution). Behavioral example for the per-step shape on real runs (`steps: [{step, name, success, duration_ms, error}, ...]`) also documented |
 | 14 | 2026-04-26 | `lanes import --json` envelope tightened: `file` is now always the computed `.fledge/lanes/<safe_name>.toml` path (string, never null), and a new `written: bool` field signals whether the file was actually created (false when every lane was skipped). Previously `file: null` in the all-skipped case implied the path wasn't computable, but it's a pure function of source — null was misleading |
 | 13 | 2026-04-25 | Fix `lanes run --json` prose leak: fledge's own progress prints AND each spawned task's stdout/stderr were going to the agent's stdout, interleaving with the JSON envelope and breaking `--json | jq`. Threaded a `quiet` flag through `execute_task_with_deps` / `execute_inline` / `execute_parallel` / `execute_single_task` / `execute_task_recursive`. In JSON mode prose is suppressed and spawned commands' stdout/stderr are redirected to `/dev/null`. Trade-off: per-step output isn't captured into the JSON record (consumers needing it re-run without `--json`). New regression test `cli_lane_run_json_stdout_is_clean` guards the contract |
 | 12 | 2026-04-25 | **Breaking (tier C, #272):** `lanes list --json`, `lanes search --json`, `lanes run --json`, `lanes validate --json` migrated to `{schema_version: 1, <resource>: [...]}` (or flattened with `schema_version` at top for run/validate). `lanes` for list, `results` for search, run/validate get the field added to the existing object. Last-chance shape break before 1.0 |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -200,7 +200,7 @@ pub fn run(action: LaneAction) -> Result<()> {
             validate_lane(&name, lane, &config.tasks)?;
 
             if dry_run {
-                dry_run_lane(&name, lane)
+                dry_run_lane(&name, lane, json)
             } else {
                 let project_dir = std::env::current_dir().context("getting current directory")?;
                 execute_lane(&name, lane, &config.tasks, &project_dir, json)
@@ -379,8 +379,61 @@ fn check_dep_cycle(
     Ok(())
 }
 
-fn dry_run_lane(lane_name: &str, lane: &LaneDef) -> Result<()> {
+fn dry_run_lane(lane_name: &str, lane: &LaneDef, json: bool) -> Result<()> {
     let desc = lane.description.as_deref().unwrap_or("(no description)");
+
+    if json {
+        let steps: Vec<serde_json::Value> = lane
+            .steps
+            .iter()
+            .enumerate()
+            .map(|(i, step)| match step {
+                Step::TaskRef(name) => serde_json::json!({
+                    "step": i + 1,
+                    "kind": "task",
+                    "name": name,
+                }),
+                Step::Inline { run: cmd } => serde_json::json!({
+                    "step": i + 1,
+                    "kind": "inline",
+                    "name": cmd,
+                }),
+                Step::Parallel { parallel } => {
+                    let items: Vec<serde_json::Value> = parallel
+                        .iter()
+                        .map(|item| match item {
+                            ParallelItem::TaskRef(name) => serde_json::json!({
+                                "kind": "task",
+                                "name": name,
+                            }),
+                            ParallelItem::Inline { run: cmd } => serde_json::json!({
+                                "kind": "inline",
+                                "name": cmd,
+                            }),
+                        })
+                        .collect();
+                    serde_json::json!({
+                        "step": i + 1,
+                        "kind": "parallel",
+                        "items": items,
+                    })
+                }
+            })
+            .collect();
+
+        let output = serde_json::json!({
+            "schema_version": 1,
+            "lane": lane_name,
+            "description": lane.description.as_deref().unwrap_or(""),
+            "total_steps": lane.steps.len(),
+            "fail_fast": lane.fail_fast,
+            "dry_run": true,
+            "steps": steps,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
     println!(
         "{} {} — {}",
         style("Lane:").bold(),

--- a/tests/lanes.rs
+++ b/tests/lanes.rs
@@ -185,4 +185,48 @@ steps = ["build", "test"]
     );
 }
 
+#[test]
+fn cli_lane_run_json_dry_run_emits_envelope() {
+    // Regression guard: `lanes run --json --dry-run` must emit a parseable
+    // JSON envelope, not prose. Pre-fix, the dry-run path ignored --json and
+    // printed human-readable text, breaking the contract that --json always
+    // means parseable stdout. Per-step shape: {step, kind, name, items?}.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        r#"[tasks]
+build = "echo build"
+lint = "echo lint"
+fmt = "echo fmt"
+
+[lanes.ci]
+description = "CI"
+steps = ["build", { parallel = ["lint", "fmt"] }, { run = "echo done" }]
+"#,
+    )
+    .unwrap();
+    let output = run_fledge_in(tmp.path(), &["lane", "run", "ci", "--json", "--dry-run"]);
+    assert!(
+        output.status.success(),
+        "lane run --json --dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("stdout is not JSON in dry-run mode (regression).\nerror: {e}\nstdout:\n{stdout}")
+    });
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["lane"].as_str(), Some("ci"));
+    assert_eq!(parsed["dry_run"].as_bool(), Some(true));
+    assert_eq!(parsed["total_steps"].as_u64(), Some(3));
+    let steps = parsed["steps"].as_array().expect("steps array");
+    assert_eq!(steps.len(), 3);
+    assert_eq!(steps[0]["kind"].as_str(), Some("task"));
+    assert_eq!(steps[0]["name"].as_str(), Some("build"));
+    assert_eq!(steps[1]["kind"].as_str(), Some("parallel"));
+    assert!(steps[1]["items"].is_array());
+    assert_eq!(steps[2]["kind"].as_str(), Some("inline"));
+    assert!(steps[0]["duration_ms"].is_null());
+}
+
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`fledge lanes run <name> --json --dry-run` previously ignored `--json` and emitted human-readable prose, breaking the contract that `--json` always means parseable stdout. Surfaced by the multi-model 1.0 readiness review (gpt-oss flagged it as the only inconsistency in the lanes JSON envelope shapes).

### Before
\`\`\`
$ fledge lanes run ci --json --dry-run
Lane: ci — CI pipeline
  1. build (task)
\`\`\`

### After
\`\`\`json
{
  "schema_version": 1,
  "lane": "ci",
  "description": "CI pipeline",
  "total_steps": 1,
  "fail_fast": true,
  "dry_run": true,
  "steps": [
    { "step": 1, "kind": "task", "name": "build" }
  ]
}
\`\`\`

Per-step shape: \`{step, kind: "task"|"inline"|"parallel", name, items?}\`. \`duration_ms\` is omitted in dry-run mode (nothing executed). Real-run shape unchanged; spec example tightened to show the full per-step record (`{step, name, success, duration_ms, error}`).

## Spec bumps

- \`lanes\` v13 → v15. **Stacks on #276** (which bumps to v14). Merge order should be #276 → this PR. If #276 lands second, this PR's spec changelog needs a one-line renumber.

## What was *not* fixed

The multi-model review surfaced a few other concerns; investigation showed most were stale or hallucinated:

| Concern | Reality |
|---|---|
| \`min_fledge_version\` parsed but not enforced | **Already enforced** at \`src/init.rs:542\` via \`check_fledge_version()\` |
| \`files.copy\` field unused | **Field doesn't exist** — \`FileRules\` only has \`render\` and \`ignore\` |
| Per-step \`duration_ms\` not specified | **Already emitted**; spec example just hid it behind \`steps: [...]\` — now shown |
| Plugin/lane envelope inconsistencies | **Fixed** in tier C (#274) |

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test\` — 848/848 pass (679 unit + 169 integration; 1 ignored, pre-existing)
- [x] \`fledge spec check --strict\` — 29/29 clean
- [x] New test \`cli_lane_run_json_dry_run_emits_envelope\` — covers task/parallel/inline step kinds
- [x] Manual smoke: confirmed JSON output parses with \`jq\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)