### PR TITLE
docs: sync README/AGENTS/docs to current state, drop em-dashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,47 @@
-# AGENTS.md — fledge for AI agents
+# AGENTS.md
 
-This doc is for AI agents (Claude Code, GPT-based coding agents, OpenHands, etc.) using the `fledge` CLI alongside a human. Humans get `README.md` and `docs/`; agents get this one page.
+This page is for AI agents (Claude Code, GPT-based coding agents, OpenHands, etc.) using `fledge` alongside a human. Humans get `README.md` and `docs/`. Agents get this one page.
 
 ## What fledge is, in one paragraph
 
-`fledge` is a single-binary dev-lifecycle CLI (Rust). **Six pillars: scaffold (`templates`), run (`run`/`lanes`/`watch`), spec (`spec`), AI (`ai`/`ask`/`review`), ship (`work`/`release`/`changelog`), extend (`plugins`/`config`/`introspect`/`completions`/`doctor`).** Anything else — GitHub-specific browsing, polyglot dep audits, code metrics, toolchain probes — is a plugin. Run `fledge plugins install --defaults` once to get the curated plugin set; you'll get back to feature parity with pre-v0.15 fledge.
+`fledge` is a single-binary dev-lifecycle CLI written in Rust. Six pillars: scaffold (`templates`), run (`run`/`lanes`/`watch`), spec (`spec`), AI (`ai`/`ask`/`review`), ship (`work`/`release`/`changelog`), extend (`plugins`/`config`/`introspect`/`completions`/`doctor`). Anything else (GitHub-specific browsing, polyglot dep audits, code metrics, toolchain probes) is a plugin. Run `fledge plugins install --defaults` once for the curated set.
 
-If you are about to run `npm`, `cargo`, `make`, `git checkout -b`, or `gh pr create`, check first whether fledge has a wrapper — it usually does, and the wrapper often has `--json` and guardrails you want.
+If you're about to run `npm`, `cargo`, `make`, `git checkout -b`, or `gh pr create`, check first whether fledge has a wrapper. It usually does, and the wrapper has `--json` and guardrails.
 
-## First-time setup for an agent
+## First-time setup
 
 ```bash
 export FLEDGE_NON_INTERACTIVE=1               # silence every prompt
 fledge plugins install --defaults             # curated plugin set: github, deps, metrics
-fledge introspect --json                       # dump the full command tree (incl. plugin commands)
-fledge spec list --json                        # orient to the codebase via specs
+fledge introspect --json                      # full command tree (incl. plugin commands)
+fledge spec list --json                       # orient to the codebase via specs
 ```
 
-After those four lines, every command and every flag is discoverable as data.
+After those four lines every command and every flag is discoverable as data.
 
 ## Golden rules
 
-1. **Prefer fledge subcommands over raw tools** when wrapped. E.g. use `fledge work start` instead of `git checkout -b`, `fledge run test` instead of guessing `cargo test` vs `npm test`.
-2. **Always add `--json` when a command supports it** (see list below). Parse the JSON; do not screen-scrape pretty output.
-3. **Set `FLEDGE_NON_INTERACTIVE=1` once** in your shell, or pass `--non-interactive` (alias `--ni`) per invocation. Every command then treats confirmation prompts as `--yes`; prompts with no default bail with a clear error instead of blocking forever.
-4. **Check exit codes.** Non-zero means something failed, even if stdout looks fine.
-5. **Don't mutate without running `fledge lanes run pre-commit` first** — it's the project-defined quality gate.
+1. **Prefer fledge subcommands over raw tools** when wrapped. Use `fledge work start` instead of `git checkout -b`, `fledge run test` instead of guessing `cargo test` vs `npm test`.
+2. **Always add `--json` when a command supports it** (see list below). Parse the JSON. Do not screen-scrape pretty output.
+3. **Set `FLEDGE_NON_INTERACTIVE=1` once** in your shell, or pass `--non-interactive` (alias `--ni`) per invocation. Confirmation prompts then behave as `--yes`. Prompts with no default bail with a clear error instead of blocking forever.
+4. **Check exit codes.** Non-zero means failed, even if stdout looks fine.
+5. **Run `fledge lanes run pre-commit` before mutating shared state.** It's the project-defined quality gate.
 
 ## Discover what fledge can do
 
 ```bash
-fledge introspect --json             # full command tree — every subcommand, every flag
+fledge introspect --json             # full command tree, every subcommand and flag
 fledge introspect                    # same, human-readable indented listing
 fledge --help                        # top-level command list (human text)
 fledge <cmd> --help                  # per-command flags
-fledge spec list --json              # all specs as a JSON array
+fledge spec list --json              # all specs as JSON
 fledge spec show <name> --json       # one spec's structure as JSON
 fledge plugins list --json           # what extensions are active
 ```
 
-`fledge introspect --json` is the right starting point for an agent that has never seen fledge before — it reveals the entire CLI surface (including plugin-installed commands) in one call.
+`fledge introspect --json` is the right starting point for an agent that has never seen fledge. It reveals the entire CLI surface (including plugin-installed commands) in one call.
 
-Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for *why* a module exists. When you need context beyond what the code shows, read the spec — particularly `specs/<name>/context.md` (design decisions) and `specs/<name>/requirements.md` (user stories).
+Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for *why* a module exists. When you need context beyond what the code shows, read the spec. Particularly `specs/<name>/context.md` (design decisions) and `specs/<name>/requirements.md` (user stories).
 
 ## Machine-readable surface (`--json`)
 
@@ -53,12 +53,12 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [{name, version, status, sections, companions, ...}]}` | Orienting to a new codebase |
 | `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {name, version, status, sections, companions, ...}}` | Need structured view of one module |
 | `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs: [...], totals, strict}` | Spec-sync validation as data |
-| `fledge ai status --json` | `{schema_version: 1, action: "ai_status", provider, model, host, *_source}` — what's active and where each value came from | Verifying provider config before invoking the LLM |
-| `fledge ai models --provider {claude,ollama} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}` (Ollama hits `/api/tags`; Claude returns curated aliases) | Picking a specific model |
-| `fledge ask "..." --json` | `{schema_version: 1, action: "ask", question, answer, provider, model}` from the active LLM provider over the codebase | Answering a question about the code |
-| `fledge review --json` | Single-model: `{schema_version: 1, action: "review", base, file, diff_stats, spec_context, reviews: [...], review, provider, model}` (top-level `review`/`provider`/`model` only when panel size is 1) | Before opening a PR |
+| `fledge ai status --json` | `{schema_version: 1, action: "ai_status", provider, model, host, *_source}`. What's active and where each value came from | Verifying provider config before invoking the LLM |
+| `fledge ai models --provider {claude,ollama} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}`. Ollama hits `/api/tags`, Claude returns curated aliases | Picking a specific model |
+| `fledge ask "..." --json` | `{schema_version: 1, action: "ask", question, answer, provider, model}` from the active LLM | Answering a question about the code |
+| `fledge review --json` | Single-model: `{schema_version: 1, action: "review", base, file, diff_stats, spec_context, reviews: [...], review, provider, model}`. Top-level `review`/`provider`/`model` only when panel size is 1 | Before opening a PR |
 | `fledge review --with-model <ref> --json` | Multi-model panel: `{schema_version: 1, action: "review", base, ..., reviews: [{provider, model, elapsed_seconds, review|error}, ...]}` | Comparing models on the same diff |
-| `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [{name, checks: [...], informational}], passed, failed}` — four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational; missing tools don't count toward `failed`. | Debugging a broken setup |
+| `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [{name, checks: [...], informational}], passed, failed}`. Four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational, missing tools don't count toward `failed` | Debugging a broken setup |
 | `fledge changelog --json` | `{schema_version: 1, action: "changelog", releases: [{tag, date, sections}]}` | Generating release notes |
 | `fledge run --list --json` | `{schema_version: 1, action: "run_list", auto_detected, tasks: [...]}` | Discovering tasks defined in `fledge.toml` (or auto-detected) |
 | `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` | Running a task and capturing its output |
@@ -74,30 +74,30 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge templates list --json` | `{schema_version: 1, templates: [{name, description, source, source_ref, path}]}` | Listing available templates |
 | `fledge templates search --json` | `{schema_version: 1, results: [...]}` (same shape as plugins search) | GitHub search for `fledge-template`-tagged repos |
 | `fledge templates validate --json` | `{schema_version: 1, reports: [{path, template, errors, warnings}]}` | CI gate before publish |
-| `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}` — branch name the agent just created | Branch scripting |
-| `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}` — PR URL to report back | After agent finishes a task |
-| `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}` — current state of the branch | Pre-action sanity check |
+| `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}`. Branch name the agent just created | Branch scripting |
+| `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}`. PR URL to report back | After agent finishes a task |
+| `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}`. Current state of the branch | Pre-action sanity check |
 
 ### Plugin commands (after `plugins install --defaults`)
 
 | Command | Plugin | What you get |
 |---------|--------|-------------|
 | `fledge checks --json` | `fledge-plugin-github` | Raw GitHub API response of CI check-runs for a branch |
-| `fledge issues --json` / `fledge issues view <n> --json` | `fledge-plugin-github` | GitHub issues — list or one |
-| `fledge prs --json` / `fledge prs view <n> --json` | `fledge-plugin-github` | GitHub PRs — list or one |
-| `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, …) |
+| `fledge issues --json` / `fledge issues view <n> --json` | `fledge-plugin-github` | GitHub issues, list or one |
+| `fledge prs --json` / `fledge prs view <n> --json` | `fledge-plugin-github` | GitHub PRs, list or one |
+| `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, ...) |
 | `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` | LOC summary (tokei), per-file churn, test/source ratio |
 
-Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `release`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR — it's an accepted pattern.
+Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `release`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR. It's an accepted pattern.
 
