### PR TITLE
feat(release): add --json flag

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -579,22 +579,28 @@ fledge changelog --tag v0.7.0
 
 ### fledge release `<bump>`
 
-Cut a release, bump version, generate changelog, create a git tag, and optionally push.
+Cut a release. Bump version, generate changelog, create a git tag, and optionally push.
 
 ```
 fledge release <bump> [OPTIONS]
 ```
 
 **Arguments:**
-- `<bump>` - Version bump: `major`, `minor`, `patch`, or an explicit version (e.g. `1.0.0`)
+- `<bump>`: Version bump: `major`, `minor`, `patch`, or an explicit version (e.g. `1.0.0`)
 
 **Options:**
-- `--dry-run` - Show what would happen without making changes
-- `--no-tag` - Skip creating a git tag
-- `--no-changelog` - Skip changelog generation
-- `--push` - Push commit and tag to remote after release
-- `--pre-lane <NAME>` - Run a lane before releasing (e.g. `ci`)
-- `--allow-dirty` - Allow releasing with uncommitted changes
+- `--dry-run`: Show what would happen without making changes
+- `--no-tag`: Skip creating a git tag
+- `--no-changelog`: Skip changelog generation
+- `--no-bump`: Skip bumping any version files (tag-only release)
+- `--push`: Push commit and tag to remote after release
+- `--pre-lane <NAME>`: Run a lane before releasing (e.g. `ci`)
+- `--allow-dirty`: Allow releasing with uncommitted changes
+- `--json`: Emit a JSON envelope. Suppresses prose output
+
+**Output (`--json --dry-run`):** `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}`
+
+**Output (`--json` real run):** `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}`
 
 **Examples:**
 
@@ -602,7 +608,8 @@ fledge release <bump> [OPTIONS]
 fledge release patch                          # bump patch version
 fledge release minor --push                   # bump minor + push
 fledge release major --pre-lane ci            # run CI lane first, then bump major
-fledge release 2.0.0 --dry-run               # preview a specific version bump
+fledge release 2.0.0 --dry-run                # preview a specific version bump
+fledge release 2.0.0 --dry-run --json         # preview as JSON
 fledge release patch --no-tag --no-changelog  # just bump version
 ```
 

--- a/docs/src/ship.md
+++ b/docs/src/ship.md
@@ -81,13 +81,14 @@ fledge changelog --json
 
 ## Releases with `fledge release`
 
-Cut a release, bump the version, generate changelog, create an annotated git tag, and optionally push. Pure git, no GitHub-specific calls (the GitHub Releases UI object is created separately, e.g. via `gh release create`).
+Cut a release. Bump the version, generate changelog, create an annotated git tag, and optionally push. Pure git, no GitHub-specific calls (the GitHub Releases UI object is created separately, e.g. via `gh release create`).
 
 ```bash
 fledge release patch                          # bump patch version
 fledge release minor --push                   # bump minor + push to remote
 fledge release major --pre-lane ci            # run CI lane first, then bump major
 fledge release 2.0.0 --dry-run                # preview a specific version bump
