### PR TITLE
fix: address 1.0 readiness blockers from multi-model review

### DIFF
--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -1,6 +1,6 @@
 ---
 module: config
-version: 8
+version: 9
 status: active
 files:
   - src/config.rs
@@ -33,6 +33,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `save` | Serializes config to TOML and writes to disk, creating parent directories if needed |
 | `get` | Returns a config value by dotted key (e.g. `defaults.author`), or `None` if unset/unknown. List keys return newline-separated values |
 | `is_valid_key` | Returns whether a dotted key is recognized (scalar or list) |
+| `valid_keys_hint` | Returns a static string listing all valid config keys for use in error messages |
 | `set` | Sets a scalar config value by dotted key; errors on list keys or unknown keys |
 | `unset` | Removes a scalar config value or clears a list config value by dotted key; errors on unknown key |
 | `add_to_list` | Appends a value to a list config key (templates.paths, templates.repos); deduplicates; errors on scalar or unknown keys |
@@ -71,6 +72,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `Config::save` | `(&self) -> Result<()>` | Serialize config to TOML and write to disk, creating parent dirs if needed |
 | `Config::get` | `(&self, key: &str) -> Option<String>` | Get a config value by dotted key. List keys return newline-separated values |
 | `Config::is_valid_key` | `(key: &str) -> bool` | Check whether a dotted key is recognized |
+| `Config::valid_keys_hint` | `() -> &'static str` | Returns a static hint string listing all valid config keys |
 | `Config::set` | `(&mut self, key: &str, value: &str) -> Result<()>` | Set a scalar config value, errors on list or unknown keys |
 | `Config::unset` | `(&mut self, key: &str) -> Result<()>` | Remove a scalar value or clear a list by dotted key, errors on unknown key |
 | `Config::add_to_list` | `(&mut self, key: &str, value: &str) -> Result<()>` | Add a value to a list key with deduplication, errors on scalar or unknown keys |
@@ -211,3 +213,4 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | 2026-04-22 | CorvidAgent | v6: github_token() now falls back to `gh auth token` CLI when no env var or config is set |
 | 2026-04-23 | CorvidAgent | v7: add `[ai]` section — `ai.provider` (scalar, `claude`/`ollama` only), `ai.claude.model`, `ai.ollama.host`, `ai.ollama.api_key`, `ai.ollama.model`. Defaults preserve pre-v0.13 Claude-only behavior. `add_to_list`/`remove_from_list` now route through `is_valid_key` so new scalar keys get the right error message. |
 | 2026-04-24 | CorvidAgent | v8: add `ai.ollama.timeout_seconds` scalar (default 600). Mirrors the existing `FLEDGE_AI_TIMEOUT` env var so Ollama timeouts are tunable without env vars; env still wins. `set` parses as `u64` and rejects non-integer input; `unset` restores the 600s default. |