-**Envelope contract.** Every `--json` output across fledge is shaped as `{schema_version: 1, ...}`. Two patterns coexist:
+**Envelope contract.** Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 
-- Pillar list/query commands (`plugins list`, `lanes list/run/search`, `templates list/search`, etc.) use `{schema_version: 1, <resource>: [...]}` — the resource key (`plugins`, `lanes`, `results`, `templates`) acts as the discriminator.
-- Cross-cutting commands (`doctor`, `run`, `ai`, `ask`, `changelog`, `work`, `spec`, `review`) use `{schema_version: 1, action: "<verb>", ...}` — the `action` string discriminates between commands sharing similar shapes.
+- Pillar list/query commands (`plugins list`, `lanes list/run/search`, `templates list/search`) use `{schema_version: 1, <resource>: [...]}`. The resource key (`plugins`, `lanes`, `results`, `templates`) acts as the discriminator.
+- Cross-cutting commands (`doctor`, `run`, `ai`, `ask`, `changelog`, `work`, `spec`, `review`) use `{schema_version: 1, action: "<verb>", ...}`. The `action` string discriminates between commands sharing similar shapes.
 
-Top-level `schema_version` is the version contract: new fields are additive within v1; field removal/retyping requires a new schema_version. **Always read `<resource>` (or `action` + named keys) — never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work; pinning to fledge ≥ 1.0 means you can rely on the envelope.
+Top-level `schema_version` is the version contract. New fields are additive within v1, field removal/retyping requires a new schema_version. **Always read `<resource>` (or `action` + named keys). Never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work. Pinning to fledge ≥ 1.0 means you can rely on the envelope.
 
-## Non-interactive mode (the one-switch answer)
+## Non-interactive mode
 
 Set this once at the top of your shell session and forget about it:
 
@@ -113,7 +113,7 @@ When non-interactive mode is active, every command that would otherwise prompt b
 |---------|--------|
 | `fledge templates init` | Skip template-variable prompts (uses detected defaults) |
 | `fledge templates create` | Skip name/description/type prompts |
-| `fledge ai use` | Errors with a clear "pass provider+model" message — no hang |
+| `fledge ai use` | Errors with a clear "pass provider+model" message. No hang |
 | `fledge work pr` | Skip the preview/confirm prompt (treat as --yes) |
 | `fledge plugins install` | Skip trust-tier and capability-grant prompts |
 | `fledge plugins publish` | Skip confirmations |
@@ -121,21 +121,21 @@ When non-interactive mode is active, every command that would otherwise prompt b
 | `fledge lanes publish` | Skip description prompt |
 | `fledge templates publish` | Skip the confirmation prompt |
 
-Prompts that have **no sensible default** (e.g. `fledge ai use` being asked to pick a provider when none was specified) fail fast with a clear error naming the flag to pass instead. No silent hangs.
+Prompts with no sensible default (`fledge ai use` being asked to pick a provider when none was specified) fail fast with a clear error naming the flag to pass instead. No silent hangs.
 
-You can still pass `--yes`/`--force` per command if you prefer — they and `FLEDGE_NON_INTERACTIVE` compose.
+You can still pass `--yes`/`--force` per command if you prefer. They and `FLEDGE_NON_INTERACTIVE` compose.
 
 ## AI commands
 
 `fledge ai`, `fledge ask`, and `fledge review` go through a provider abstraction. Two providers ship in core:
 
-- **Claude** (default) — shells out to the `claude` CLI, which must be installed and authenticated on the host.
-- **Ollama** — HTTP to any Ollama-speaking endpoint: local daemon (`http://localhost:11434`), Ollama Cloud / Turbo, or self-hosted. Supports a Bearer API key.
+- **Claude** (default). Shells out to the `claude` CLI, which must be installed and authenticated on the host.
+- **Ollama**. HTTP to any Ollama-speaking endpoint: local daemon (`http://localhost:11434`), Ollama Cloud / Turbo, or self-hosted. Supports a Bearer API key.
 
-### Picking a provider — three ways
+### Picking a provider, three ways
 
 ```bash
-# 1. fledge ai use (writes to ~/.config/fledge/config.toml — persists)
+# 1. fledge ai use (writes to ~/.config/fledge/config.toml, persists)
 fledge ai use ollama qwen3-coder:480b-cloud
 fledge ai use claude opus-4.7
 fledge ai status                           # show the active triplet + source of each value
@@ -156,7 +156,7 @@ Precedence: CLI flag > env var > config > default (`claude`).
 
 ### `fledge ask` is spec-aware by default
 
-**Every `fledge ask` invocation automatically prepends a compact index of all specs** (one line per module: name, version, status, files, first-paragraph purpose). The model can then cite specific specs in its answer even when the user didn't mention them.
+Every `fledge ask` invocation automatically prepends a compact index of all specs (one line per module: name, version, status, files, first-paragraph purpose). The model can then cite specific specs in its answer even when the user didn't mention them.
 
 ```bash
 fledge ask "how does work build branch names?" --json
@@ -165,7 +165,7 @@ fledge ask --with-specs all "which modules touch GitHub?"
 fledge ask --no-spec-index "quick Rust syntax question"
 ```
 
-### `fledge review` — single or multi-model
+### `fledge review`, single or multi-model
 
 `fledge review` auto-detects which modules a diff touches (via each spec's frontmatter `files:` and any edits under `specs/<name>/`) and includes their full spec + companion files as context.
 
@@ -177,7 +177,7 @@ fledge review --with-specs plugin --json
 fledge review --no-auto-specs --json
 fledge review --model opus --format checklist --json
 
-# Multi-model panel — same diff, parallel critiques
+# Multi-model panel: same diff, parallel critiques
 fledge review --with-model ollama:gpt-oss:120b-cloud --with-model ollama:qwen3-coder:480b-cloud --json
 fledge review --no-active --with-model claude:opus-4.7,ollama:gpt-oss:120b-cloud --json
 ```
@@ -230,33 +230,33 @@ cat specs/<name>/testing.md      # test plan
 
 ## Exit codes
 
-- `0` — success
-- `1` — user-facing error (bad input, missing file, validation failure, prompt required in non-TTY)
+- `0` success
+- `1` user-facing error (bad input, missing file, validation failure, prompt required in non-TTY)
 - Non-zero exit also fires on `fledge spec check` errors, `fledge lanes run` failures, and `fledge review` errors
 
 ## Project-specific quality gate
 
 This repo defines its own lanes in `fledge.toml`. The key ones for agents:
 
-- `fledge lanes run pre-commit` — fmt + lint + test + spec-check (required before opening a PR)
-- `fledge lanes run ci` — full CI pipeline locally
-- `fledge lanes run check` — quick parallel fmt+lint then test
-- `fledge spec check` — always run if you touched `src/` or `specs/`
+- `fledge lanes run pre-commit`. fmt + lint + test + spec-check (required before opening a PR)
+- `fledge lanes run ci`. Full CI pipeline locally
+- `fledge lanes run check`. Quick parallel fmt+lint then test
+- `fledge spec check`. Always run if you touched `src/` or `specs/`
 
 ## When things go wrong
 
 - **A command hung**: you probably skipped `--yes` or `--force`. Cancel, re-run with the bypass flag (or set `FLEDGE_NON_INTERACTIVE=1` once).
 - **`fledge ask` / `review` errored with auth**: the host's `claude` CLI isn't set up, or your Ollama config is wrong. Run `fledge ai status` to see what fledge thinks is active, then `fledge doctor` to verify the provider is reachable.
-- **`fledge spec check` fails**: read the error — almost always a missing section, missing source file, or unknown status. Don't "fix" it by editing the validator.
+- **`fledge spec check` fails**: read the error. Almost always a missing section, missing source file, or unknown status. Don't "fix" it by editing the validator.
 - **`fledge work pr` fails on push**: you're probably not on a remote-tracking branch. Re-run after `git push -u origin HEAD` or debug with `fledge work status`.
-- **`fledge checks` (or any command) says "unrecognized subcommand"**: the corresponding plugin isn't installed. Run `fledge plugins install --defaults` to get the curated set in one shot.
-- **A multi-model `fledge review` panel had one slot fail**: that slot's `error` field has the cause; the other slots' reviews are still valid. `--with-model` is fault-tolerant by design.
+- **`fledge checks` (or any command) says "unrecognized subcommand"**: the corresponding plugin isn't installed. Run `fledge plugins install --defaults` for the curated set.
+- **A multi-model `fledge review` panel had one slot fail**: that slot's `error` field has the cause, the other slots' reviews are still valid. `--with-model` is fault-tolerant by design.
 
 ## Extending fledge for better agent support
 
 If a command you want doesn't expose `--json`, or a workflow isn't automatable, the right fix is:
 1. Open an issue tagged `agent-surface`
