### PR TITLE
docs(1.0): sync AGENTS.md + spec behavioral examples to envelope shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,16 +50,19 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | Command | What you get | Use when |
 |---------|-------------|----------|
 | `fledge introspect --json` | Full command tree: every subcommand, every flag, every arg | First contact with fledge |
-| `fledge spec list --json` | Array of spec summaries (module, version, status, sections, companions) | Orienting to a new codebase |
-| `fledge spec show <name> --json` | Single spec detail (frontmatter + section list + companion status) | Need structured view of one module |
-| `fledge spec check --json` | `{specs: [{name, version, status, errors, warnings, ...}], totals, strict}` | Spec-sync validation as data |
-| `fledge ai status --json` | `{provider, model, host, *_source}` — what's active and where each value came from | Verifying provider config before invoking the LLM |
-| `fledge ai models --provider {claude,ollama} --json` | Live model list (Ollama hits `/api/tags`; Claude returns curated aliases) | Picking a specific model |
-| `fledge ask "..." --json` | `{question, answer, provider, model}` from the active LLM provider over the codebase | Answering a question about the code |
-| `fledge review --json` | Single-model: `{base, file, diff_stats, spec_context, review, provider, model, reviews:[...]}` | Before opening a PR |
-| `fledge review --with-model <ref> --json` | Multi-model panel: `reviews:[{provider, model, elapsed_seconds, review|error}, ...]` | Comparing models on the same diff |
-| `fledge doctor --json` | `{sections:[{name, checks:[...], informational}], passed, failed}` — four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational; missing tools don't count toward `failed`. | Debugging a broken setup |
-| `fledge changelog --json` | Structured changelog from tags | Generating release notes |
+| `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [{name, version, status, sections, companions, ...}]}` | Orienting to a new codebase |
+| `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {name, version, status, sections, companions, ...}}` | Need structured view of one module |
+| `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs: [...], totals, strict}` | Spec-sync validation as data |
+| `fledge ai status --json` | `{schema_version: 1, action: "ai_status", provider, model, host, *_source}` — what's active and where each value came from | Verifying provider config before invoking the LLM |
+| `fledge ai models --provider {claude,ollama} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}` (Ollama hits `/api/tags`; Claude returns curated aliases) | Picking a specific model |
+| `fledge ask "..." --json` | `{schema_version: 1, action: "ask", question, answer, provider, model}` from the active LLM provider over the codebase | Answering a question about the code |
+| `fledge review --json` | Single-model: `{schema_version: 1, action: "review", base, file, diff_stats, spec_context, reviews: [...], review, provider, model}` (top-level `review`/`provider`/`model` only when panel size is 1) | Before opening a PR |
+| `fledge review --with-model <ref> --json` | Multi-model panel: `{schema_version: 1, action: "review", base, ..., reviews: [{provider, model, elapsed_seconds, review|error}, ...]}` | Comparing models on the same diff |
+| `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [{name, checks: [...], informational}], passed, failed}` — four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational; missing tools don't count toward `failed`. | Debugging a broken setup |
+| `fledge changelog --json` | `{schema_version: 1, action: "changelog", releases: [{tag, date, sections}]}` | Generating release notes |
+| `fledge run --list --json` | `{schema_version: 1, action: "run_list", auto_detected, tasks: [...]}` | Discovering tasks defined in `fledge.toml` (or auto-detected) |
+| `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` | Running a task and capturing its output |
+| `fledge run --init --json` | `{schema_version: 1, action: "run_init", file, project_type, files_created}` | Scaffolding a `fledge.toml` |
 | `fledge plugins list --json` | `{schema_version: 1, plugins: [{name, version, source, trust_tier, ...}]}` | Auditing plugin state |
 | `fledge plugins audit --json` | `{schema_version: 1, audit: [{name, version, trust_tier, capabilities, has_lifecycle_hooks, ...}]}` | Capability/hook audit |
 | `fledge plugins search --json` | `{schema_version: 1, results: [{name, full_name, stars, trust_tier, ...}]}` | GitHub search for `fledge-plugin`-tagged repos |