+| 2026-04-26 | CorvidAgent | v9: document `valid_keys_hint()` — returns a static string listing all valid config keys, used by `handle_config` in main.rs for error messages |

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,10 @@ fn default_ollama_timeout_seconds() -> u64 {
 const VALID_KEYS_HINT: &str = "Valid keys: defaults.author, defaults.github_org, defaults.license, github.token, templates.paths, templates.repos, ai.provider, ai.claude.model, ai.ollama.host, ai.ollama.api_key, ai.ollama.model, ai.ollama.timeout_seconds";
 
 impl Config {
+    pub fn valid_keys_hint() -> &'static str {
+        VALID_KEYS_HINT
+    }
+
     pub fn load() -> Result<Self> {
         let path = Self::config_path();
         if path.exists() {

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -1350,30 +1350,11 @@ fn format_lane_toml(name: &str, lane: &LaneDef) -> String {
 }
 
 fn base64_decode(input: &str) -> Result<Vec<u8>> {
-    let mut output = Vec::with_capacity(input.len() * 3 / 4);
-    let mut buf: u32 = 0;
-    let mut bits: u32 = 0;
-
-    for c in input.chars() {
-        let val = match c {
-            'A'..='Z' => c as u32 - b'A' as u32,
-            'a'..='z' => c as u32 - b'a' as u32 + 26,
-            '0'..='9' => c as u32 - b'0' as u32 + 52,
-            '+' => 62,
-            '/' => 63,
-            '=' => break,
-            _ => continue,
-        };
-        buf = (buf << 6) | val;
-        bits += 6;
-        if bits >= 8 {
-            bits -= 8;
-            output.push((buf >> bits) as u8);
-            buf &= (1 << bits) - 1;
-        }
-    }
-
-    Ok(output)
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(input))
+        .context("invalid base64 input")
 }
 
 fn create_lane_repo(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1240,8 +1240,9 @@ fn handle_config(action: ConfigAction) -> Result<()> {
             let config = config::Config::load()?;
             if !config::Config::is_valid_key(&key) {
                 anyhow::bail!(
-                    "Unknown config key '{}'. Valid keys: defaults.author, defaults.github_org, defaults.license, github.token, templates.paths, templates.repos",
-                    key
+                    "Unknown config key '{}'. {}",
+                    key,
+                    config::Config::valid_keys_hint()
                 );
             }
             match config.get(&key) {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -287,25 +287,12 @@ fn run_message_loop(
             }
             OutboundMessage::Store { key, value } => {
                 if !capabilities.store {
-                    let msg = format!(
-                        "  {} [{}] store blocked — capability not granted (key: {})",
-                        style("WARN").yellow(),
-                        style(plugin_name).dim(),
-                        key,
-                    );
-                    eprintln!("{msg}");
-                    handle_log(plugin_name, "error", "store capability not granted");
                     continue;
                 }
                 handle_store(plugin_dir, &key, &value)?;
             }
             OutboundMessage::Load { id, key } => {
                 if !capabilities.store {
-                    eprintln!(
-                        "  {} [{}] load blocked — capability not granted",
-                        style("WARN").yellow(),
-                        style(plugin_name).dim()
-                    );
                     send_response(child, &id, serde_json::Value::Null)?;
                     continue;
                 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -222,7 +222,7 @@ fn resolve_target_version(dir: &Path, bump: &str) -> Result<Version> {
     match bump {
         "major" | "minor" | "patch" => {
             let current = detect_current_version(dir)?;
-            Ok(apply_bump(&current, bump))
+            apply_bump(&current, bump)
         }
         _ => parse_version(bump),
     }
@@ -421,24 +421,27 @@ fn replace_versioned_toml_section(
     Some(joined)
 }
 
-fn apply_bump(current: &Version, bump: &str) -> Version {
+fn apply_bump(current: &Version, bump: &str) -> Result<Version> {
     match bump {
-        "major" => Version {
+        "major" => Ok(Version {
             major: current.major + 1,
             minor: 0,
             patch: 0,
-        },
-        "minor" => Version {
+        }),
+        "minor" => Ok(Version {
             major: current.major,
             minor: current.minor + 1,
             patch: 0,
-        },
-        "patch" => Version {
+        }),
+        "patch" => Ok(Version {
             major: current.major,
             minor: current.minor,
             patch: current.patch + 1,
-        },
-        _ => unreachable!(),
+        }),
+        other => bail!(
+            "Unknown bump level '{}'. Expected major, minor, or patch",
+            other
+        ),
     }
 }
 
@@ -911,30 +914,36 @@ mod tests {
     #[test]
     fn apply_bump_major() {
         let v = parse_version("1.2.3").unwrap();
-        let bumped = apply_bump(&v, "major");
+        let bumped = apply_bump(&v, "major").unwrap();
         assert_eq!(bumped.to_string(), "2.0.0");
     }
 
     #[test]
     fn apply_bump_minor() {
         let v = parse_version("1.2.3").unwrap();
-        let bumped = apply_bump(&v, "minor");
+        let bumped = apply_bump(&v, "minor").unwrap();
         assert_eq!(bumped.to_string(), "1.3.0");
     }
 
     #[test]
     fn apply_bump_patch() {
         let v = parse_version("1.2.3").unwrap();
-        let bumped = apply_bump(&v, "patch");
+        let bumped = apply_bump(&v, "patch").unwrap();
         assert_eq!(bumped.to_string(), "1.2.4");
     }
 
     #[test]
     fn apply_bump_from_zero() {
         let v = parse_version("0.0.0").unwrap();
-        assert_eq!(apply_bump(&v, "major").to_string(), "1.0.0");
-        assert_eq!(apply_bump(&v, "minor").to_string(), "0.1.0");
-        assert_eq!(apply_bump(&v, "patch").to_string(), "0.0.1");
+        assert_eq!(apply_bump(&v, "major").unwrap().to_string(), "1.0.0");
+        assert_eq!(apply_bump(&v, "minor").unwrap().to_string(), "0.1.0");
+        assert_eq!(apply_bump(&v, "patch").unwrap().to_string(), "0.0.1");
+    }
+
+    #[test]
+    fn apply_bump_invalid_level() {
+        let v = parse_version("1.2.3").unwrap();
+        assert!(apply_bump(&v, "mega").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Five fixes from the three-model (Opus/Sonnet/Haiku) 1.0 readiness audit:

- **Config error message** (`main.rs`): Hardcoded valid-keys list omitted all `ai.*` keys — now delegates to `Config::valid_keys_hint()` so the hint stays in sync automatically
- **Protocol store/load blocking** (`protocol.rs`): Code emitted WARN logs when store capability was denied, but spec says "silently dropped" — removed the noisy logging to match spec
- **Hand-rolled base64** (`lanes.rs`): Replaced 26-line custom decoder with the `base64` crate already in `Cargo.toml` — eliminates a maintenance hazard with potential edge-case bugs
- **`unreachable!()` panic** (`release.rs`): `apply_bump` panicked on unexpected input — now returns a proper `Result` error
- **New test**: Added `apply_bump_invalid_level` test for the new error path

## Test plan

- [x] `cargo test` — 681 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6