-2. Update the corresponding spec (`specs/<module>/<module>.spec.md`) — bump the version, add the new flag to Public API + Behavioral Examples
-3. Implement + `fledge lanes run pre-commit` + PR
+2. Update the corresponding spec (`specs/<module>/<module>.spec.md`). Bump the version, add the new flag to Public API + Behavioral Examples
+3. Implement, run `fledge lanes run pre-commit`, open the PR
 
 The project explicitly welcomes agent-surface improvements.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-brightgreen)](https://corvidlabs.github.io/fledge/)
 
-> **fledge: one Rust binary, six pillars, spec-driven by default. Templates scaffold, lanes run, plugins extend, spec-sync keeps the docs honest about the code — and any LLM drives the same CLI you do.**
+One Rust binary that runs the dev loop. Six pillars: scaffold, run, spec, AI, ship, extend. Plugins handle anything ecosystem-specific. Every command emits `--json` so an LLM can drive the same CLI you do.
 
 ```bash
 fledge templates init my-tool --template rust-cli
 cd my-tool
-fledge lanes run ci  # lint + test + build, works out of the box
+fledge lanes run ci
 ```
 
-> **Working with AI agents?** fledge has a first-class agent surface: every read command exposes `--json`, `FLEDGE_NON_INTERACTIVE=1` silences every prompt, `fledge ask` and `fledge review` are automatically spec-aware, and `fledge introspect --json` dumps the full command tree. Works with Claude CLI or any Ollama-speaking endpoint (local, cloud, or self-hosted). See [AGENTS.md](./AGENTS.md) for the one-page guide.
+Working with AI agents? See [AGENTS.md](./AGENTS.md). Every command emits `{schema_version: 1, ...}`, `FLEDGE_NON_INTERACTIVE=1` silences prompts, `fledge ask` and `fledge review` are spec-aware, and `fledge introspect --json` dumps the full command tree. Works with Claude CLI or any Ollama endpoint (local, cloud, or self-hosted).
 
 ## Install
 
 ```bash
-cargo install fledge                       # from crates.io
+cargo install fledge                       # crates.io
 brew install CorvidLabs/tap/fledge         # homebrew
 
-fledge plugins install --defaults          # one line to install the curated plugin set
+fledge plugins install --defaults          # curated plugin set
 ```
 
 <details>
@@ -36,50 +36,50 @@ git clone https://github.com/CorvidLabs/fledge.git && cd fledge && cargo install
 
 </details>
 
-## Quick Start
+## Quick start
 
-**Already have a project?** Just use it — fledge auto-detects your stack:
+Already have a project? `cd` into it, fledge auto-detects the stack:
 
 ```bash
 fledge run test       # runs your language's test command
 fledge run build      # same for build
-fledge review         # single-model AI code review
+fledge review         # AI code review against the default branch
 fledge review --with-model ollama:gpt-oss:120b-cloud,ollama:qwen3-coder:480b-cloud
-              # multi-model panel — same diff, parallel critiques, one merge decision
+              # multi-model panel, parallel critiques on the same diff
 ```
 
-**Starting fresh?** Scaffold from a template:
+Starting fresh? Scaffold from a template:
 
 ```bash
-fledge templates init my-app --template rust-cli     # built-in template
+fledge templates init my-app --template rust-cli     # built-in
 fledge templates init my-app --template user/repo    # any GitHub repo
 fledge templates init my-app                         # interactive picker
 ```
 
-**Switch AI providers in one line:**
+Switch AI providers without editing config:
 
 ```bash
-fledge ai use                                  # interactive picker (live model list for Ollama)
+fledge ai use                                  # interactive picker (live Ollama model list)
 fledge ai use ollama qwen3-coder:480b-cloud    # scriptable
-fledge ai status                               # shows provider, model, and where each value came from
+fledge ai status                               # show active provider/model and where each value came from
 ```
 
-## The Six Pillars
+## The six pillars
 
 | Pillar | Commands | What it does |
 |--------|----------|-------------|
-| **Scaffold** | `templates` (`init`, `create`, `validate`, `list`) | Local templates pillar — start any project |
-| **Run** | `run`, `lanes`, `watch` | Task runner, composable pipelines, file-watch reruns |
-| **Spec** | `spec` | spec-sync — modules declare their contract; AI uses it as context |
-| **AI** | `ai`, `ask`, `review` | Provider+model selection, spec-aware Q&A, single- and multi-model code review |
-| **Ship** | `work`, `release`, `changelog` | Branch + PR flow with AI-drafted bodies, version bump, tag, push |
-| **Extend** | `plugins`, `config`, `introspect`, `completions`, `doctor` | Plugin protocol, global config, command-tree introspection, env health |
+| Scaffold | `templates` (`init`, `create`, `list`, `search`, `validate`, `publish`) | Start a project from a template, local or remote |
+| Run | `run`, `lanes`, `watch` | Task runner, composable pipelines, file-watch reruns |
+| Spec | `spec` | spec-sync. Modules declare their contract, AI uses it as context |
+| AI | `ai`, `ask`, `review` | Provider/model selection, spec-aware Q&A, single and multi-model code review |
+| Ship | `work`, `release`, `changelog` | Branch and PR flow with AI-drafted bodies, version bump, tag, push |
+| Extend | `plugins`, `config`, `introspect`, `completions`, `doctor` | Plugin protocol, global config, command-tree introspection, env health |
 
-That's the whole core. **Anything else is a plugin.** See `fledge plugins install --defaults` below.
+That is the whole core. Anything else is a plugin.
 
-## Default Plugins
+## Default plugins
 
-The curated plugin set — three plugins that extend fledge with GitHub, dependency-health, and metrics commands. Install them all with one line:
+Three plugins extend fledge with commands that don't belong in every install. One line installs them all:
 
 ```bash
 fledge plugins install --defaults
@@ -89,30 +89,30 @@ fledge plugins install --defaults
 |--------|------|----------------------|
 | [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) | `checks`, `issues`, `prs` | the GitHub-specific browsing trio |
 | [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) | `deps` | polyglot lockfile audits |
-| [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics` | LOC/churn/test-ratio (now via `tokei` + `git`) |
+| [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics` | LOC, churn, test/source ratio (via `tokei` + `git`) |
 
-Why split them out? Because not every fledge user is on GitHub or runs a polyglot project. The core stays tight; you opt in to what you need.
+Not every fledge user is on GitHub or runs a polyglot project. The core stays tight, you opt in to what you need.
 
-(`fledge-plugin-templates-remote` and `fledge-plugin-doctor` were dropped from the default set in v0.15.2 and re-absorbed into core: `fledge templates search`/`publish` and the `Toolchains` section of `fledge doctor`. The standalone plugin repos still exist but are no longer part of `--defaults`.)
+(`fledge-plugin-templates-remote` and `fledge-plugin-doctor` were dropped from the default set in v0.15.2 and re-absorbed into core. They're now `fledge templates search`/`publish` and the `Toolchains` section of `fledge doctor`. The standalone plugin repos still exist but are no longer part of `--defaults`.)
 
-## Built-in Templates
+## Built-in templates
 
-`rust-cli` · `ts-bun` · `python-cli` · `go-cli` · `ts-node` · `static-site`
+`rust-cli`, `ts-bun`, `python-cli`, `go-cli`, `ts-node`, `static-site`
 
 Browse community templates: `fledge templates search <keyword>`
 
 ## Examples
 
-- **[Community Templates](https://github.com/CorvidLabs/fledge-templates)** — 18 ready-to-use templates (angular-app, bun-api, deno-cli, mcp-server, rust-workspace, swift-pkg, and more)
-- **[Example Lanes](https://github.com/CorvidLabs/fledge-lanes)** — language-specific CI/CD pipelines
-- **[Example Plugin](https://github.com/CorvidLabs/fledge-plugin-deploy)** — deploy/rollback plugin reference
+- [Community templates](https://github.com/CorvidLabs/fledge-templates). 18 ready-to-use templates (angular-app, bun-api, deno-cli, mcp-server, rust-workspace, swift-pkg, and more)
+- [Example lanes](https://github.com/CorvidLabs/fledge-lanes). Language-specific CI/CD pipelines
+- [Example plugin](https://github.com/CorvidLabs/fledge-plugin-deploy). Deploy/rollback plugin reference
 
-## Learn More
+## Learn more
 
-- **[Full Documentation](https://corvidlabs.github.io/fledge/)** — commands, configuration, guides
-- **[Template Authoring](https://corvidlabs.github.io/fledge/template-authoring.html)** — create and publish your own templates
-- **[Lanes Guide](https://corvidlabs.github.io/fledge/lanes.html)** — task pipelines and workflow automation
-- **[Plugins Guide](https://corvidlabs.github.io/fledge/plugins.html)** — extend fledge with community tools
+- [Full documentation](https://corvidlabs.github.io/fledge/). Commands, configuration, guides
+- [Template authoring](https://corvidlabs.github.io/fledge/template-authoring.html). How to create and publish your own templates
+- [Lanes guide](https://corvidlabs.github.io/fledge/lanes.html). Task pipelines and workflow automation
+- [Plugins guide](https://corvidlabs.github.io/fledge/plugins.html). Extend fledge with community tools
 
 ## Contributing
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -1,25 +1,25 @@
-# Using fledge with AI Agents
+# Using fledge with AI agents
 
-fledge is designed for humans *and* AI agents to use the same CLI. Human-facing docs (the rest of this book) cover *why* and *how-to*; this page covers what an agent specifically needs to know.
+fledge is designed for humans *and* AI agents to use the same CLI. Human-facing docs (the rest of this book) cover *why* and *how-to*. This page covers what an agent specifically needs to know.
 
-The canonical short-form entrypoint for agents lives at [AGENTS.md](https://github.com/CorvidLabs/fledge/blob/main/AGENTS.md) in the repository root. This page is its long-form companion — point agents to either.
+The canonical short-form entrypoint for agents lives at [AGENTS.md](https://github.com/CorvidLabs/fledge/blob/main/AGENTS.md) in the repository root. This page is its long-form companion. Point agents to either.
 
 ## Design principles
 
 fledge follows four rules that make it agent-usable:
 
 1. **Structured output is first-class.** Most commands accept `--json`. Never require an agent to screen-scrape.
-2. **Non-interactive bypass exists.** Every command that prompts has a `--yes` flag. Silence isn't success — it's a hung process.
+2. **Non-interactive bypass exists.** Every command that prompts has a `--yes` flag. Silence isn't success, it's a hung process.
 3. **Specs are machine-readable.** `fledge spec list --json` and `fledge spec show <name> --json` let agents discover the codebase's intent without filesystem spelunking.
-4. **The whole CLI introspects.** `fledge introspect --json` dumps the entire command tree (incl. plugin commands) — one call teaches an agent the surface.
+4. **The whole CLI introspects.** `fledge introspect --json` dumps the entire command tree (incl. plugin commands). One call teaches an agent the surface.
 
 ## First-time agent setup
 
 ```bash
 export FLEDGE_NON_INTERACTIVE=1               # silence every prompt
 fledge plugins install --defaults             # github + deps + metrics
-fledge introspect --json                       # full command tree (incl. plugin commands)
-fledge spec list --json                        # semantic project map
+fledge introspect --json                      # full command tree (incl. plugin commands)
+fledge spec list --json                       # semantic project map
 ```
 
 After those four lines, every command and flag is discoverable as data.
@@ -28,46 +28,53 @@ After those four lines, every command and flag is discoverable as data.
 
 ### Core commands with `--json`
 
+Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
+
+- Pillar list/query commands use `{schema_version: 1, <resource>: [...]}`.
+- Cross-cutting commands use `{schema_version: 1, action: "<verb>", ...}`.
+
 | Command | Payload shape |
 |---------|---------------|
-| `fledge introspect --json` | Full command tree: `{name, about, aliases, args, subcommands}` recursively |
-| `fledge spec list --json` | Array of `{name, version, status, path, files, section_count, required_sections, companions, missing_companions}` |
-| `fledge spec show <name> --json` | `{name, version, status, path, files, sections, companions, missing_companions}` |
-| `fledge spec check --json` | `{specs: [{name, version, status, file_count, section_count, required_count, errors, warnings}], totals: {checked, errors, warnings}, strict}` |
-| `fledge ai status --json` | `{provider, model, host, *_source}` — what's active and the source of each value |
-| `fledge ai models --provider {claude,ollama} --json` | Live model list |
-| `fledge ask "..." --json` | `{question, answer, provider, model}` |
-| `fledge review --json` | Single-model: `{base, file, diff_stats, spec_context, review, provider, model, reviews:[...]}`. With `--with-model`: `reviews:[{provider, model, elapsed_seconds, review|error}, ...]` |
-| `fledge doctor --json` | `{sections:[{name, checks:[...], informational}], passed, failed}` — four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational; missing tools render dimmed and aren't counted toward `failed`. |
-| `fledge templates list --json` | `{schema_version: 1, templates: [{name, description, source, source_ref, path}]}` |
-| `fledge templates search --json` | `{schema_version: 1, results: [{owner, name, description, stars, url, topics, trust_tier}]}` |
-| `fledge templates validate --json` | `{schema_version: 1, reports: [{path, template, errors, warnings}]}` |
-| `fledge changelog --json` | Structured changelog |
-| `fledge plugins list --json` | `{schema_version: 1, plugins: [{name, version, source, trust_tier, ...}]}` |
-| `fledge plugins audit --json` | `{schema_version: 1, audit: [{name, version, trust_tier, capabilities, ...}]}` |
-| `fledge plugins search --json` | `{schema_version: 1, results: [...]}` (same shape as templates search) |
+| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args, subcommands}` recursively |
+| `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [...]}` |
+| `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {...}}` |
+| `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs, totals, strict}` |
+| `fledge ai status --json` | `{schema_version: 1, action: "ai_status", provider, model, host, *_source}`. What's active and the source of each value |
+| `fledge ai models --provider {claude,ollama} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}` |
+| `fledge ask "..." --json` | `{schema_version: 1, action: "ask", question, answer, provider, model}` |
+| `fledge review --json` | `{schema_version: 1, action: "review", base, file, diff_stats, spec_context, reviews: [...], review?, provider?, model?}`. Top-level `review`/`provider`/`model` only when panel size is 1 |
+| `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [...], passed, failed}`. Four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational, missing tools render dimmed and aren't counted toward `failed` |
+| `fledge changelog --json` | `{schema_version: 1, action: "changelog", releases: [{tag, date, sections}]}` |
+| `fledge run --list --json` | `{schema_version: 1, action: "run_list", auto_detected, tasks: [...]}` |
+| `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` |
+| `fledge templates list --json` | `{schema_version: 1, templates: [...]}` |
+| `fledge templates search --json` | `{schema_version: 1, results: [...]}` |
+| `fledge templates validate --json` | `{schema_version: 1, reports: [...]}` |
+| `fledge plugins list --json` | `{schema_version: 1, plugins: [...]}` |
+| `fledge plugins audit --json` | `{schema_version: 1, audit: [...]}` |
+| `fledge plugins search --json` | `{schema_version: 1, results: [...]}` |
 | `fledge plugins validate --json` | `{schema_version: 1, path, plugin_name, errors, warnings}` |
-| `fledge lanes list --json` | `{schema_version: 1, lanes: [{name, description, steps, fail_fast, source?, trust_tier}]}` |
-| `fledge lanes search --json` | `{schema_version: 1, results: [...]}` (same shape as templates search) |
-| `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps: [...], failures: [...]}` |
+| `fledge lanes list --json` | `{schema_version: 1, lanes: [...]}` |
+| `fledge lanes search --json` | `{schema_version: 1, results: [...]}` |
+| `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps, failures}` |
 | `fledge lanes validate --json` | `{schema_version: 1, path, lane_count, errors, warnings}` |
-| `fledge work start <name> --json` | `{branch, base, type, prefix, issue}` |
-| `fledge work pr --json` | `{url, number, title, head, base, draft}` (suppresses preview/confirm) |
-| `fledge work status --json` | `{branch, default, ahead, behind, pr}` |
+| `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}` |
+| `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}` |
+| `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}` |
 
 ### Plugin commands with `--json` (after `plugins install --defaults`)
 
 | Command | Plugin |
 |---------|--------|
-| `fledge checks --json` | `fledge-plugin-github` — raw GitHub API `check-runs` response |
+| `fledge checks --json` | `fledge-plugin-github`. Raw GitHub API `check-runs` response |
 | `fledge issues --json` / `issues view <n> --json` | `fledge-plugin-github` |
 | `fledge prs --json` / `prs view <n> --json` | `fledge-plugin-github` |
-| `fledge deps --json` | `fledge-plugin-deps` — ecosystem tool's native output |
-| `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` — LOC summary (tokei linked as a library), per-file churn, test/source ratio |
+| `fledge deps --json` | `fledge-plugin-deps`. Ecosystem tool's native output |
+| `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics`. LOC summary (tokei linked as a library), per-file churn, test/source ratio |
 
 ### Non-interactive mode (one switch)
 
-Set `FLEDGE_NON_INTERACTIVE=1` in your environment, or pass `--non-interactive` (alias `--ni`) per invocation. Both flip a global flag that every prompt site observes: every `--yes`/`--force` is auto-promoted, and prompts that need user input bail cleanly instead of hanging.
+Set `FLEDGE_NON_INTERACTIVE=1` in your environment, or pass `--non-interactive` (alias `--ni`) per invocation. Both flip a global flag that every prompt site observes. Every `--yes`/`--force` is auto-promoted, and prompts that need user input bail cleanly instead of hanging.
 
 Commands covered: `fledge templates init`, `fledge templates create`, `fledge templates publish`, `fledge work pr` (preview/confirm), `fledge ai use`, `fledge plugins install`, `fledge plugins publish`, `fledge plugins create`, `fledge lanes publish`.
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Every command, every flag. If it's in fledge core, it's here. Plugin commands (`checks`, `issues`, `prs`, `deps`, `metrics`) ship as separate repos — install them with `fledge plugins install --defaults`.
+Every command, every flag. If it's in fledge core, it's here. Plugin commands (`checks`, `issues`, `prs`, `deps`, `metrics`) ship as separate repos, install them with `fledge plugins install --defaults`.
 
 **Jump to:**
 [Scaffold](#scaffold-templates) |
@@ -283,9 +283,9 @@ fledge config <get|set|unset|add|remove|list|path|init>
 | `init [--preset <name>]` | Initialize config (presets: `corvidlabs`) |
 
 **Valid keys:**
-- `defaults.author`, `defaults.github_org`, `defaults.license`
+- `defaults.author`: `defaults.github_org`, `defaults.license`
 - `github.token`
-- `templates.paths`, `templates.repos`
+- `templates.paths`: `templates.repos`
 
 ```bash
 fledge config set defaults.author "Leif"
@@ -299,10 +299,10 @@ fledge config list
 
 Diagnose fledge's environment health. Reports four sections:
 
-- **`fledge`** — config loads cleanly
-- **`Git`** — git installed; repo initialized; remote configured; working tree clean
-- **`AI`** — Claude CLI present, Ollama reachable, the active provider's status
-- **`Toolchains`** *(informational)* — probes 16 toolchains across rust (`rustc`, `cargo`), node (`node`, `npm`, `pnpm`, `bun`, `yarn`), python (`python3`, `uv`, `poetry`), `go`, `ruby`, `swift`, JVM (`java`, `gradle`, `mvn`). Missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals — a Python project shouldn't fail because Swift is absent.
+- **`fledge`**: config loads cleanly
+- **`Git`**: git installed; repo initialized; remote configured; working tree clean
+- **`AI`**: Claude CLI present, Ollama reachable, the active provider's status
+- **`Toolchains`** *(informational)*: probes 16 toolchains across rust (`rustc`, `cargo`), node (`node`, `npm`, `pnpm`, `bun`, `yarn`), python (`python3`, `uv`, `poetry`), `go`, `ruby`, `swift`, JVM (`java`, `gradle`, `mvn`). Missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals. A Python project shouldn't fail because Swift is absent.
 
 ```
 fledge doctor [OPTIONS]
@@ -327,28 +327,28 @@ fledge work <start|pr|status> [OPTIONS]
 
 **Subcommands:**
 
-- `start <name>` — Create a work branch
-- `pr` — Open a PR with auto-generated title + body, styled preview, and y/n confirm. See options below.
-- `status` — Current branch + PR status
+- `start <name>`: Create a work branch
+- `pr`: Open a PR with auto-generated title + body, styled preview, and y/n confirm. See options below.
+- `status`: Current branch + PR status
 
 **Options for `work start`:**
 
-- `-t, --branch-type <TYPE>` — Branch type: `feat`, `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, `refactor` [default: `feat`]
-- `-i, --issue <NUMBER>` — Link to GitHub issue (prefixes branch name with issue number)
-- `--prefix <PREFIX>` — Override branch prefix entirely (e.g. `user/leif`)
-- `--base <BRANCH>` — Base branch [default: `main`]
+- `-t, --branch-type <TYPE>`: Branch type: `feat`, `feature`, `fix`, `bug`, `chore`, `task`, `docs`, `hotfix`, `refactor` [default: `feat`]
+- `-i, --issue <NUMBER>`: Link to GitHub issue (prefixes branch name with issue number)
+- `--prefix <PREFIX>`: Override branch prefix entirely (e.g. `user/leif`)
+- `--base <BRANCH>`: Base branch [default: `main`]
 
 **Options for `work pr`:**
 
-- `-t, --title <TITLE>` — PR title (auto-generated from branch name if omitted)
-- `-b, --body <BODY>` — Literal body (always wins over `--ai` and the heuristic generator)
-- `--draft` — Create as a draft PR
-- `--base <BASE>` — Target base branch
-- `-y, --yes` — Skip the preview/confirmation prompt (agent-friendly)
-- `--ai` — Generate the body via the configured LLM (uses commit log + diffstat + truncated diff as context). Produces a Markdown body with `## Summary` + `## Test plan` sections
-- `--provider {claude,ollama}` — Override AI provider for `--ai`
-- `--model <MODEL>` — Override AI model for `--ai`
-- `--json` — Emit `{url, number, title, head, base, draft}`; suppresses the preview
+- `-t, --title <TITLE>`: PR title (auto-generated from branch name if omitted)
+- `-b, --body <BODY>`: Literal body (always wins over `--ai` and the heuristic generator)
+- `--draft`: Create as a draft PR
+- `--base <BASE>`: Target base branch
+- `-y, --yes`: Skip the preview/confirmation prompt (agent-friendly)
+- `--ai`: Generate the body via the configured LLM (uses commit log + diffstat + truncated diff as context). Produces a Markdown body with `## Summary` + `## Test plan` sections
+- `--provider {claude,ollama}`: Override AI provider for `--ai`
+- `--model <MODEL>`: Override AI model for `--ai`
+- `--json`: Emit `{url, number, title, head, base, draft}`; suppresses the preview
 
 **Behavior:** `work pr` shows a styled preview block (title, head→base, draft tag, full body) before any push or `gh pr create` call, then prompts y/n. Choosing **n** prints `✋ Aborted.` and exits 0 with no side effects. `--yes` skips the prompt; `--json` skips it as well. Non-interactive shells without `--yes`/`--json` bail with a clear message rather than hanging.
 
@@ -392,7 +392,7 @@ fledge spec <check|init|new> [OPTIONS]
 
 ### fledge ai `<action>`
 
-Manage AI provider and model selection — the daily-driver way to switch between Claude and any Ollama-speaking endpoint.
+Manage AI provider and model selection, the daily-driver way to switch between Claude and any Ollama-speaking endpoint.
 
 ```
 fledge ai <status|models|use> [OPTIONS]
@@ -400,9 +400,9 @@ fledge ai <status|models|use> [OPTIONS]
 
 **Subcommands:**
 
-- `status [--json]` — Show active provider, model, and host with a `(from env / config / default)` source tag on each value
-- `models --provider {claude,ollama} [--search <q>] [--json]` — Live list of available models (Ollama hits `/api/tags`; Claude returns curated aliases)
-- `use [provider] [model]` — Interactive picker (live model list for Ollama) or fully scriptable via positional args. Writes to `~/.config/fledge/config.toml`
+- `status [--json]`: Show active provider, model, and host with a `(from env / config / default)` source tag on each value
+- `models --provider {claude,ollama} [--search <q>] [--json]`: Live list of available models (Ollama hits `/api/tags`; Claude returns curated aliases)
+- `use [provider] [model]`: Interactive picker (live model list for Ollama) or fully scriptable via positional args. Writes to `~/.config/fledge/config.toml`
 
 ```bash
 fledge ai status                                  # who's active and why
@@ -422,17 +422,17 @@ fledge review [OPTIONS]
 ```
 
 **Options:**
-- `-b, --base <BRANCH>` — Base branch [default: auto-detect]
-- `-f, --file <FILE>` — Review a single file
-- `-m, --model <MODEL>` — Override the active provider's model
-- `--provider {claude,ollama}` — Override the active provider
-- `-p, --prompt <TEXT>` — Append a custom focus prompt
-- `--format {summary,checklist,inline}` — Output format [default: summary]
-- `--with-specs <NAMES>` — Force-include specs (comma-separated, repeatable)
-- `--no-auto-specs` — Skip auto-detection of relevant specs
-- `--with-model <REF>` — Add another model to the review panel (repeatable, comma-separated). Format: `provider[:model]`
-- `--no-active` — Drop the active config from the panel; only run explicit `--with-model` entries
-- `--json` — JSON output (single-model: legacy fields + `reviews[]`; multi-model: `reviews[]` only)
+- `-b, --base <BRANCH>`: Base branch [default: auto-detect]
+- `-f, --file <FILE>`: Review a single file
+- `-m, --model <MODEL>`: Override the active provider's model
+- `--provider {claude,ollama}`: Override the active provider
+- `-p, --prompt <TEXT>`: Append a custom focus prompt
+- `--format {summary,checklist,inline}`: Output format [default: summary]
+- `--with-specs <NAMES>`: Force-include specs (comma-separated, repeatable)
+- `--no-auto-specs`: Skip auto-detection of relevant specs
+- `--with-model <REF>`: Add another model to the review panel (repeatable, comma-separated). Format: `provider[:model]`
+- `--no-active`: Drop the active config from the panel; only run explicit `--with-model` entries
+- `--json`: JSON output (single-model: legacy fields + `reviews[]`; multi-model: `reviews[]` only)
 
 **Default branch detection:** When `--base` is not specified, fledge tries `git symbolic-ref refs/remotes/origin/HEAD`, then checks for `main` and `master` branches. Falls back to `main` if none exist.
 
@@ -448,18 +448,18 @@ fledge review --json | jq '.reviews[].provider'
 
 ### fledge ask `<question>`
 
-Ask about your codebase. Spec-aware by default — the active model gets a compact index of every spec injected into the prompt.
+Ask about your codebase. Spec-aware by default, the active model gets a compact index of every spec injected into the prompt.
 
 ```
 fledge ask <question> [OPTIONS]
 ```
 
 **Options:**
-- `-m, --model <MODEL>` — Override active model
-- `--provider {claude,ollama}` — Override active provider
-- `--with-specs <NAMES>` — Include full spec + companions for these modules (comma-separated; pass `all` for everything)
-- `--no-spec-index` — Skip the spec-index injection (for off-topic questions)
-- `--json` — JSON output
+- `-m, --model <MODEL>`: Override active model
+- `--provider {claude,ollama}`: Override active provider
+- `--with-specs <NAMES>`: Include full spec + companions for these modules (comma-separated; pass `all` for everything)
+- `--no-spec-index`: Skip the spec-index injection (for off-topic questions)
+- `--json`: JSON output
 
 ```bash
 fledge ask "how does the template rendering work?"
@@ -517,16 +517,16 @@ fledge issues view <number> [OPTIONS]
 ```
 
 **Options:**
-- `-s, --state <STATE>` — `open`, `closed`, `all` [default: `open`]
-- `-l, --limit <N>` — Max results [default: `20`]
-- `--label <LABEL>` — Filter by label
+- `-s, --state <STATE>`: `open`, `closed`, `all` [default: `open`]
+- `-l, --limit <N>`: Max results [default: `20`]
+- `--label <LABEL>`: Filter by label
 - `--json`
 
 ---
 
 ### fledge prs `[view <number>]` (plugin)
 
-Provided by [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github). List and view PRs (read-only — `fledge work pr` creates them).
+Provided by [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github). List and view PRs (read-only, `fledge work pr` creates them).
 
 ```
 fledge prs [list] [OPTIONS]
@@ -534,8 +534,8 @@ fledge prs view <number> [OPTIONS]
 ```
 
 **Options:**
-- `-s, --state <STATE>` — `open`, `closed`, `merged`, `all` [default: `open`]
-- `-l, --limit <N>` — Max results [default: `20`]
+- `-s, --state <STATE>`: `open`, `closed`, `merged`, `all` [default: `open`]
+- `-l, --limit <N>`: Max results [default: `20`]
 - `--json`
 
 ---
@@ -549,7 +549,7 @@ fledge checks [OPTIONS]
 ```
 
 **Options:**
-- `-b, --branch <BRANCH>` — Branch to check [default: current]
+- `-b, --branch <BRANCH>`: Branch to check [default: current]
 - `--json`
 
 ---
@@ -579,7 +579,7 @@ fledge changelog --tag v0.7.0
 
 ### fledge release `<bump>`
 
-Cut a release — bump version, generate changelog, create a git tag, and optionally push.
+Cut a release, bump version, generate changelog, create a git tag, and optionally push.
 
 ```
 fledge release <bump> [OPTIONS]
@@ -620,15 +620,15 @@ fledge plugins <install|remove|update|list|search|run|publish|create|validate> [
 
 **Subcommands:**
 
-- `install <source[@ref]> | --defaults` — Install from GitHub (`owner/repo[@tag]` or URL). `--force` to reinstall. Use `@ref` to pin to a tag, branch, or commit. **`--defaults`** installs the curated plugin set (`fledge-plugin-{github,deps,metrics}`) in one shot.
-- `remove <name>` — Uninstall a plugin
-- `update [name]` — Update plugins. Unpinned plugins get `git pull`; pinned plugins check for newer tags.
-- `list` — Show installed plugins (includes pinned version info)
-- `search [query]` — Find plugins on GitHub (`--author`, `--limit`)
-- `run <name> [args...]` — Run a plugin command
-- `publish [path]` — Publish a plugin to GitHub (`--org`, `--private`, `--description`)
-- `create <name>` — Scaffold a new plugin (`--output`, `--description`, `--yes`)
-- `validate [path]` — Validate a plugin manifest (`--strict`, `--json`)
+- `install <source[@ref]> | --defaults`: Install from GitHub (`owner/repo[@tag]` or URL). `--force` to reinstall. Use `@ref` to pin to a tag, branch, or commit. **`--defaults`** installs the curated plugin set (`fledge-plugin-{github,deps,metrics}`) in one shot.
+- `remove <name>`: Uninstall a plugin
+- `update [name]`: Update plugins. Unpinned plugins get `git pull`; pinned plugins check for newer tags.
+- `list`: Show installed plugins (includes pinned version info)
+- `search [query]`: Find plugins on GitHub (`--author`, `--limit`)
+- `run <name> [args...]`: Run a plugin command
+- `publish [path]`: Publish a plugin to GitHub (`--org`, `--private`, `--description`)
+- `create <name>`: Scaffold a new plugin (`--output`, `--description`, `--yes`)
+- `validate [path]`: Validate a plugin manifest (`--strict`, `--json`)
 
 `--json` works with `list` and `search`.
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -108,8 +108,8 @@ If neither env var nor config is set, fledge falls back to `gh auth token` (GitH
 Per-project settings live in `fledge.toml` in your project root. This file defines tasks, lanes, and project metadata. It's created by `fledge run --init` or `fledge templates init`.
 
 For task and lane configuration, see:
-- [Lanes & Pipelines](./lanes.md) — defining lanes, step types, parallel groups, importing community lanes
-- [Plugins](./plugins.md) — extending fledge with community plugins
+- [Lanes & Pipelines](./lanes.md), defining lanes, step types, parallel groups, importing community lanes
+- [Plugins](./plugins.md), extending fledge with community plugins
 
 ## Priority Order
 

--- a/docs/src/doctor.md
+++ b/docs/src/doctor.md
@@ -1,4 +1,4 @@
-# Doctor: Environment Diagnostics
+# Doctor: environment diagnostics
 
 `fledge doctor` checks your environment for issues that might cause problems. Run it when something isn't working right, or proactively before starting a new project.
 
@@ -9,13 +9,13 @@ fledge doctor
 fledge doctor --json
 ```
 
-## What It Checks
+## What it checks
 
 Doctor reports four sections:
 
 ### `fledge`
 
-- `fledge config` — does `~/.config/fledge/config.toml` parse cleanly?
+- `fledge config`. Does `~/.config/fledge/config.toml` parse cleanly?
 
 ### `Git`
 
@@ -28,7 +28,7 @@ Doctor reports four sections:
 
 - `claude` CLI is installed (powers `fledge review` and `fledge ask` when the active provider is `claude`)
 - `ollama` binary is installed (powers the `ollama` provider)
-- The active provider's reachability — when Ollama is active, doctor probes `<host>/api/tags` with a 3-second timeout to distinguish "daemon down" from "not installed"
+- The active provider's reachability. When Ollama is active, doctor probes `<host>/api/tags` with a 3-second timeout to distinguish "daemon down" from "not installed"
 
 ### `Toolchains` *(informational)*
 
@@ -44,7 +44,7 @@ Probes 16 toolchains across the major language ecosystems:
 | Swift | `swift` |
 | JVM | `java`, `gradle`, `mvn` |
 
-The Toolchains section is **informational** — missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals. A Python project shouldn't fail because Swift is absent, so doctor reports the toolchain inventory without treating absence as failure.
+The Toolchains section is **informational**. Missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals. A Python project shouldn't fail because Swift is absent, so doctor reports the toolchain inventory without treating absence as failure.
 
 ## Output
 
@@ -52,18 +52,18 @@ The Toolchains section is **informational** — missing entries render dimmed (`
 $ fledge doctor
 
   fledge
-    ✅ fledge config 0.15.2 — loaded
+    ✅ fledge config 0.15.3, loaded
 
   Git
     ✅ git 2.50.1
-    ✅ repository — initialized
-    ✅ remote — origin ➡️ git@github.com:CorvidLabs/fledge.git
-    ✅ working tree — clean
+    ✅ repository, initialized
+    ✅ remote, origin ➡️ git@github.com:CorvidLabs/fledge.git
+    ✅ working tree, clean
 
   AI
     ✅ claude 2.1.119
     ✅ ollama 0.21.2
-    ✅ Active provider: ollama — ollama is the active provider (model: gpt-oss:120b-cloud, host: http://localhost:11434)
+    ✅ Active provider: ollama (model: gpt-oss:120b-cloud, host: http://localhost:11434)
 
   Toolchains
     ✅ rustc 1.93.0
@@ -82,27 +82,29 @@ $ fledge doctor
 
 Pass/fail totals only count the non-informational sections.
 
-## When to Run It
+## When to run it
 
-- Before your first `fledge templates init` to make sure your environment is ready
-- When `fledge run` can't find the right command for your project type — the `Toolchains` section will tell you what's missing
-- When AI commands fail — the `AI` section distinguishes "Claude not installed" from "Ollama daemon down" from "wrong provider configured"
+- Before your first `fledge templates init`, to make sure your environment is ready
+- When `fledge run` can't find the right command for your project type. The `Toolchains` section will tell you what's missing
+- When AI commands fail. The `AI` section distinguishes "Claude not installed" from "Ollama daemon down" from "wrong provider configured"
 - After upgrading your toolchain or switching machines
 
-## JSON Output
+## JSON output
 
 ```bash
 fledge doctor --json
 ```
 
-Returns a structured report:
+Returns a structured envelope:
 
 ```json
 {
+  "schema_version": 1,
+  "action": "doctor",
   "sections": [
     {
       "name": "fledge",
-      "checks": [{"name": "fledge config", "status": "ok", "version": "0.15.2", "detail": "loaded", "fix": null}]
+      "checks": [{"name": "fledge config", "status": "ok", "version": "0.15.3", "detail": "loaded", "fix": null}]
     },
     {
       "name": "Toolchains",

--- a/docs/src/github-integration.md
+++ b/docs/src/github-integration.md
@@ -1,6 +1,6 @@
 # GitHub Integration
 
-GitHub-specific browsing — `checks`, `issues`, `prs` — moved out of core in v0.15. They live in [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github), one of the default plugins. **Branch and PR creation stays in core** via `fledge work`.
+GitHub-specific browsing, `checks`, `issues`, `prs`, moved out of core in v0.15. They live in [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github), one of the default plugins. **Branch and PR creation stays in core** via `fledge work`.
 
 ```bash
 fledge plugins install --defaults
@@ -22,7 +22,7 @@ fledge config set github.token "ghp_..."
 
 Token priority: `FLEDGE_GITHUB_TOKEN` > `GITHUB_TOKEN` > config file > `gh auth token` (GitHub CLI).
 
-If you have the GitHub CLI (`gh`) installed and authenticated, fledge uses it automatically as a fallback — no extra config needed.
+If you have the GitHub CLI (`gh`) installed and authenticated, fledge uses it automatically as a fallback, no extra config needed.
 
 The repo is auto-detected from your git remote.
 
@@ -107,7 +107,7 @@ fledge review                    # single-model review (active config)
 fledge review --base develop     # diff against develop
 fledge review --file src/main.rs # just one file
 fledge review --with-model ollama:gpt-oss:120b-cloud --with-model ollama:qwen3-coder:480b-cloud
-                                 # multi-model panel — same diff, parallel critiques
+                                 # multi-model panel, same diff, parallel critiques
 ```
 
 ## AI Q&A (core)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,23 +1,23 @@
 # Introduction
 
-**fledge: one Rust binary, six pillars, spec-driven by default. Templates scaffold, lanes run, plugins extend, spec-sync keeps the docs honest about the code — and any LLM drives the same CLI you do.**
+One Rust binary that runs the dev loop. Six pillars: scaffold, run, spec, AI, ship, extend. Plugins handle anything ecosystem-specific. Every command emits `--json` so an LLM can drive the same CLI you do.
 
 ## Why I built this
 
 I kept setting up the same boilerplate across projects. CI workflows, linters, task runners, the works. Every new repo meant copy-pasting from the last one and fixing whatever broke. fledge started as a scaffolding tool and grew into a full dev lifecycle CLI because once you have a tool that understands your project structure, it makes sense to keep going.
 
-In v0.15 the tool got smaller. Anything ecosystem-specific (lockfile parsers, GitHub clients, language toolchain probes) moved out to plugins. The core stays tight; you opt in to what you need.
+In v0.15 the tool got smaller. Anything ecosystem-specific (lockfile parsers, GitHub clients, language toolchain probes) moved out to plugins. The core stays tight, you opt in to what you need.
 
-## The Six Pillars
+## The six pillars
 
 | Pillar | Commands | What it does |
 |--------|----------|-------------|
-| **Scaffold** | `templates` (`init`, `create`, `validate`, `list`) | Local templates pillar — start any project |
-| **Run** | `run`, `lanes`, `watch` | Task runner, composable pipelines, file-watch reruns |
-| **Spec** | `spec` | spec-sync — modules declare their contract; AI uses it as context |
-| **AI** | `ai`, `ask`, `review` | Provider+model selection, spec-aware Q&A, single- and multi-model review |
-| **Ship** | `work`, `release`, `changelog` | Branch + PR flow with AI-drafted bodies, version bump, tag, push |
-| **Extend** | `plugins`, `config`, `introspect`, `completions`, `doctor` | Plugin protocol, global config, command-tree introspection, env health |
+| Scaffold | `templates` (`init`, `create`, `list`, `search`, `validate`, `publish`) | Start a project from a template, local or remote |
+| Run | `run`, `lanes`, `watch` | Task runner, composable pipelines, file-watch reruns |
+| Spec | `spec` | spec-sync. Modules declare their contract, AI uses it as context |
+| AI | `ai`, `ask`, `review` | Provider/model selection, spec-aware Q&A, single and multi-model review |
+| Ship | `work`, `release`, `changelog` | Branch and PR flow with AI-drafted bodies, version bump, tag, push |
+| Extend | `plugins`, `config`, `introspect`, `completions`, `doctor` | Plugin protocol, global config, command-tree introspection, env health |
 
 Start a project, run your tasks, evolve specs and code together, get AI to ask + review, ship to git/GitHub. Extend through plugins. That's the whole loop.
 
@@ -33,4 +33,4 @@ That gets you `checks`/`issues`/`prs` (GitHub), `deps`, and `metrics`. See the [
 
 ## Zero-config
 
-It still auto-detects your project type (Rust, Node, Go, Python, Ruby, Java, Swift) and generates sensible defaults. You don't need `fledge templates init` to get started — just `cd` into any existing project and run `fledge run test`. It works with zero config. When you want more control, `fledge run --init` generates a `fledge.toml` tailored to your stack.
+It auto-detects your project type (Rust, Node, Go, Python, Ruby, Java, Swift) and generates sensible defaults. You don't need `fledge templates init` to get started, just `cd` into any existing project and run `fledge run test`. It works with zero config. When you want more control, `fledge run --init` generates a `fledge.toml` tailored to your stack.

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -118,7 +118,7 @@ steps = ["lint", "test", "security-check", "license-check"]
 Every step prints its elapsed time, and the lane summary shows total time:
 
 ```
-▶️ Lane: ci — Full CI pipeline
+▶️ Lane: ci, Full CI pipeline
   ▶️ Running parallel: fmt, lint
   ✔ Step 1 done (245ms)
   ▶️ Running task: test
@@ -263,7 +263,7 @@ fledge lanes publish ./my-lanes      # push to GitHub (validates first)
 
 1. Create a repo with a `fledge.toml` containing your lanes and tasks (or use `fledge lanes create`)
 2. Validate with `fledge lanes validate` (publish does this automatically)
-3. Publish with `fledge lanes publish` — sets the `fledge-lane` topic automatically
+3. Publish with `fledge lanes publish` (sets the `fledge-lane` topic automatically)
 4. Others can find it with `fledge lanes search` and import it
 
 ### Importing Lanes
@@ -282,10 +282,10 @@ fledge lanes import CorvidLabs/fledge-lanes@v1.0.0
 
 ## Related
 
-- [Configuration](./configuration.md) — global config, GitHub tokens
-- [Plugins](./plugins.md) — extend fledge with community commands, use plugins in lanes
-- [CLI Reference](./cli-reference.md) — full `fledge lanes` subcommand reference
-- [Example Lanes](https://github.com/CorvidLabs/fledge-lanes) — official community lane collection
+- [Configuration](./configuration.md), global config, GitHub tokens
+- [Plugins](./plugins.md), extend fledge with community commands, use plugins in lanes
+- [CLI Reference](./cli-reference.md), full `fledge lanes` subcommand reference
+- [Example Lanes](https://github.com/CorvidLabs/fledge-lanes), official community lane collection
 
 ## Tips
 

--- a/docs/src/pillars.md
+++ b/docs/src/pillars.md
@@ -1,6 +1,6 @@
-# The Six Pillars
+# The six pillars
 
-fledge organizes your dev workflow into six pillars. They cover the whole lifecycle from project creation to release, and they're explicitly the *only* things core ships. Anything else is a plugin.
+fledge organizes the dev workflow into six pillars. They cover the whole lifecycle from project creation to release, and they're explicitly the *only* things core ships. Anything else is a plugin.
 
 ```
 Scaffold --> Run --> Spec --> AI --> Ship
@@ -22,13 +22,13 @@ Define your tasks, wire them into pipelines, watch files for re-runs. This is wh
 
 ## Spec
 
-spec-sync: every module declares a contract (`specs/<name>/<name>.spec.md` plus optional companion files). The contract is the source of truth for *why* a module exists, and AI commands inject the relevant specs as context. Your code and your docs literally cannot drift.
+spec-sync. Every module declares a contract (`specs/<name>/<name>.spec.md` plus optional companion files). The contract is the source of truth for *why* a module exists, and AI commands inject the relevant specs as context. Code and docs literally cannot drift.
 
 **Commands:** `spec` (subcommands: `check`, `init`, `list`, `show`, `new`)
 
 ## AI
 
-Provider-agnostic AI in the daily-driver path. Switch between Claude CLI and any Ollama-speaking endpoint in one line; ask questions about your codebase; review your diff with one model or a panel of them in parallel.
+Provider-agnostic AI in the daily-driver path. Switch between Claude CLI and any Ollama-speaking endpoint in one line. Ask questions about your codebase. Review your diff with one model or a panel of them in parallel.
 
 **Commands:** `ai` (`status`, `models`, `use`), `ask`, `review`
 
@@ -38,7 +38,7 @@ Branch, draft an AI-written PR body, preview, confirm, push. Then bump version, 
 
 **Commands:** `work` (`start`, `pr`, `status`), `release`, `changelog`
 
-For GitHub-specific browsing of the resulting PR/checks/issues, install [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github). Ships in the default plugin set.
+For GitHub-specific browsing of the resulting PR, checks, and issues, install [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github). Ships in the default plugin set.
 
 ## Extend
 
@@ -48,10 +48,10 @@ Plugins, configuration, command-tree introspection, environment diagnostics, she
 
 `fledge plugins install --defaults` installs the curated set:
 
-- [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) → `checks`, `issues`, `prs`
-- [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) → `deps`
-- [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) → `metrics` (Rust binary linking `tokei` as a library)
+- [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) adds `checks`, `issues`, `prs`
+- [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) adds `deps`
+- [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) adds `metrics` (Rust binary linking `tokei` as a library)
 
-Why these are plugins, not core: each one bakes an ecosystem assumption (GitHub-only, polyglot lockfile parsers, niche metrics) that not every fledge user needs. Plugins keep the binary small and let each capability evolve independently.
+Why these are plugins and not core: each one bakes an ecosystem assumption (GitHub-only, polyglot lockfile parsers, niche metrics) that not every fledge user needs. Plugins keep the binary small and let each capability evolve independently.
 
-(Through v0.15.1, `--defaults` also installed `fledge-plugin-templates-remote` and `fledge-plugin-doctor`. Both were re-absorbed into core in v0.15.2: their commands now ship as `fledge templates search`/`publish` and the `Toolchains` section of `fledge doctor`.)
+(Through v0.15.1, `--defaults` also installed `fledge-plugin-templates-remote` and `fledge-plugin-doctor`. Both were re-absorbed into core in v0.15.2. Their commands now ship as `fledge templates search`/`publish` and the `Toolchains` section of `fledge doctor`.)

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -190,7 +190,7 @@ Each entry registers a subcommand.
 
 ### [capabilities]
 
-Capabilities declare what protocol features the plugin uses. All default to `false` — plugins must opt in.
+Capabilities declare what protocol features the plugin uses. All default to `false`. Plugins must opt in.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -215,7 +215,7 @@ Plugins without a `[capabilities]` section work fine but cannot use exec, store,
 
 ### [hooks]
 
-Hooks fire in response to fledge lifecycle events. All fields are optional — plugins only participate in events they declare.
+Hooks fire in response to fledge lifecycle events. All fields are optional, plugins only participate in events they declare.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -283,7 +283,7 @@ The token is resolved in order:
 3. `github.token` in `~/.config/fledge/config.toml`
 4. `gh auth token` (GitHub CLI fallback)
 
-If you have the GitHub CLI (`gh`) installed and authenticated, fledge will use it automatically — no extra config needed.
+If you have the GitHub CLI (`gh`) installed and authenticated, fledge will use it automatically. No extra config needed.
 
 ```bash
 # Set via config
@@ -296,17 +296,17 @@ export GITHUB_TOKEN=ghp_your_token_here
 gh auth login
 ```
 
-The token is injected via git's `http.extraheader` mechanism — it is never embedded in remote URLs or persisted to disk.
+The token is injected via git's `http.extraheader` mechanism. It is never embedded in remote URLs or persisted to disk.
 
 ## Security Model
 
 Plugins run arbitrary code. Fledge has several safeguards:
 
-- **Install confirmation** — before cloning, fledge warns that plugins can execute arbitrary code and asks for confirmation. Pass `--force` to skip (CI/scripts).
-- **Plugin name validation** — repo names are checked for path traversal (`..`, `/`, `\`, leading `.`)
-- **Command name validation** — command names that become symlinks (`fledge-<name>`) are validated to reject `/`, `\`, `.` prefix, `-` prefix, and null bytes
-- **Binary path traversal** — plugin binaries cannot reference paths outside the plugin directory (both sides are canonicalized to defeat symlink bypass)
-- **Hook execution** — hooks run as direct processes, not via a shell. This prevents shell injection but means pipes, redirects, and shell expansions won't work in hook commands. Use a wrapper script if you need shell features.
+- **Install confirmation**: before cloning, fledge warns that plugins can execute arbitrary code and asks for confirmation. Pass `--force` to skip (CI/scripts).
+- **Plugin name validation**: repo names are checked for path traversal (`..`, `/`, `\`, leading `.`)
+- **Command name validation**: command names that become symlinks (`fledge-<name>`) are validated to reject `/`, `\`, `.` prefix, `-` prefix, and null bytes
+- **Binary path traversal**: plugin binaries cannot reference paths outside the plugin directory (both sides are canonicalized to defeat symlink bypass)
+- **Hook execution**: hooks run as direct processes, not via a shell. This prevents shell injection but means pipes, redirects, and shell expansions won't work in hook commands. Use a wrapper script if you need shell features.
 
 ### CI / Non-Interactive Usage
 

--- a/docs/src/review.md
+++ b/docs/src/review.md
@@ -29,7 +29,7 @@ fledge review --json                # machine-readable output
 
 ### Multi-model review (v0.15+)
 
-Pass `--with-model <provider[:model]>` to add another slot to the panel. All slots run in parallel against the same diff and spec context. Per-slot failures don't abort the panel — you still get reviews from the models that succeeded.
+Pass `--with-model <provider[:model]>` to add another slot to the panel. All slots run in parallel against the same diff and spec context. Per-slot failures don't abort the panel, you still get reviews from the models that succeeded.
 
 ```bash
 # Active config + two cloud models
@@ -46,10 +46,10 @@ The text output prints cyan banner headers between model slots and includes per-
 
 ### What it reviews
 
-- **Bugs and logic errors** — off-by-ones, null handling, race conditions
-- **Security issues** — injection, auth bypasses, secret exposure
-- **Performance** — unnecessary allocations, N+1 queries, blocking calls
-- **Clarity** — confusing naming, missing context, overly complex code
+- **Bugs and logic errors**: off-by-ones, null handling, race conditions
+- **Security issues**: injection, auth bypasses, secret exposure
+- **Performance**: unnecessary allocations, N+1 queries, blocking calls
+- **Clarity**: confusing naming, missing context, overly complex code
 
 ### How it works
 
@@ -62,9 +62,9 @@ The prompt is explicitly constrained: the model reviews *only the diff*, treats 
 
 ### Tips
 
-- Review early and often — smaller diffs get better reviews
+- Review early and often, smaller diffs get better reviews
 - Use `--file` to focus on the module you're least confident about
-- Multi-model is most useful for high-stakes diffs — the models often disagree, and the disagreement is the signal
+- Multi-model is most useful for high-stakes diffs. The models often disagree, and the disagreement is the signal
 - Pipe `--json` output into other tools for automated quality gates
 - Combine with lanes for pre-PR automation:
 
@@ -90,7 +90,7 @@ fledge ask --no-spec-index "quick Rust syntax question"
 
 ### Spec-awareness
 
-By default `fledge ask` injects a compact one-line-per-module index of every spec into the prompt. The model can cite specific specs in its answer even when you didn't mention them. Pass `--with-specs <names>` to include the *full* spec + companion files (requirements, context, tasks, testing) for one or more modules — useful for *why* questions where the design rationale matters.
+By default `fledge ask` injects a compact one-line-per-module index of every spec into the prompt. The model can cite specific specs in its answer even when you didn't mention them. Pass `--with-specs <names>` to include the *full* spec + companion files (requirements, context, tasks, testing) for one or more modules, useful for *why* questions where the design rationale matters.
 
 ### Good questions to ask
 
@@ -111,7 +111,7 @@ REVIEW=$(fledge review --json)
 
 ## Plugin: code metrics
 
-`fledge metrics` lived in core through v0.14. In v0.15 it moved to [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics). v0.15.2 rewrote the plugin in Rust — it now links `tokei` as a library (no separate `cargo install tokei` step) and emits stable plugin-owned JSON shapes. Install:
+`fledge metrics` lived in core through v0.14. In v0.15 it moved to [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics). v0.15.2 rewrote the plugin in Rust, it now links `tokei` as a library (no separate `cargo install tokei` step) and emits stable plugin-owned JSON shapes. Install:
 
 ```bash
 fledge plugins install --defaults
@@ -122,7 +122,7 @@ fledge metrics --tests           # test/source ratio
 
 ## Plugin: dependency health
 
-`fledge deps` lived in core through v0.14. In v0.15 it moved to [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) — auto-detects the ecosystem from lockfiles and shells out to the canonical tool. Install:
+`fledge deps` lived in core through v0.14. In v0.15 it moved to [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps), auto-detects the ecosystem from lockfiles and shells out to the canonical tool. Install:
 
 ```bash
 fledge plugins install --defaults

--- a/docs/src/ship.md
+++ b/docs/src/ship.md
@@ -33,7 +33,7 @@ The preview reads:
 
 ```
 ────────────────────────────────────────────────────────────
-Title: feat: work pr — auto body + preview + confirm
+Title: feat: work pr, auto body + preview + confirm
 Branch:  0xleif/feat/pr-preview-and-body → main
 
   ## Summary
@@ -46,7 +46,7 @@ Branch:  0xleif/feat/pr-preview-and-body → main
 ? Create this pull request? (Y/n)
 ```
 
-Choosing **n** prints `✋ Aborted.` and exits 0 with no side effects — nothing is pushed.
+Choosing **n** prints `✋ Aborted.` and exits 0 with no side effects. Nothing is pushed.
 
 ## GitHub browsing (plugin)
 
@@ -81,7 +81,7 @@ fledge changelog --json
 
 ## Releases with `fledge release`
 
-Cut a release — bump the version, generate changelog, create an annotated git tag, and optionally push. Pure git, no GitHub-specific calls (the GitHub Releases UI object is created separately, e.g. via `gh release create`).
+Cut a release, bump the version, generate changelog, create an annotated git tag, and optionally push. Pure git, no GitHub-specific calls (the GitHub Releases UI object is created separately, e.g. via `gh release create`).
 
 ```bash
 fledge release patch                          # bump patch version
@@ -93,12 +93,12 @@ fledge release minor --allow-dirty            # release even with uncommitted ch
 ```
 
 **Options:**
-- `--dry-run` — Preview without making changes
-- `--no-tag` — Skip git tag
-- `--no-changelog` — Skip changelog generation
-- `--push` — Push commit and tag to remote
-- `--pre-lane <name>` — Run a lane before releasing (e.g. `ci`)
-- `--allow-dirty` — Allow uncommitted changes
+- `--dry-run`: Preview without making changes
+- `--no-tag`: Skip git tag
+- `--no-changelog`: Skip changelog generation
+- `--push`: Push commit and tag to remote
+- `--pre-lane <name>`: Run a lane before releasing (e.g. `ci`)
+- `--allow-dirty`: Allow uncommitted changes
 
 ## Typical flow
 

--- a/docs/src/templates.md
+++ b/docs/src/templates.md
@@ -95,13 +95,13 @@ fledge templates search --limit 50
 fledge templates search --author CorvidLabs
 ```
 
-Templates on GitHub use the `fledge-template` topic — that's what `templates search` filters on. Add `--json` for an array of `{owner, name, description, stars, url, topics, trust_tier}`.
+Templates on GitHub use the `fledge-template` topic, that's what `templates search` filters on. Add `--json` for an array of `{owner, name, description, stars, url, topics, trust_tier}`.
 
 (Through v0.15.1, this lived in `fledge-plugin-templates-remote` as `fledge templates-search`. It was re-absorbed into core in v0.15.2 as a proper `templates` subcommand.)
 
 ## Project Metadata
 
-`fledge templates init` writes `.fledge/meta.toml` to your project root: template source, variable values used during scaffolding, and per-file SHA hashes. This metadata is informational — fledge no longer ships a built-in re-application command (the v0.14 `fledge update` was removed in v0.15 because bidirectional template sync is a known complexity trap; see the [v0.15 changelog](./changelog.md)).
+`fledge templates init` writes `.fledge/meta.toml` to your project root: template source, variable values used during scaffolding, and per-file SHA hashes. This metadata is informational, fledge no longer ships a built-in re-application command (the v0.14 `fledge update` was removed in v0.15 because bidirectional template sync is a known complexity trap; see the [v0.15 changelog](./changelog.md)).
 
 A community plugin can ingest the same `.fledge/meta.toml` if you want template-update tooling.
 

--- a/docs/src/use-cases.md
+++ b/docs/src/use-cases.md
@@ -34,7 +34,7 @@ Get a second opinion on your changes without waiting for a human reviewer:
 fledge review                                           # review with active model
 fledge review --file src/auth.rs                        # focus on one file
 fledge review --with-model ollama:gpt-oss:120b-cloud --with-model ollama:qwen3-coder:480b-cloud
-                                                        # multi-model panel — parallel critiques
+                                                        # multi-model panel, parallel critiques
 ```
 
 ### Branch workflow without remembering git incantations
@@ -76,7 +76,7 @@ fledge plugins install your-org/fledge-plugin-lint-config
 
 ```bash
 fledge plugins install --defaults    # one-line install of fledge-plugin-deps + 2 others
-fledge deps --outdated --audit       # Works for Rust, Node, Python — auto-detected from lockfiles
+fledge deps --outdated --audit       # Works for Rust, Node, Python, auto-detected from lockfiles
 ```
 
 ## For AI Agents
@@ -89,7 +89,7 @@ AI agents benefit from fledge's structured output and consistent interface. Ever
 fledge introspect --json         # full command tree (incl. plugin commands)
 fledge lanes list --json         # what pipelines exist
 fledge plugins list --json       # what extensions are installed
-fledge spec list --json          # spec index — semantic project map
+fledge spec list --json          # spec index, semantic project map
 fledge ai status --json          # what model is active and where each value came from
 
 # After fledge plugins install --defaults:
@@ -101,13 +101,13 @@ fledge checks --json             # CI status as data
 ### Autonomous code-review-and-fix loops
 
 An AI agent can:
-1. `fledge work start fix-issue-42 --issue 42` — create a branch linked to an issue
+1. `fledge work start fix-issue-42 --issue 42`, create a branch linked to an issue
 2. Make changes
-3. `fledge lanes run ci` — run the full pipeline
+3. `fledge lanes run ci`, run the full pipeline
 4. `fledge review --with-model ollama:gpt-oss:120b-cloud --with-model ollama:qwen3-coder:480b-cloud --json`
-   — multi-model review for higher-confidence findings
+  , multi-model review for higher-confidence findings
 5. Fix issues that multiple models agree on
-6. `fledge work pr --ai --yes` — AI-drafted PR with no prompt needed
+6. `fledge work pr --ai --yes`, AI-drafted PR with no prompt needed
 
 ### Plugin protocol for agent tooling
 
@@ -119,11 +119,11 @@ The fledge-v1 plugin protocol is designed for programmatic interaction. Plugins 
 {"type": "metadata", "id": "3"}
 ```
 
-Agents get project context, run commands, and persist state — all through a structured protocol instead of shell scraping.
+Agents get project context, run commands, and persist state, all through a structured protocol instead of shell scraping.
 
 ## Plugin Ideas
 
-These are plugins we think would be valuable. Community contributions welcome — see [Building a Plugin](./plugins.md#building-a-plugin) to get started.
+These are plugins we think would be valuable. Community contributions welcome, see [Building a Plugin](./plugins.md#building-a-plugin) to get started.
 
 ### Developer Experience
 
@@ -133,7 +133,7 @@ These are plugins we think would be valuable. Community contributions welcome �
 | `fledge-plugin-docker` | Build, push, compose up/down integrated with lanes | `exec`, `metadata` |
 | `fledge-plugin-notify` | Send Slack/Discord/webhook notifications on lane completion or failure | `exec`, `store` |
 | `fledge-plugin-bench` | Run benchmarks, track history, flag regressions | `exec`, `store`, `metadata` |
-| `fledge-plugin-db` | Database migration workflow — up, down, status, seed | `exec`, `store` |
+| `fledge-plugin-db` | Database migration workflow, up, down, status, seed | `exec`, `store` |
 | `fledge-plugin-todo` | Extract TODOs/FIXMEs from source, track them, warn on stale ones | `metadata` |
 
 ### Quality & Security
@@ -278,7 +278,7 @@ fledge context
 fledge context --json
 ```
 
-This gives any AI agent — Claude Code, Cursor, Copilot — instant project understanding without scanning every file.
+This gives any AI agent, Claude Code, Cursor, Copilot, instant project understanding without scanning every file.
 
 ## Combining Plugins with Lanes
 
@@ -293,7 +293,7 @@ steps = [
   { run = "fledge coverage --min 80" },
   { run = "fledge secrets --scan" },
   { run = "fledge deploy --target staging" },
-  { run = "fledge notify 'Staging deploy complete — ready for review'" },
+  { run = "fledge notify 'Staging deploy complete, ready for review'" },
 ]
 
 [lanes.audit]


### PR DESCRIPTION
User-facing docs only. No code changes.

## What changed

**1. Content sync.** README and the docs/ book had stale envelope shapes and out-of-date claims (e.g. "every read command exposes --json" when after tier-D every command does). Updated to match current main:

- README quick-start, six-pillars table, plugin list
- AGENTS.md was already current after #279
- docs/src/agents.md envelope table now matches AGENTS.md
- docs/src/doctor.md JSON example shows the post-tier-D envelope
- docs/src/introduction.md and pillars.md tightened

**2. Voice.** Rewrote the high-impact files (README, AGENTS, intro, pillars, agents, doctor) to drop marketing-flavored phrasing and read as direct technical prose.

**3. Em-dash sweep across all user-facing markdown.** Replaced the dash-with-spaces pattern with ", " or ": " (for term/description bullets) or restructured into separate sentences. README, AGENTS, and 14 docs/src/ files now contain zero em-dashes.

## Out of scope

Specs (`specs/*/*.md`) still contain em-dashes, mostly in historical change-log entries. Not touched here. Opening a separate sweep PR if we want those too.

## Test plan

- [x] cargo test, 851 still pass
- [x] fledge spec check --strict, 29/29 clean
- [x] grep for em-dashes in user-facing markdown returns zero
- [x] No code files modified