@@ -71,9 +74,9 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge templates list --json` | `{schema_version: 1, templates: [{name, description, source, source_ref, path}]}` | Listing available templates |
 | `fledge templates search --json` | `{schema_version: 1, results: [...]}` (same shape as plugins search) | GitHub search for `fledge-template`-tagged repos |
 | `fledge templates validate --json` | `{schema_version: 1, reports: [{path, template, errors, warnings}]}` | CI gate before publish |
-| `fledge work start <name> --json` | `{branch, base, type, prefix, issue}` — branch name the agent just created | Branch scripting |
-| `fledge work pr --json` | `{url, number, title, head, base, draft}` — PR URL to report back | After agent finishes a task |
-| `fledge work status --json` | `{branch, default, ahead, behind, pr?}` — current state of the branch | Pre-action sanity check |
+| `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}` — branch name the agent just created | Branch scripting |
+| `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}` — PR URL to report back | After agent finishes a task |
+| `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}` — current state of the branch | Pre-action sanity check |
 
 ### Plugin commands (after `plugins install --defaults`)
 
@@ -85,9 +88,14 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, …) |
 | `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` | LOC summary (tokei), per-file churn, test/source ratio |
 
-Commands **without** `--json` (pretty output only): `init`, `spec init`, `spec new`, `run`, `watch`, `release`, `ai use`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
+Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `release`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
 
-**Envelope contract.** Every `--json` output in the three pillars (plugins/lanes/templates) is shaped as `{schema_version: 1, <resource>: [...]}` or `{schema_version: 1, action: "<verb>", ...}` for mutating commands. Top-level `schema_version` is the version contract: new fields are additive within v1; field removal/retyping requires a new schema_version. **Always read `<resource>` (or named keys) — never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C of the 1.0 readiness work; pinning to fledge ≥ that release means you can rely on the envelope.
+**Envelope contract.** Every `--json` output across fledge is shaped as `{schema_version: 1, ...}`. Two patterns coexist:
+
+- Pillar list/query commands (`plugins list`, `lanes list/run/search`, `templates list/search`, etc.) use `{schema_version: 1, <resource>: [...]}` — the resource key (`plugins`, `lanes`, `results`, `templates`) acts as the discriminator.
+- Cross-cutting commands (`doctor`, `run`, `ai`, `ask`, `changelog`, `work`, `spec`, `review`) use `{schema_version: 1, action: "<verb>", ...}` — the `action` string discriminates between commands sharing similar shapes.
+
+Top-level `schema_version` is the version contract: new fields are additive within v1; field removal/retyping requires a new schema_version. **Always read `<resource>` (or `action` + named keys) — never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work; pinning to fledge ≥ 1.0 means you can rely on the envelope.
 
 ## Non-interactive mode (the one-switch answer)
 

--- a/specs/ask/ask.spec.md
+++ b/specs/ask/ask.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ask
-version: 5
+version: 6
 status: active
 files:
   - src/ask.rs
@@ -94,8 +94,12 @@ $ fledge ask --no-spec-index "quick syntax question: how do I declare an async t
 ```
 $ fledge ask --json "what is the release workflow?"
 {
+  "schema_version": 1,
+  "action": "ask",
   "question": "what is the release workflow?",
-  "answer": "..."
+  "answer": "...",
+  "provider": "ollama",
+  "model": "llama3.3"
 }
 ```
 
@@ -125,6 +129,7 @@ error: Please provide a question. Usage: fledge ask <question>
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 6 | 2026-04-26 | Doc sync — behavioral example updated to show the post-tier-D envelope shape with `schema_version`/`action`/`provider`/`model`. No code change |
 | 5 | 2026-04-26 | Tier-D 1.0 envelope: `ask --json` now wraps output as `{schema_version: 1, action: "ask", question, answer, provider, model}`. Previously emitted bare `{question, answer, provider, model}`. Closes a gap where tier C (#274) only migrated plugins/lanes/templates |
 | 4 | 2026-04-23 | Provider abstraction: Claude CLI is no longer hardcoded. New `--provider` and `--model` flags. JSON output gains `provider` and `model` fields. Runs through `llm::build_provider` with config / env / override precedence. |
 | 3 | 2026-04-23 | Default-on spec index in prompt; add `--with-specs` for full spec+companion bundles; add `--no-spec-index` escape hatch. Depends on `spec` module helpers. |

--- a/specs/changelog/changelog.spec.md
+++ b/specs/changelog/changelog.spec.md
@@ -1,6 +1,6 @@
 ---
 module: changelog
-version: 3
+version: 4
 status: active
 files:
   - src/changelog.rs
@@ -79,7 +79,7 @@ Unreleased (2026-04-19)
     abc1234 fix typo in README
 
 $ fledge changelog --json
-[{"tag": "v0.7.0", "date": "2026-04-19", "sections": [...]}]
+{"schema_version": 1, "action": "changelog", "releases": [{"tag": "v0.7.0", "date": "2026-04-19", "sections": [...]}]}
 ```
 
 ## Error Cases
