### PR TITLE
feat(1.0)!: tier-D schema_version envelope on cross-cutting --json paths

### DIFF
--- a/specs/ai/ai.spec.md
+++ b/specs/ai/ai.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ai
-version: 1
+version: 2
 status: active
 files:
   - src/ai.rs
@@ -37,7 +37,7 @@ depends_on:
 | `AiAction` | `Status { json }`, `Models { provider, search, json }`, `Use { provider, model }` |
 | `Source` | Private — `Env` / `ConfigFile` / `Default` tag on resolved values for status reporting |
 | `StatusReport` | Serializable — `provider`, `provider_source`, `model`, `model_source`, `host`, `host_source` |
-| `ModelsReport` | Serializable — `provider` + `models: Vec<ModelEntry>` |
+| `ModelEntry`s for `ai models` | Serialized inline in the JSON envelope — see Invariants |
 | `ModelEntry` | Serializable — `name`, optional `family` / `parameter_size` / `quantization` / `size_bytes` / `remote_host` |
 | `OllamaTagsResponse` | Private — decodes `{ models: [...] }` from Ollama's `/api/tags` |
 
@@ -126,4 +126,5 @@ $ fledge ai use                           # interactive picker
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2 | 2026-04-26 | Tier-D 1.0 envelope: `ai status --json` and `ai models --json` now emit `{schema_version: 1, action: "ai_status"|"ai_models", ...}` envelopes. Previously emitted bare `StatusReport` / `ModelsReport` shapes that violated the AGENTS.md envelope contract. The dropped `ModelsReport` struct is unused; `ModelEntry` items are serialized inline under `models`. Closes the gap where tier C (#274) only migrated plugins/lanes/templates |
 | 1 | 2026-04-24 | Initial spec — `fledge ai status` / `models` / `use`. Status reports the *source* of each resolved value so users can tell env from config from default. `ai use` is interactive by default with a live Ollama model picker and a non-interactive positional form (`fledge ai use <provider> [<model>]`) for agents. |

--- a/specs/ask/ask.spec.md
+++ b/specs/ask/ask.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ask
-version: 4
+version: 5
 status: active
 files:
   - src/ask.rs
@@ -125,6 +125,7 @@ error: Please provide a question. Usage: fledge ask <question>
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-04-26 | Tier-D 1.0 envelope: `ask --json` now wraps output as `{schema_version: 1, action: "ask", question, answer, provider, model}`. Previously emitted bare `{question, answer, provider, model}`. Closes a gap where tier C (#274) only migrated plugins/lanes/templates |
 | 4 | 2026-04-23 | Provider abstraction: Claude CLI is no longer hardcoded. New `--provider` and `--model` flags. JSON output gains `provider` and `model` fields. Runs through `llm::build_provider` with config / env / override precedence. |
 | 3 | 2026-04-23 | Default-on spec index in prompt; add `--with-specs` for full spec+companion bundles; add `--no-spec-index` escape hatch. Depends on `spec` module helpers. |
 | 2 | 2026-04-21 | Add json field to AskOptions |

--- a/specs/changelog/changelog.spec.md
+++ b/specs/changelog/changelog.spec.md
@@ -1,6 +1,6 @@
 ---
 module: changelog
-version: 2
+version: 3
 status: active
 files:
   - src/changelog.rs
@@ -98,5 +98,6 @@ None (uses only git CLI and standard library)
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-26 | **Breaking (tier D, 1.0):** `changelog --json` migrated from a bare top-level array to `{schema_version: 1, action: "changelog", releases: [...]}`. Same shape break tier C (#274) applied to the three pillars — this caught a remaining bare-array output. Last-chance shape break before 1.0 freezes the contract. Consumers reading `result[0]` now read `result.releases[0]` |
 | 2 | 2026-04-22 | Document that breaking changes are not parsed separately; note no types filter config |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -1,6 +1,6 @@
 ---
 module: doctor
-version: 6
+version: 7
 status: active
 files:
   - src/doctor.rs
@@ -120,6 +120,7 @@ $ fledge doctor --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 7 | 2026-04-26 | Tier-D 1.0 envelope: `doctor --json` now wraps output as `{schema_version: 1, action: "doctor", sections, passed, failed}`. Previously emitted bare `{sections, passed, failed}` — a 1.0 contract violation per the AGENTS.md rule that every `--json` output is enveloped. Inner `DoctorReport` struct unchanged so the unit test still validates section serialization. New integration assertion in `cli_doctor_json_valid` |
 | 6 | 2026-04-25 | Re-absorbed `fledge-plugin-doctor` toolchain probes into core as a new informational `Toolchains` section. Missing toolchain entries render dimmed and don't pollute the pass/fail totals because environmental availability isn't a project error. Plugin dropped from `DEFAULT_PLUGINS`. |
 | 5 | 2026-04-25 | v0.15 tight-core: stripped `Project Type`, `Toolchain`, and `Dependencies` sections. Self-check only: fledge config, git, AI provider. Toolchain probes deferred to `fledge-plugin-doctor`. |
 | 4 | 2026-04-24 | Active-Ollama display honors `FLEDGE_AI_MODEL` env override (previously only `OLLAMA_HOST` was honored) |

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 7
+version: 8
 status: active
 files:
   - src/review.rs
@@ -207,6 +207,7 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 | Version | Date | Changes |
 |---------|------|---------|
 | 6 | 2026-04-23 | Provider abstraction: `--provider` flag, JSON gains `provider`/`model` fields, invocation routes through `llm::build_provider` instead of shelling out to `claude` directly. Works with Ollama (local or cloud) end-to-end. |
+| 8 | 2026-04-26 | Tier-D 1.0 envelope: `review --json` adds `schema_version: 1` and `action: "review"` at the top level. Existing fields (`base`, `file`, `diff_stats`, `spec_context`, `reviews`, single-model `provider`/`model`/`review`) all preserved — purely additive. Closes the gap where tier C (#274) only migrated plugins/lanes/templates |
 | 7 | 2026-04-24 | Multi-model panel: `--with-model <provider[:model]>` (repeatable + comma-separated) and `--no-active` add parallel review slots that share the same diff + spec context. Per-slot errors are captured (not fatal). JSON gains `reviews[]` array; legacy top-level `review`/`provider`/`model` preserved when panel size is 1. Text output gets cyan banner headers between slots when panel size ≥ 2. |
 | 5 | 2026-04-23 | Spec-aware review: auto-detect specs for diffed modules (honors `specs_dir` config), `--with-specs`, `--no-auto-specs`, `spec_context` field in JSON output, prompt constraints to keep review target on the diff only |
 | 4 | 2026-04-23 | Add ReviewFormat enum, model/prompt/format fields to ReviewOptions |

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -1,6 +1,6 @@
 ---
 module: run
-version: 2
+version: 3
 status: active
 files:
   - src/run.rs
@@ -110,5 +110,6 @@ Available tasks:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-26 | Tier-D 1.0 envelope: all three `--json` paths now emit `{schema_version: 1, action, ...}`. `run --init --json` previously emitted prose ("✅ Created fledge.toml") — now `{action: "run_init", file, project_type, files_created}`, a real fix not just a wrapping. `run --list --json` adds `action: "run_list"` (was bare `{auto_detected, tasks}`). `run <task> --json` adds `action: "run_task"` (was bare `{task, command, ...}`). Three new integration tests guard each shape |
 | 2 | 2026-04-23 | Add `--json` flag (list + execute), `--lang` override, `detect_node_runner` |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 5
+version: 6
 status: active
 files:
   - src/spec.rs
@@ -222,6 +222,7 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 6 | 2026-04-26 | Tier-D 1.0 envelope (continuation): all three `--json` paths now wrap output as `{schema_version: 1, action, ...}`. **`spec list --json` is breaking**: bare top-level array → `{schema_version: 1, action: "spec_list", specs: [...]}`. `spec check --json` adds `schema_version`/`action: "spec_check"` (existing fields preserved). `spec show --json` wraps the prior bare detail as `{schema_version: 1, action: "spec_show", spec: {...}}`. Tests updated to assert the envelope shape |
 | 5 | 2026-04-23 | Add `--json` to `spec check`. Payload: `{specs: [{name, version, status, file_count, section_count, required_count, errors, warnings}], totals: {checked, errors, warnings}, strict}`. Exit code still non-zero on errors or strict-with-warnings. |
 | 4 | 2026-04-23 | Add `specs_for_changed_files` for `review`'s spec auto-detection (matches frontmatter `files:` and `<specs_dir>/<name>/` directory prefix, respecting the configured `specs_dir`) |
 | 3 | 2026-04-23 | Expose `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`, and `IndexEntry` for consumers that need spec content in prompt-friendly form (`ask` is the first such consumer). Add `extract_purpose` helper. |

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 8
+version: 9
 status: active
 files:
   - src/work.rs
@@ -304,3 +304,4 @@ $ fledge work status --json
 | 6 | 2026-04-23 | Add `--json` to `start`, `pr`, and `status`. `status` now also reports `behind`. Pretty output suppressed in JSON mode; errors still go to stderr. |
 | 7 | 2026-04-24 | `work pr` auto-generates the PR body from commits when `--body` is omitted, shows a styled preview, and prompts for confirmation before creating the PR. `--yes` / `-y` skips the prompt; non-interactive shells must pass `--yes` or `--json`. |
 | 8 | 2026-04-24 | `work pr --ai` generates a richer Markdown body via the configured LLM (`fledge ai use`-aware), with `--provider` / `--model` per-call overrides. Prompt includes commit log, diffstat, and truncated diff; spinner shown unless `--json`. |
+| 9 | 2026-04-26 | Tier-D 1.0 envelope: `work start --json`, `work pr --json`, `work status --json` now include `schema_version: 1` and `action: "work_start"|"work_pr"|"work_status"` at the top level. Field shapes otherwise unchanged. Closes the gap where tier C (#274) only migrated plugins/lanes/templates and missed the cross-cutting commands |

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -93,7 +93,17 @@ fn status(json: bool) -> Result<()> {
     };
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "ai_status",
+            "provider": report.provider,
+            "provider_source": report.provider_source,
+            "model": report.model,
+            "model_source": report.model_source,
+            "host": report.host,
+            "host_source": report.host_source,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 
@@ -208,12 +218,6 @@ struct OllamaTagDetails {
 const CLAUDE_WELL_KNOWN_MODELS: &[&str] = &["opus-4.7", "opus-4.6", "sonnet-4.6", "haiku-4.5"];
 
 #[derive(Debug, Serialize)]
-struct ModelsReport {
-    provider: String,
-    models: Vec<ModelEntry>,
-}
-
-#[derive(Debug, Serialize)]
 struct ModelEntry {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -262,11 +266,13 @@ fn models(provider: Option<String>, search: Option<String>, json: bool) -> Resul
     };
 
     if json {
-        let report = ModelsReport {
-            provider: kind.as_str().to_string(),
-            models: filtered,
-        };
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "ai_models",
+            "provider": kind.as_str(),
+            "models": filtered,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -38,6 +38,8 @@ pub fn run(options: AskOptions) -> Result<()> {
 
     if options.json {
         let response = serde_json::json!({
+            "schema_version": 1,
+            "action": "ask",
             "question": options.question,
             "answer": answer.trim(),
             "provider": provider.kind().as_str(),

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -70,7 +70,12 @@ pub fn run(opts: ChangelogOptions) -> Result<()> {
     };
 
     if opts.json {
-        println!("{}", serde_json::to_string_pretty(&releases)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "changelog",
+            "releases": releases,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -73,7 +73,14 @@ pub fn run(opts: DoctorOptions) -> Result<()> {
             passed,
             failed,
         };
-        println!("{}", serde_json::to_string_pretty(&report)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "doctor",
+            "sections": report.sections,
+            "passed": report.passed,
+            "failed": report.failed,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -277,6 +277,8 @@ pub fn run(options: ReviewOptions) -> Result<()> {
         // Single-model invocations keep the legacy top-level `review` /
         // `provider` / `model` fields so existing scripts don't break.
         let mut response = serde_json::json!({
+            "schema_version": 1,
+            "action": "review",
             "base": base,
             "file": options.file,
             "diff_stats": diff_stats,

--- a/src/run.rs
+++ b/src/run.rs
@@ -93,15 +93,9 @@ struct TaskInfo {
     dir: Option<String>,
 }
 
-#[derive(Serialize)]
-struct TaskListOutput {
-    auto_detected: bool,
-    tasks: Vec<TaskInfo>,
-}
-
 pub fn run(opts: RunOptions) -> Result<()> {
     if opts.init {
-        return init_fledge_toml(opts.lang.as_deref());
+        return init_fledge_toml(opts.lang.as_deref(), opts.json);
     }
 
     let project_dir = std::env::current_dir().context("getting current directory")?;
@@ -190,11 +184,13 @@ fn list_tasks_json(tasks: &BTreeMap<String, TaskDef>, auto_detected: bool) -> Re
             dir: task.dir().map(|s| s.to_string()),
         })
         .collect();
-    let output = TaskListOutput {
-        auto_detected,
-        tasks: task_list,
-    };
-    println!("{}", serde_json::to_string_pretty(&output)?);
+    let envelope = serde_json::json!({
+        "schema_version": 1,
+        "action": "run_list",
+        "auto_detected": auto_detected,
+        "tasks": task_list,
+    });
+    println!("{}", serde_json::to_string_pretty(&envelope)?);
     Ok(())
 }
 
@@ -240,6 +236,8 @@ fn execute_task(
             .with_context(|| format!("running task '{name}'"))?;
 
         let result = serde_json::json!({
+            "schema_version": 1,
+            "action": "run_task",
             "task": name,
             "command": cmd_str,
             "exit_code": output.status.code().unwrap_or(-1),
@@ -447,7 +445,7 @@ fn auto_detect_tasks(project_type: &str, dir: &Path) -> BTreeMap<String, TaskDef
     tasks
 }
 
-fn init_fledge_toml(lang_override: Option<&str>) -> Result<()> {
+fn init_fledge_toml(lang_override: Option<&str>, json: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = cwd.join("fledge.toml");
     if path.exists() {
@@ -477,6 +475,19 @@ fn init_fledge_toml(lang_override: Option<&str>) -> Result<()> {
     );
 
     std::fs::write(&path, content).context("writing fledge.toml")?;
+
+    if json {
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "run_init",
+            "file": "fledge.toml",
+            "project_type": project_type,
+            "files_created": ["fledge.toml"],
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
+        return Ok(());
+    }
+
     println!(
         "{} Created {}",
         style("✅").green().bold(),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -385,6 +385,8 @@ fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
     if !specs_dir.exists() {
         if json {
             let payload = serde_json::json!({
+                "schema_version": 1,
+                "action": "spec_check",
                 "specs": [],
                 "totals": { "checked": 0, "errors": 0, "warnings": 0 },
                 "strict": strict,
@@ -429,6 +431,8 @@ fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
     if results.is_empty() {
         if json {
             let payload = serde_json::json!({
+                "schema_version": 1,
+                "action": "spec_check",
                 "specs": [],
                 "totals": { "checked": 0, "errors": 0, "warnings": 0 },
                 "strict": strict,
@@ -482,6 +486,8 @@ fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
             })
             .collect();
         let payload = serde_json::json!({
+            "schema_version": 1,
+            "action": "spec_check",
             "specs": specs_payload,
             "totals": {
                 "checked": results.len(),
@@ -806,7 +812,12 @@ fn list_specs(root: &Path, json: bool) -> Result<()> {
     summaries.sort_by(|a, b| a.name.cmp(&b.name));
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&summaries)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "spec_list",
+            "specs": summaries,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 
@@ -914,7 +925,12 @@ fn show_spec(root: &Path, name: &str, json: bool) -> Result<()> {
     };
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&detail)?);
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "spec_show",
+            "spec": detail,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
 

--- a/src/work.rs
+++ b/src/work.rs
@@ -264,6 +264,8 @@ fn start(
 
     if json {
         let payload = serde_json::json!({
+            "schema_version": 1,
+            "action": "work_start",
             "branch": branch_name,
             "base": base_branch,
             "type": btype,
@@ -430,6 +432,8 @@ fn pr(
 
     if json {
         let payload = serde_json::json!({
+            "schema_version": 1,
+            "action": "work_pr",
             "url": pr_url,
             "number": pr_number,
             "title": pr_title,
@@ -504,6 +508,8 @@ fn status(json: bool) -> Result<()> {
             None => serde_json::Value::Null,
         };
         let payload = serde_json::json!({
+            "schema_version": 1,
+            "action": "work_status",
             "branch": branch,
             "default": default,
             "ahead": ahead,

--- a/tests/changelog.rs
+++ b/tests/changelog.rs
@@ -18,12 +18,15 @@ fn cli_changelog_json_valid() {
     let output = run_fledge(&["changelog", "--json"]);
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // When there are no tags, changelog prints a plain-text hint instead of JSON
-    if stdout.trim().is_empty() || !stdout.trim_start().starts_with('[') {
+    // When there are no tags, changelog prints a plain-text hint instead of JSON.
+    if stdout.trim().is_empty() || !stdout.trim_start().starts_with('{') {
         return;
     }
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert!(parsed.is_array() || parsed.is_object());
+    // Tier-D envelope: {schema_version: 1, action: "changelog", releases: [...]}
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("changelog"));
+    assert!(parsed["releases"].is_array());
 }
 
 #[test]

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -18,6 +18,8 @@ fn cli_doctor_json_valid() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("doctor"));
     assert!(parsed["sections"].is_array());
     assert!(parsed["passed"].is_number());
     assert!(parsed["failed"].is_number());

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -182,6 +182,62 @@ fn cli_run_list_shows_tasks() {
 }
 
 #[test]
+fn cli_run_init_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_fledge_in(tmp.path(), &["run", "--init", "--json"]);
+    assert!(
+        output.status.success(),
+        "run --init --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("run --init --json must emit JSON, got prose. error: {e}\nstdout:\n{stdout}")
+    });
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("run_init"));
+    assert_eq!(parsed["file"].as_str(), Some("fledge.toml"));
+    assert!(parsed["files_created"].is_array());
+}
+
+#[test]
+fn cli_run_list_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[tasks]\nbuild = \"echo build\"\ntest = \"echo test\"\n",
+    )
+    .unwrap();
+    let output = run_fledge_in(tmp.path(), &["run", "--list", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("run_list"));
+    assert!(parsed["tasks"].is_array());
+    assert_eq!(parsed["tasks"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn cli_run_task_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[tasks]\nhello = \"echo hi\"\n",
+    )
+    .unwrap();
+    let output = run_fledge_in(tmp.path(), &["run", "hello", "--json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("run_task"));
+    assert_eq!(parsed["task"].as_str(), Some("hello"));
+    assert_eq!(parsed["success"].as_bool(), Some(true));
+    assert_eq!(parsed["exit_code"].as_i64(), Some(0));
+}
+
+#[test]
 fn cli_run_unknown_task_fails() {
     let tmp = TempDir::new().unwrap();
     fs::write(

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -69,10 +69,12 @@ fn cli_spec_list_json_valid() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert!(parsed.is_array(), "expected JSON array, got {parsed}");
-    let arr = parsed.as_array().unwrap();
-    assert!(!arr.is_empty(), "fledge project should have specs");
-    let first = &arr[0];
+    // Tier-D envelope: {schema_version: 1, action: "spec_list", specs: [...]}
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("spec_list"));
+    let specs = parsed["specs"].as_array().expect("specs array");
+    assert!(!specs.is_empty(), "fledge project should have specs");
+    let first = &specs[0];
     for field in [
         "name",
         "version",
@@ -102,8 +104,8 @@ fn cli_spec_list_json_empty_dir() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
-    assert!(parsed.is_array());
-    assert!(parsed.as_array().unwrap().is_empty());
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert!(parsed["specs"].as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -121,11 +123,15 @@ fn cli_spec_show_json_valid() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert!(parsed.is_object());
-    assert_eq!(parsed["name"].as_str(), Some("spec"));
-    assert!(parsed["sections"].is_array());
-    assert!(parsed["companions"].is_array());
-    assert!(parsed["missing_companions"].is_array());
+    // Tier-D envelope: {schema_version: 1, action: "spec_show", spec: {...}}
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("spec_show"));
+    let spec = &parsed["spec"];
+    assert!(spec.is_object());
+    assert_eq!(spec["name"].as_str(), Some("spec"));
+    assert!(spec["sections"].is_array());
+    assert!(spec["companions"].is_array());
+    assert!(spec["missing_companions"].is_array());
 }
 
 #[test]
@@ -142,7 +148,9 @@ fn cli_spec_check_json_valid() {
     // May pass or fail on the repo's specs; either way stdout must be JSON
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert!(parsed.is_object());
+    // Tier-D envelope
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("spec_check"));
     assert!(parsed["specs"].is_array());
     assert!(parsed["totals"].is_object());
     assert!(parsed["totals"]["checked"].is_number());


### PR DESCRIPTION
## Summary

Tier C (#274) standardized envelopes on the plugins/lanes/templates pillars but missed the cross-cutting commands. Smoke testing the 1.0-ready binary surfaced **12 gaps** total (8 in the first wave, 4 more after the spec/review audit) where AGENTS.md's contract — *"every \`--json\` output is shaped as \`{schema_version: 1, ...}\`"* — was broken.

## What's fixed

| Command | Before | Severity |
|---|---|---|
| `doctor --json` | bare `{sections, passed, failed}` | major |
| `changelog --json` | **bare top-level array** | **breaking** |
| `run --init --json` | emitted prose, not JSON at all | **blocker** |
| `run --list --json` | bare `{auto_detected, tasks}` | major |
| `run <task> --json` | bare `{task, command, exit_code, ...}` | major |
| `ai status --json` | bare `StatusReport` | minor |
| `ai models --json` | bare `ModelsReport` | minor |
| `ask --json` | bare `{question, answer, ...}` | minor |
| `work start --json` | bare `{branch, base, ...}` | major |
| `work pr --json` | bare `{url, number, ...}` | major |
| `work status --json` | bare `{branch, ahead, behind, pr}` | major |
| **`spec list --json`** | **bare top-level array** | **breaking** |
| **`spec check --json`** | bare `{specs, totals, strict}` | major |
| **`spec show --json`** | bare `{name, version, sections, ...}` | major |
| **`review --json`** | bare `{base, file, reviews, ...}` | major |

After this PR, every `--json` path emits `{schema_version: 1, action, ...}` with a stable `action` discriminator (`"work_start"`, `"run_task"`, `"changelog"`, `"spec_list"`, `"review"`, etc.).

## Breaking changes (2)

1. `changelog --json`: bare top-level array → `{schema_version: 1, action: "changelog", releases: [...]}`. Consumers reading `result[0]` must now read `result.releases[0]`.
2. `spec list --json`: bare top-level array → `{schema_version: 1, action: "spec_list", specs: [...]}`. Same migration pattern.

Both follow tier C's "wrap bare arrays before 1.0 freeze" precedent.

## Spec bumps (8)

- doctor v6 → v7
- changelog v2 → v3 (breaking)
- run v2 → v3
- work v8 → v9
- ai v1 → v2
- ask v4 → v5
- spec v5 → v6 (breaking — `spec list`)
- review v7 → v8

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — **851 pass**
- [x] New: `cli_run_init_json_emits_envelope`, `cli_run_list_json_emits_envelope`, `cli_run_task_json_emits_envelope`
- [x] Updated: `cli_doctor_json_valid`, `cli_changelog_json_valid`, `cli_spec_list_json_valid`, `cli_spec_list_json_empty_dir`, `cli_spec_show_json_valid`, `cli_spec_check_json_valid`
- [x] `fledge spec check --strict` — 29/29 clean
- [x] Manual smoke: every fixed command emits `schema_version: 1`

## Out of scope (separate followup)

- `release --dry-run` has no `--json` flag at all — additive feature, not a contract break

🤖 Generated with [Claude Code](https://claude.com/claude-code)