+fledge release 2.0.0 --dry-run --json         # preview as JSON envelope
 fledge release patch --no-tag --no-changelog  # just bump version, skip extras
 fledge release minor --allow-dirty            # release even with uncommitted changes
 ```
@@ -96,9 +97,11 @@ fledge release minor --allow-dirty            # release even with uncommitted ch
 - `--dry-run`: Preview without making changes
 - `--no-tag`: Skip git tag
 - `--no-changelog`: Skip changelog generation
+- `--no-bump`: Skip bumping any version files (tag-only)
 - `--push`: Push commit and tag to remote
 - `--pre-lane <name>`: Run a lane before releasing (e.g. `ci`)
 - `--allow-dirty`: Allow uncommitted changes
+- `--json`: Emit a JSON envelope. Suppresses prose output
 
 ## Typical flow
 

--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -1,6 +1,6 @@
 ---
 module: release
-version: 2
+version: 3
 status: active
 files:
   - src/release.rs
@@ -128,5 +128,6 @@ Then version.txt is bumped alongside auto-detected files
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-26 | Add `--json` flag. `release X.Y.Z --dry-run --json` emits `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}`. `release X.Y.Z --json` (real run) emits `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}` and suppresses prose output. Helper functions (`generate_changelog_entry`, `create_release_commit`, `create_tag`, `push_release`) gained a `quiet` param threaded from `opts.json`. New integration tests `cli_release_dry_run_json_emits_envelope` and `cli_release_dry_run_json_no_bump_flag` |
 | 2 | 2026-04-25 | Recognize `plugin.toml` (`[plugin].version`) as a first-class fledge-ecosystem version source. Added `--no-bump` flag for tag-only releases. The plugin.toml bumper is section-scoped so other tables' `version` keys (e.g. on `[[commands]]`) aren't touched. Rust plugins with both `Cargo.toml` and `plugin.toml` get both bumped together. (#264) |
-| 1 | 2026-04-21 | Initial spec — full release workflow with multi-language support |
+| 1 | 2026-04-21 | Initial spec for the full release workflow with multi-language support |

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ enum Commands {
         #[arg(long, global = true)]
         json: bool,
     },
-    /// Cut a release — bump version, changelog, tag, and optionally push
+    /// Cut a release: bump version, changelog, tag, and optionally push.
     Release {
         /// Version bump: major, minor, patch, or explicit version (e.g. "1.0.0")
         bump: String,
@@ -151,7 +151,7 @@ enum Commands {
         /// Skip changelog generation
         #[arg(long)]
         no_changelog: bool,
-        /// Skip bumping any version files. Tag-only release — useful when the
+        /// Skip bumping any version files. Tag-only release, useful when the
         /// canonical version lives outside the tree (e.g. the GitHub Release
         /// tag itself is the source of truth).
         #[arg(long)]
@@ -165,6 +165,9 @@ enum Commands {
         /// Allow releasing with uncommitted changes
         #[arg(long)]
         allow_dirty: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// AI-powered code review of current changes
     Review {
@@ -1050,6 +1053,7 @@ fn run() -> Result<()> {
             push,
             pre_lane,
             allow_dirty,
+            json,
         } => {
             release::run(release::ReleaseOptions {
                 bump,
@@ -1060,6 +1064,7 @@ fn run() -> Result<()> {
                 push,
                 pre_lane,
                 allow_dirty,
+                json,
             })?;
         }
         Commands::Ai { action } => {

--- a/src/release.rs
+++ b/src/release.rs
@@ -1412,7 +1412,9 @@ edition = "2021"
 
         let tmp_path = tmp.path().to_path_buf();
         let version = parse_version("0.2.0").unwrap();
-        let result = with_cwd(&tmp_path, || generate_changelog_entry(&tmp_path, &version, false));
+        let result = with_cwd(&tmp_path, || {
+            generate_changelog_entry(&tmp_path, &version, false)
+        });
 
         assert!(result.is_ok());
         let changelog = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();

--- a/src/release.rs
+++ b/src/release.rs
@@ -12,13 +12,14 @@ pub struct ReleaseOptions {
     pub dry_run: bool,
     pub no_tag: bool,
     pub no_changelog: bool,
-    /// Skip bumping any version files. Tag-only release — useful for repos
+    /// Skip bumping any version files. Tag-only release, useful for repos
     /// whose version source-of-truth lives outside the working tree (e.g. a
     /// GitHub Release whose tag is the canonical version).
     pub no_bump: bool,
     pub push: bool,
     pub pre_lane: Option<String>,
     pub allow_dirty: bool,
+    pub json: bool,
 }
 
 struct BumpResult {
@@ -39,6 +40,29 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
     let new_version = resolve_target_version(&dir, &opts.bump)?;
 
     if opts.dry_run {
+        let files_to_bump = if opts.no_bump {
+            Vec::new()
+        } else {
+            detect_version_files(&dir)
+        };
+
+        if opts.json {
+            let envelope = serde_json::json!({
+                "schema_version": 1,
+                "action": "release",
+                "dry_run": true,
+                "version": new_version.to_string(),
+                "no_bump": opts.no_bump,
+                "files_to_bump": files_to_bump,
+                "will_changelog": !opts.no_changelog,
+                "will_tag": !opts.no_tag,
+                "will_push": opts.push,
+                "tag": format!("v{}", new_version),
+            });
+            println!("{}", serde_json::to_string_pretty(&envelope)?);
+            return Ok(());
+        }
+
         println!(
             "{} Would release v{} (dry run)",
             style("*").cyan().bold(),
@@ -46,14 +70,11 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
         );
         if opts.no_bump {
             println!("  Tag-only release (--no-bump)");
+        } else if files_to_bump.is_empty() {
+            println!("  Tag-only release (no version files detected)");
         } else {
-            let files = detect_version_files(&dir);
-            if files.is_empty() {
-                println!("  Tag-only release (no version files detected)");
-            } else {
-                for f in &files {
-                    println!("  Would bump: {}", style(f).cyan());
-                }
+            for f in &files_to_bump {
+                println!("  Would bump: {}", style(f).cyan());
             }
         }
         if !opts.no_changelog {
@@ -82,33 +103,60 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
         bump_version_files(&dir, &new_version)?
     };
 
-    println!(
-        "{} {} → {}",
-        style("📦").bold(),
-        style(&result.old).dim(),
-        style(&result.new).green().bold()
-    );
+    if !opts.json {
+        println!(
+            "{} {} → {}",
+            style("📦").bold(),
+            style(&result.old).dim(),
+            style(&result.new).green().bold()
+        );
 
-    for f in &result.files_bumped {
-        println!("  Bumped {}", style(f).cyan());
+        for f in &result.files_bumped {
+            println!("  Bumped {}", style(f).cyan());
+        }
+
+        if result.files_bumped.is_empty() {
+            println!("  Tag-only release (no version files found)");
+        }
     }
 
-    if result.files_bumped.is_empty() {
-        println!("  Tag-only release (no version files found)");
-    }
-
+    let mut changelog_updated = false;
     if !opts.no_changelog {
-        generate_changelog_entry(&dir, &new_version)?;
+        changelog_updated = generate_changelog_entry(&dir, &new_version, opts.json)?;
     }
 
-    create_release_commit(&dir, &new_version, &result.files_bumped, !opts.no_changelog)?;
+    create_release_commit(
+        &dir,
+        &new_version,
+        &result.files_bumped,
+        !opts.no_changelog,
+        opts.json,
+    )?;
 
     if !opts.no_tag {
-        create_tag(&dir, &new_version)?;
+        create_tag(&dir, &new_version, opts.json)?;
     }
 
     if opts.push {
-        push_release(&dir, &new_version, !opts.no_tag)?;
+        push_release(&dir, &new_version, !opts.no_tag, opts.json)?;
+    }
+
+    if opts.json {
+        let envelope = serde_json::json!({
+            "schema_version": 1,
+            "action": "release",
+            "dry_run": false,
+            "version": new_version.to_string(),
+            "old_version": result.old.to_string(),
+            "files_bumped": result.files_bumped,
+            "changelog_updated": changelog_updated,
+            "commit_created": true,
+            "tag_created": !opts.no_tag,
+            "tag": format!("v{}", new_version),
+            "pushed": opts.push,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
+        return Ok(());
     }
 
     println!(
@@ -561,7 +609,7 @@ fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {
     })
 }
 
-fn generate_changelog_entry(dir: &Path, version: &Version) -> Result<()> {
+fn generate_changelog_entry(dir: &Path, version: &Version, quiet: bool) -> Result<bool> {
     let date = chrono::Local::now().format("%Y-%m-%d").to_string();
     let tag_name = format!("v{version}");
 
@@ -592,11 +640,13 @@ fn generate_changelog_entry(dir: &Path, version: &Version) -> Result<()> {
         .collect();
 
     if commits.is_empty() {
-        println!(
-            "  {} No commits since last tag — skipping changelog",
-            style("*").cyan().bold()
-        );
-        return Ok(());
+        if !quiet {
+            println!(
+                "  {} No commits since last tag, skipping changelog",
+                style("*").cyan().bold()
+            );
+        }
+        return Ok(false);
     }
 
     let mut sections: std::collections::BTreeMap<&str, Vec<(&str, &str)>> =
@@ -638,8 +688,10 @@ fn generate_changelog_entry(dir: &Path, version: &Version) -> Result<()> {
         std::fs::write(&changelog_path, content)?;
     }
 
-    println!("  Updated {}", style("CHANGELOG.md").cyan());
-    Ok(())
+    if !quiet {
+        println!("  Updated {}", style("CHANGELOG.md").cyan());
+    }
+    Ok(true)
 }
 
 fn classify_for_changelog(msg: &str) -> &'static str {
@@ -689,6 +741,7 @@ fn create_release_commit(
     version: &Version,
     bumped_files: &[String],
     has_changelog: bool,
+    quiet: bool,
 ) -> Result<()> {
     let mut files_to_add: Vec<String> = bumped_files.to_vec();
     if has_changelog && dir.join("CHANGELOG.md").exists() {
@@ -728,11 +781,13 @@ fn create_release_commit(
         );
     }
 
-    println!("  Created commit: {}", style(&msg).dim());
+    if !quiet {
+        println!("  Created commit: {}", style(&msg).dim());
+    }
     Ok(())
 }
 
-fn create_tag(dir: &Path, version: &Version) -> Result<()> {
+fn create_tag(dir: &Path, version: &Version, quiet: bool) -> Result<()> {
     let tag = format!("v{version}");
 
     let check = Command::new("git")
@@ -761,11 +816,13 @@ fn create_tag(dir: &Path, version: &Version) -> Result<()> {
         );
     }
 
-    println!("  Created tag: {}", style(&tag).cyan());
+    if !quiet {
+        println!("  Created tag: {}", style(&tag).cyan());
+    }
     Ok(())
 }
 
-fn push_release(dir: &Path, version: &Version, has_tag: bool) -> Result<()> {
+fn push_release(dir: &Path, version: &Version, has_tag: bool, quiet: bool) -> Result<()> {
     let output = Command::new("git")
         .args(["push"])
         .current_dir(dir)
@@ -795,7 +852,9 @@ fn push_release(dir: &Path, version: &Version, has_tag: bool) -> Result<()> {
         }
     }
 
-    println!("  Pushed to remote");
+    if !quiet {
+        println!("  Pushed to remote");
+    }
     Ok(())
 }
 
@@ -1231,6 +1290,7 @@ edition = "2021"
                 push: false,
                 pre_lane: None,
                 allow_dirty: false,
+                json: false,
             })
         });
 
@@ -1268,6 +1328,7 @@ edition = "2021"
                 push: false,
                 pre_lane: None,
                 allow_dirty: false,
+                json: false,
             })
         });
 
@@ -1311,6 +1372,7 @@ edition = "2021"
                 push: false,
                 pre_lane: None,
                 allow_dirty: false,
+                json: false,
             })
         });
 
@@ -1350,7 +1412,7 @@ edition = "2021"
 
         let tmp_path = tmp.path().to_path_buf();
         let version = parse_version("0.2.0").unwrap();
-        let result = with_cwd(&tmp_path, || generate_changelog_entry(&tmp_path, &version));
+        let result = with_cwd(&tmp_path, || generate_changelog_entry(&tmp_path, &version, false));
 
         assert!(result.is_ok());
         let changelog = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
@@ -1388,7 +1450,7 @@ edition = "2021"
         let tmp_path = tmp.path().to_path_buf();
         let version = parse_version("0.1.1").unwrap();
         with_cwd(&tmp_path, || {
-            generate_changelog_entry(&tmp_path, &version).unwrap();
+            generate_changelog_entry(&tmp_path, &version, false).unwrap();
         });
 
         let changelog = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
@@ -1520,7 +1582,7 @@ end
             .unwrap();
 
         let version = parse_version("1.0.0").unwrap();
-        let result = create_tag(tmp.path(), &version);
+        let result = create_tag(tmp.path(), &version, false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1595,7 +1657,7 @@ end
         let tmp_path = tmp.path().to_path_buf();
         let version = parse_version("0.1.0").unwrap();
         with_cwd(&tmp_path, || {
-            generate_changelog_entry(&tmp_path, &version).unwrap();
+            generate_changelog_entry(&tmp_path, &version, false).unwrap();
         });
 
         let changelog = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
@@ -1632,6 +1694,7 @@ end
                 push: false,
                 pre_lane: None,
                 allow_dirty: false,
+                json: false,
             })
         });
 

--- a/tests/release.rs
+++ b/tests/release.rs
@@ -1,0 +1,108 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+// Release command (requires git repo)
+// ──────────────────────────────────────────────────────────
+
+fn init_git_repo(dir: &std::path::Path) {
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+}
+
+#[test]
+fn cli_release_dry_run_json_emits_envelope() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let output = run_fledge_in(tmp.path(), &["release", "0.2.0", "--dry-run", "--json"]);
+    assert!(
+        output.status.success(),
+        "release --dry-run --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("release --dry-run --json must emit JSON. error: {e}\nstdout:\n{stdout}")
+    });
+    assert_eq!(parsed["schema_version"].as_u64(), Some(1));
+    assert_eq!(parsed["action"].as_str(), Some("release"));
+    assert_eq!(parsed["dry_run"].as_bool(), Some(true));
+    assert_eq!(parsed["version"].as_str(), Some("0.2.0"));
+    assert_eq!(parsed["tag"].as_str(), Some("v0.2.0"));
+    assert_eq!(parsed["will_push"].as_bool(), Some(false));
+    assert!(parsed["files_to_bump"].is_array());
+    let files = parsed["files_to_bump"].as_array().unwrap();
+    assert!(
+        files.iter().any(|f| f.as_str() == Some("Cargo.toml")),
+        "expected Cargo.toml in files_to_bump, got: {files:?}"
+    );
+}
+
+#[test]
+fn cli_release_dry_run_json_no_bump_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let output = run_fledge_in(
+        tmp.path(),
+        &["release", "0.2.0", "--dry-run", "--json", "--no-bump"],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["no_bump"].as_bool(), Some(true));
+    assert_eq!(
+        parsed["files_to_bump"].as_array().unwrap().len(),
+        0,
+        "no_bump should result in empty files_to_bump"
+    );
+}
+
+// ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the last known additive gap in the agent surface. Both the dry-run and real-run paths now emit a structured envelope when \`--json\` is passed.

## What changed

\`release\` gained \`--json\`:

**Dry-run envelope:**
\`\`\`json
{
  "schema_version": 1,
  "action": "release",
  "dry_run": true,
  "version": "0.2.0",
  "no_bump": false,
  "files_to_bump": ["Cargo.toml"],
  "will_changelog": true,
  "will_tag": true,
  "will_push": false,
  "tag": "v0.2.0"
}
\`\`\`

**Real-run envelope:**
\`\`\`json
{
  "schema_version": 1,
  "action": "release",
  "dry_run": false,
  "version": "0.2.0",
  "old_version": "0.1.0",
  "files_bumped": ["Cargo.toml"],
  "changelog_updated": true,
  "commit_created": true,
  "tag_created": true,
  "tag": "v0.2.0",
  "pushed": false
}
\`\`\`

Helper functions (\`generate_changelog_entry\`, \`create_release_commit\`, \`create_tag\`, \`push_release\`) gained a \`quiet\` param threaded from \`opts.json\` so the JSON envelope is the only thing on stdout in \`--json\` mode.

## Spec

\`release\` v2 to v3.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` 853 pass (+2 new: \`cli_release_dry_run_json_emits_envelope\`, \`cli_release_dry_run_json_no_bump_flag\`)
- [x] \`fledge spec check --strict\` 29/29 clean
- [x] Manual smoke: \`fledge release 0.2.0 --dry-run --json | jq\` parses cleanly with all expected fields

## Note on docs

Touched \`docs/src/ship.md\` and \`docs/src/cli-reference.md\` to add the \`--json\` documentation. Pre-existing em-dashes in those files are not cleaned in this PR. PR #280 (the doc-sync PR) handles that. If #280 lands first this PR will rebase cleanly.