@@ -98,6 +98,7 @@ None (uses only git CLI and standard library)
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-26 | Doc sync — behavioral example updated to show the post-tier-D envelope shape (was still showing the pre-1.0 bare-array form). No code change |
 | 3 | 2026-04-26 | **Breaking (tier D, 1.0):** `changelog --json` migrated from a bare top-level array to `{schema_version: 1, action: "changelog", releases: [...]}`. Same shape break tier C (#274) applied to the three pillars — this caught a remaining bare-array output. Last-chance shape break before 1.0 freezes the contract. Consumers reading `result[0]` now read `result.releases[0]` |
 | 2 | 2026-04-22 | Document that breaking changes are not parsed separately; note no types filter config |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -1,6 +1,6 @@
 ---
 module: doctor
-version: 7
+version: 8
 status: active
 files:
   - src/doctor.rs
@@ -97,7 +97,7 @@ $ fledge doctor
   7 checks passed, 0 issues found
 
 $ fledge doctor --json
-{ "sections": [...], "passed": 7, "failed": 0 }
+{ "schema_version": 1, "action": "doctor", "sections": [...], "passed": 7, "failed": 0 }
 ```
 
 ## Error Cases
@@ -120,6 +120,7 @@ $ fledge doctor --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 8 | 2026-04-26 | Doc sync — `doctor --json` behavioral example updated to show the post-tier-D envelope shape. No code change |
 | 7 | 2026-04-26 | Tier-D 1.0 envelope: `doctor --json` now wraps output as `{schema_version: 1, action: "doctor", sections, passed, failed}`. Previously emitted bare `{sections, passed, failed}` — a 1.0 contract violation per the AGENTS.md rule that every `--json` output is enveloped. Inner `DoctorReport` struct unchanged so the unit test still validates section serialization. New integration assertion in `cli_doctor_json_valid` |
 | 6 | 2026-04-25 | Re-absorbed `fledge-plugin-doctor` toolchain probes into core as a new informational `Toolchains` section. Missing toolchain entries render dimmed and don't pollute the pass/fail totals because environmental availability isn't a project error. Plugin dropped from `DEFAULT_PLUGINS`. |
 | 5 | 2026-04-25 | v0.15 tight-core: stripped `Project Type`, `Toolchain`, and `Dependencies` sections. Self-check only: fledge config, git, AI provider. Toolchain probes deferred to `fledge-plugin-doctor`. |

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 8
+version: 9
 status: active
 files:
   - src/review.rs
@@ -114,11 +114,16 @@ $ fledge review --file src/github.rs
 ```
 $ fledge review --json
 {
+  "schema_version": 1,
+  "action": "review",
   "base": "main",
   "file": null,
   "diff_stats": "...",
   "spec_context": ["trust"],
-  "review": "..."
+  "reviews": [{"provider": "claude", "model": "opus-4.7", "elapsed_seconds": 5.2, "review": "..."}],
+  "review": "...",
+  "provider": "claude",
+  "model": "opus-4.7"
 }
 ```
 
@@ -169,6 +174,8 @@ $ fledge review --no-active --with-model claude:opus-4.7,ollama:gpt-oss:120b-clo
 ```
 $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 {
+  "schema_version": 1,
+  "action": "review",
   "base": "main",
   "diff_stats": "...",
   "spec_context": ["work"],
@@ -178,6 +185,7 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
   ]
 }
 ```
+*Note: top-level `provider`/`model`/`review` are only present when the panel has exactly one slot (single-model invocations). Multi-model invocations only have the `reviews` array.*
 
 ## Error Cases
 
@@ -207,6 +215,7 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 | Version | Date | Changes |
 |---------|------|---------|
 | 6 | 2026-04-23 | Provider abstraction: `--provider` flag, JSON gains `provider`/`model` fields, invocation routes through `llm::build_provider` instead of shelling out to `claude` directly. Works with Ollama (local or cloud) end-to-end. |
+| 9 | 2026-04-26 | Doc sync — `review --json` (single + panel) behavioral examples updated to show the post-tier-D envelope shape. Single-vs-panel field-presence rule explicitly documented. No code change |
 | 8 | 2026-04-26 | Tier-D 1.0 envelope: `review --json` adds `schema_version: 1` and `action: "review"` at the top level. Existing fields (`base`, `file`, `diff_stats`, `spec_context`, `reviews`, single-model `provider`/`model`/`review`) all preserved — purely additive. Closes the gap where tier C (#274) only migrated plugins/lanes/templates |
 | 7 | 2026-04-24 | Multi-model panel: `--with-model <provider[:model]>` (repeatable + comma-separated) and `--no-active` add parallel review slots that share the same diff + spec context. Per-slot errors are captured (not fatal). JSON gains `reviews[]` array; legacy top-level `review`/`provider`/`model` preserved when panel size is 1. Text output gets cyan banner headers between slots when panel size ≥ 2. |
 | 5 | 2026-04-23 | Spec-aware review: auto-detect specs for diffed modules (honors `specs_dir` config), `--with-specs`, `--no-auto-specs`, `spec_context` field in JSON output, prompt constraints to keep review target on the diff only |

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -1,6 +1,6 @@
 ---
 module: run
-version: 3
+version: 4
 status: active
 files:
   - src/run.rs
@@ -78,11 +78,15 @@ $ fledge run --init
 
 # List tasks as JSON
 $ fledge run --json
-{"auto_detected": false, "tasks": [...]}
+{"schema_version": 1, "action": "run_list", "auto_detected": false, "tasks": [...]}
+
+# Init fledge.toml as JSON
+$ fledge run --init --json
+{"schema_version": 1, "action": "run_init", "file": "fledge.toml", "project_type": "rust", "files_created": ["fledge.toml"]}
 
 # Run a task with JSON output
 $ fledge run test --json
-{"task": "test", "command": "cargo test", "exit_code": 0, "success": true, "stdout": "...", "stderr": "..."}
+{"schema_version": 1, "action": "run_task", "task": "test", "command": "cargo test", "exit_code": 0, "success": true, "stdout": "...", "stderr": "..."}
 
 # Override project type
 $ fledge run --lang node
@@ -110,6 +114,7 @@ Available tasks:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-26 | Doc sync — behavioral examples updated to show the post-tier-D envelope shapes for `run --json`, `run <task> --json`, and `run --init --json`. No code change |
 | 3 | 2026-04-26 | Tier-D 1.0 envelope: all three `--json` paths now emit `{schema_version: 1, action, ...}`. `run --init --json` previously emitted prose ("✅ Created fledge.toml") — now `{action: "run_init", file, project_type, files_created}`, a real fix not just a wrapping. `run --list --json` adds `action: "run_list"` (was bare `{auto_detected, tasks}`). `run <task> --json` adds `action: "run_task"` (was bare `{task, command, ...}`). Three new integration tests guard each shape |
 | 2 | 2026-04-23 | Add `--json` flag (list + execute), `--lang` override, `detect_node_runner` |
 | 1 | 2026-04-19 | Initial spec |

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 6
+version: 7
 status: active
 files:
   - src/spec.rs
@@ -73,7 +73,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 5. All files listed in frontmatter `files` must exist on disk
 6. All required sections from config must be present in the spec body
 7. Companion files (requirements.md, tasks.md, context.md, testing.md) are validated if present
-8. `spec list` returns sorted results by module name; `--json` emits an array (empty array when no specs)
+8. `spec list` returns sorted results by module name; `--json` emits `{schema_version: 1, action: "spec_list", specs: [...]}` (with `specs: []` when no specs are present)
 9. `spec show` errors if the spec is not found and suggests `fledge spec list`
 10. `spec list` and `spec show` are read-only — they never mutate the filesystem
 11. `collect_index` silently skips specs whose frontmatter is malformed or files are unreadable, so a single broken spec never breaks a caller like `fledge ask`
@@ -148,19 +148,23 @@ $ fledge spec list
 ### spec list --json — machine-readable summary
 ```
 $ fledge spec list --json
