### PR TITLE
fix: propagate --json to pre-release lane, document release JSON shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,9 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge run --list --json` | `{schema_version: 1, action: "run_list", auto_detected, tasks: [...]}` | Discovering tasks defined in `fledge.toml` (or auto-detected) |
 | `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` | Running a task and capturing its output |
 | `fledge run --init --json` | `{schema_version: 1, action: "run_init", file, project_type, files_created}` | Scaffolding a `fledge.toml` |
+| `fledge release --dry-run --json` | `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}` | Preview what a release would do |
+| `fledge release --json` | `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}` | After a real release completes |
+| `fledge lanes run <name> --dry-run --json` | `{schema_version: 1, lane, description, total_steps, fail_fast, dry_run: true, steps: [{step, kind, name}]}` | Preview lane steps without executing |
 | `fledge plugins list --json` | `{schema_version: 1, plugins: [{name, version, source, trust_tier, ...}]}` | Auditing plugin state |
 | `fledge plugins audit --json` | `{schema_version: 1, audit: [{name, version, trust_tier, capabilities, has_lifecycle_hooks, ...}]}` | Capability/hook audit |
 | `fledge plugins search --json` | `{schema_version: 1, results: [{name, full_name, stars, trust_tier, ...}]}` | GitHub search for `fledge-plugin`-tagged repos |
@@ -88,7 +91,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, ...) |
 | `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` | LOC summary (tokei), per-file churn, test/source ratio |
 
-Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `release`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR. It's an accepted pattern.
+Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR. It's an accepted pattern.
 
 **Envelope contract.** Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 
@@ -96,6 +99,8 @@ Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `wa
 - Cross-cutting commands (`doctor`, `run`, `ai`, `ask`, `changelog`, `work`, `spec`, `review`) use `{schema_version: 1, action: "<verb>", ...}`. The `action` string discriminates between commands sharing similar shapes.
 
 Top-level `schema_version` is the version contract. New fields are additive within v1, field removal/retyping requires a new schema_version. **Always read `<resource>` (or `action` + named keys). Never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work. Pinning to fledge ≥ 1.0 means you can rely on the envelope.
+
+**Error output.** Errors are always plain text on stderr, even when `--json` is active. JSON appears only on stdout for successful operations. Check the exit code first; if non-zero, read stderr for the human-readable error message. Do not attempt to parse stderr as JSON.
 
 ## Non-interactive mode
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -34,7 +34,7 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
     preflight_checks(&dir, opts.allow_dirty)?;
 
     if let Some(ref lane) = opts.pre_lane {
-        run_pre_lane(lane, opts.dry_run)?;
+        run_pre_lane(lane, opts.dry_run, opts.json)?;
     }
 
     let new_version = resolve_target_version(&dir, &opts.bump)?;
@@ -200,21 +200,25 @@ fn preflight_checks(dir: &Path, allow_dirty: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_pre_lane(lane: &str, dry_run: bool) -> Result<()> {
-    println!(
-        "{} Running pre-release lane: {}",
-        style("🔄").bold(),
-        style(lane).cyan()
-    );
+fn run_pre_lane(lane: &str, dry_run: bool, json: bool) -> Result<()> {
+    if !json {
+        println!(
+            "{} Running pre-release lane: {}",
+            style("🔄").bold(),
+            style(lane).cyan()
+        );
+    }
 
     let action = crate::lanes::LaneAction::Run {
         name: lane.to_string(),
         dry_run,
-        json: false,
+        json,
     };
     crate::lanes::run(action)?;
 
-    println!("{} Pre-release lane passed", style("✅").green().bold());
+    if !json {
+        println!("{} Pre-release lane passed", style("✅").green().bold());
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- **release.rs**: `run_pre_lane` now accepts and propagates the `--json` flag — its pretty-print output no longer contaminates the JSON envelope
- **AGENTS.md**: removed `release` from the no-JSON list, added `release --json` / `release --dry-run --json` / `lanes run --dry-run --json` shape rows, added the "errors are always plain stderr" rule

Follow-up to #282 — items 1–4 from the ship checklist.

## Test plan
- [x] All 854 tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)