-[
-  {
-    "name": "trust",
-    "version": 1,
-    "status": "active",
-    "path": "specs/trust/trust.spec.md",
-    "files": ["src/trust.rs"],
-    "section_count": 7,
-    "required_sections": 7,
-    "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
-    "missing_companions": []
-  }
-]
+{
+  "schema_version": 1,
+  "action": "spec_list",
+  "specs": [
+    {
+      "name": "trust",
+      "version": 1,
+      "status": "active",
+      "path": "specs/trust/trust.spec.md",
+      "files": ["src/trust.rs"],
+      "section_count": 7,
+      "required_sections": 7,
+      "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
+      "missing_companions": []
+    }
+  ]
+}
 ```
 
 ### spec show — inspect one spec
@@ -189,14 +193,18 @@ trust v1 (active)
 ```
 $ fledge spec show trust --json
 {
-  "name": "trust",
-  "version": 1,
-  "status": "active",
-  "path": "specs/trust/trust.spec.md",
-  "files": ["src/trust.rs"],
-  "sections": ["Purpose", "Public API", "Invariants", ...],
-  "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
-  "missing_companions": []
+  "schema_version": 1,
+  "action": "spec_show",
+  "spec": {
+    "name": "trust",
+    "version": 1,
+    "status": "active",
+    "path": "specs/trust/trust.spec.md",
+    "files": ["src/trust.rs"],
+    "sections": ["Purpose", "Public API", "Invariants", ...],
+    "companions": ["requirements.md", "tasks.md", "context.md", "testing.md"],
+    "missing_companions": []
+  }
 }
 ```
 
@@ -222,6 +230,7 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 7 | 2026-04-26 | Doc sync — behavioral examples for `spec list --json` and `spec show --json` updated to show the post-tier-D envelope shapes (previously displayed the bare-array / bare-detail forms shipped before envelope migration). Invariant 8 reworded to describe the envelope. No code change |
 | 6 | 2026-04-26 | Tier-D 1.0 envelope (continuation): all three `--json` paths now wrap output as `{schema_version: 1, action, ...}`. **`spec list --json` is breaking**: bare top-level array → `{schema_version: 1, action: "spec_list", specs: [...]}`. `spec check --json` adds `schema_version`/`action: "spec_check"` (existing fields preserved). `spec show --json` wraps the prior bare detail as `{schema_version: 1, action: "spec_show", spec: {...}}`. Tests updated to assert the envelope shape |
 | 5 | 2026-04-23 | Add `--json` to `spec check`. Payload: `{specs: [{name, version, status, file_count, section_count, required_count, errors, warnings}], totals: {checked, errors, warnings}, strict}`. Exit code still non-zero on errors or strict-with-warnings. |
 | 4 | 2026-04-23 | Add `specs_for_changed_files` for `review`'s spec auto-detection (matches frontmatter `files:` and `<specs_dir>/<name>/` directory prefix, respecting the configured `specs_dir`) |

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 9
+version: 10
 status: active
 files:
   - src/work.rs
@@ -216,6 +216,8 @@ $ fledge work status
 ```
 $ fledge work start add-search --json
 {
+  "schema_version": 1,
+  "action": "work_start",
   "branch": "leif/feat/add-search",
   "base": "main",
   "type": "feat",
@@ -228,6 +230,8 @@ $ fledge work start add-search --json
 ```
 $ fledge work pr --json
 {
+  "schema_version": 1,
+  "action": "work_pr",
   "url": "https://github.com/owner/repo/pull/42",
   "number": 42,
   "title": "Add search command",
@@ -241,6 +245,8 @@ $ fledge work pr --json
 ```
 $ fledge work status --json
 {
+  "schema_version": 1,
+  "action": "work_status",
   "branch": "leif/feat/add-search",
   "default": "main",
   "ahead": 3,
@@ -257,6 +263,8 @@ $ fledge work status --json
 ```
 $ fledge work status --json
 {
+  "schema_version": 1,
+  "action": "work_status",
   "branch": "leif/feat/add-search",
   "default": "main",
   "ahead": 3,
@@ -304,4 +312,5 @@ $ fledge work status --json
 | 6 | 2026-04-23 | Add `--json` to `start`, `pr`, and `status`. `status` now also reports `behind`. Pretty output suppressed in JSON mode; errors still go to stderr. |
 | 7 | 2026-04-24 | `work pr` auto-generates the PR body from commits when `--body` is omitted, shows a styled preview, and prompts for confirmation before creating the PR. `--yes` / `-y` skips the prompt; non-interactive shells must pass `--yes` or `--json`. |
 | 8 | 2026-04-24 | `work pr --ai` generates a richer Markdown body via the configured LLM (`fledge ai use`-aware), with `--provider` / `--model` per-call overrides. Prompt includes commit log, diffstat, and truncated diff; spinner shown unless `--json`. |
+| 10 | 2026-04-26 | Doc sync — behavioral examples for `work start/pr/status --json` updated to show the post-tier-D envelope shapes (with `schema_version` and `action`). No code change |
 | 9 | 2026-04-26 | Tier-D 1.0 envelope: `work start --json`, `work pr --json`, `work status --json` now include `schema_version: 1` and `action: "work_start"|"work_pr"|"work_status"` at the top level. Field shapes otherwise unchanged. Closes the gap where tier C (#274) only migrated plugins/lanes/templates and missed the cross-cutting commands |


### PR DESCRIPTION
## Summary

Final 1.0 readiness pass — **pure documentation**. Code is unchanged.

After tier-A/B/C/D wrapped every \`--json\` output in \`{schema_version: 1, action, ...}\` envelopes (#273-#278), the docs still showed the pre-envelope shapes. Agents reading them would expect bare objects/arrays and fail to parse the actual output.

## AGENTS.md changes

- **13 rows updated** to show \`schema_version\` + \`action\`: ai status/models, ask, review (single + panel), doctor, changelog, work start/pr/status
- **3 new rows added** documenting \`run --list\`, \`run --init\`, \`run <task>\` envelopes
- **Envelope contract paragraph reworded**: documents both patterns (resource-key for pillar list/query, action-string for cross-cutting commands) instead of the old plugins/lanes/templates framing
- **"Without --json" list corrected**: \`init\` was wrong (no such command), \`run\` was wrong (\`run\` accepts \`--json\` everywhere now); added \`config *\` and \`completions\` which were always missing

## Module specs (8)

Behavioral examples for \`--json\` updated to the current envelope shape:

| Spec | Before bump | After |
|---|---|---|
| spec | 6 | 7 (+ invariant 8 reworded from "array" to envelope) |
| run | 3 | 4 |
| work | 9 | 10 |
| changelog | 3 | 4 |
| ask | 5 | 6 |
| doctor | 7 | 8 |
| review | 8 | 9 (single-vs-panel field-presence rule documented) |

\`introspect\` and lanes already had current examples — not touched.

## Test plan

- [x] \`cargo test\` — 851 pass
- [x] \`fledge spec check --strict\` — 29/29 clean
- [x] No code files modified — only \`AGENTS.md\` and \`specs/*/*.spec.md\`

## What this closes

The "every \`--json\` output is \`{schema_version: 1, ...}\`" promise in AGENTS.md is now actually documented to match the code. After this lands, the 1.0 \`--json\` contract is fully self-consistent: code, AGENTS.md, and per-module specs all agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)