### PR TITLE
fix(release): silence pre-release lane on --json (single-envelope contract)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge templates list --json` | `{schema_version: 1, templates: [{name, description, source, source_ref, path}]}` | Listing available templates |
 | `fledge templates search --json` | `{schema_version: 1, results: [...]}` (same shape as plugins search) | GitHub search for `fledge-template`-tagged repos |
 | `fledge templates validate --json` | `{schema_version: 1, reports: [{path, template, errors, warnings}]}` | CI gate before publish |
+| `fledge templates init <template> --json` | `{schema_version: 1, action: "init", project: {name, path}, template: {name, source, version}, variables_used, files_created, git_initialized, hooks_run}` | Scaffolding a new project |
+| `fledge templates create --json` | `{schema_version: 1, action: "create", path, name, description, render_patterns, include_hooks, include_prompts, files_created}` | Creating a new template skeleton |
+| `fledge templates publish --json` | `{schema_version: 1, action: "publish", repo: {owner, name, url, created, private}, template: {description}, topic, use_hint}` | Publishing a template repo |
 | `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}`. Branch name the agent just created | Branch scripting |
 | `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}`. PR URL to report back | After agent finishes a task |
 | `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}`. Current state of the branch | Pre-action sanity check |
@@ -100,7 +103,7 @@ Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `wa
 
 Top-level `schema_version` is the version contract. New fields are additive within v1, field removal/retyping requires a new schema_version. **Always read `<resource>` (or `action` + named keys). Never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work. Pinning to fledge ≥ 1.0 means you can rely on the envelope.
 
-**Error output.** Errors are always plain text on stderr, even when `--json` is active. JSON appears only on stdout for successful operations. Check the exit code first; if non-zero, read stderr for the human-readable error message. Do not attempt to parse stderr as JSON.
+**Error output.** Errors always go to stderr as plain text, even when `--json` is active. Check the exit code first — non-zero means failure and stderr carries the human-readable error. Do not parse stderr as JSON. Stdout may still contain a partial or final envelope before some failures (e.g. `lanes run --json` emits the lane envelope with `success: false` then bails), so don't treat "stdout has JSON" as a success signal — the exit code is the contract.
 
 ## Non-interactive mode
 

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 15
+version: 16
 status: active
 files:
   - src/lanes.rs
@@ -26,6 +26,7 @@ Composable workflow pipelines defined in `fledge.toml` and `.fledge/lanes/`. Lan
 | Export | Description |
 |--------|-------------|
 | `run` | Entry point — dispatches lane actions |
+| `run_for_pre_release` | Silent lane gate for `release --json --pre-lane`; runs steps with subprocess output suppressed and emits no envelope. Failure bails to stderr |
 | `LaneAction` | Enum: `Run`, `List`, `Init`, `Search`, `Import`, `Publish`, `Create`, `Validate` |
 | `LaneDef` | Lane definition: description, steps, and fail_fast flag |
 
@@ -43,6 +44,7 @@ Composable workflow pipelines defined in `fledge.toml` and `.fledge/lanes/`. Lan
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `run` | `(LaneAction) -> Result<()>` | Main entry — dispatch to init/list/execute/search/import |
+| `run_for_pre_release` | `(&str, bool) -> Result<()>` | Run a lane silently as a pre-release gate. No stdout output; subprocess stdout/stderr suppressed. Used by `release --json --pre-lane` to keep the release envelope the only thing on stdout |
 
 ## Config Format
 
@@ -229,6 +231,7 @@ $ fledge lanes run ci --json --dry-run
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 16 | 2026-04-26 | Add `run_for_pre_release(name, dry_run)` — a silent lane executor used by `release --json --pre-lane <name>` so the release JSON envelope is the only thing on stdout. Subprocess stdout/stderr is redirected to null; failure bails with a plain stderr error and non-zero exit. Pretty-print release path is unchanged and still goes through `LaneAction::Run` |
 | 15 | 2026-04-26 | `lanes run --json --dry-run` now emits a `{schema_version: 1, lane, description, total_steps, fail_fast, dry_run: true, steps: [{step, kind, name, items?}]}` envelope. Previously it ignored `--json` and printed prose, breaking the contract that `--json` always means parseable stdout. Per-step `duration_ms` is omitted in dry-run mode (no execution). Behavioral example for the per-step shape on real runs (`steps: [{step, name, success, duration_ms, error}, ...]`) also documented |
 | 14 | 2026-04-26 | `lanes import --json` envelope tightened: `file` is now always the computed `.fledge/lanes/<safe_name>.toml` path (string, never null), and a new `written: bool` field signals whether the file was actually created (false when every lane was skipped). Previously `file: null` in the all-skipped case implied the path wasn't computable, but it's a pure function of source — null was misleading |
 | 13 | 2026-04-25 | Fix `lanes run --json` prose leak: fledge's own progress prints AND each spawned task's stdout/stderr were going to the agent's stdout, interleaving with the JSON envelope and breaking `--json | jq`. Threaded a `quiet` flag through `execute_task_with_deps` / `execute_inline` / `execute_parallel` / `execute_single_task` / `execute_task_recursive`. In JSON mode prose is suppressed and spawned commands' stdout/stderr are redirected to `/dev/null`. Trade-off: per-step output isn't captured into the JSON record (consumers needing it re-run without `--json`). New regression test `cli_lane_run_json_stdout_is_clean` guards the contract |

--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -1,6 +1,6 @@
 ---
 module: release
-version: 3
+version: 4
 status: active
 files:
   - src/release.rs
@@ -128,6 +128,7 @@ Then version.txt is bumped alongside auto-detected files
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-04-26 | Pre-release lane no longer pollutes `--json` stdout. When `--json` is set, `run_pre_lane` calls a new silent path `crate::lanes::run_for_pre_release(name, dry_run)` that runs steps with subprocess output suppressed and emits no envelope of its own. Fixes a double-envelope regression where `release --json --pre-lane <lane>` previously emitted lane and release envelopes back-to-back on stdout. Failure path unchanged: lane bails with a plain stderr error and exit code 1 |
 | 3 | 2026-04-26 | Add `--json` flag. `release X.Y.Z --dry-run --json` emits `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}`. `release X.Y.Z --json` (real run) emits `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}` and suppresses prose output. Helper functions (`generate_changelog_entry`, `create_release_commit`, `create_tag`, `push_release`) gained a `quiet` param threaded from `opts.json`. New integration tests `cli_release_dry_run_json_emits_envelope` and `cli_release_dry_run_json_no_bump_flag` |
 | 2 | 2026-04-25 | Recognize `plugin.toml` (`[plugin].version`) as a first-class fledge-ecosystem version source. Added `--no-bump` flag for tag-only releases. The plugin.toml bumper is section-scoped so other tables' `version` keys (e.g. on `[[commands]]`) aren't touched. Rust plugins with both `Cargo.toml` and `plugin.toml` get both bumped together. (#264) |
 | 1 | 2026-04-21 | Initial spec for the full release workflow with multi-language support |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -209,6 +209,34 @@ pub fn run(action: LaneAction) -> Result<()> {
     }
 }
 
+/// Run a lane as a pre-release gate without emitting anything to stdout.
+/// The release command's own JSON envelope is the only thing the agent
+/// consumer parses; the lane runs silently and bails on failure.
+pub fn run_for_pre_release(name: &str, dry_run: bool) -> Result<()> {
+    let config = load_lane_config()?;
+    let lane = config.lanes.get(name).ok_or_else(|| {
+        let available: Vec<&str> = config.lanes.keys().map(|s| s.as_str()).collect();
+        anyhow::anyhow!(
+            "Unknown lane '{}'. Available lanes: {}",
+            name,
+            available.join(", ")
+        )
+    })?;
+
+    if lane.steps.is_empty() {
+        bail!("Lane '{}' has no steps defined", name);
+    }
+
+    validate_lane(name, lane, &config.tasks)?;
+
+    if dry_run {
+        return Ok(());
+    }
+
+    let project_dir = std::env::current_dir().context("getting current directory")?;
+    execute_lane_silent(name, lane, &config.tasks, &project_dir)
+}
+
 fn load_lane_config() -> Result<FledgeFileWithLanes> {
     let project_dir = std::env::current_dir().context("getting current directory")?;
     let config_path = project_dir.join("fledge.toml");
@@ -637,6 +665,47 @@ fn execute_lane_json(
     println!("{}", serde_json::to_string_pretty(&output)?);
 
     if !success {
+        bail!(
+            "Lane '{}' completed with {} failure(s)",
+            lane_name,
+            failures.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_lane_silent(
+    lane_name: &str,
+    lane: &LaneDef,
+    tasks: &BTreeMap<String, TaskDef>,
+    project_dir: &Path,
+) -> Result<()> {
+    let mut failures: Vec<String> = Vec::new();
+
+    for (i, step) in lane.steps.iter().enumerate() {
+        let result = match step {
+            Step::TaskRef(name) => execute_task_with_deps(name, tasks, project_dir, true),
+            Step::Inline { run: cmd } => execute_inline(cmd, project_dir, true),
+            Step::Parallel { parallel } => execute_parallel(parallel, tasks, project_dir, true),
+        };
+
+        if let Err(e) = result {
+            let step_desc = step_description(step);
+            if lane.fail_fast {
+                bail!(
+                    "Lane '{}' failed at step {} ({}): {}",
+                    lane_name,
+                    i + 1,
+                    step_desc,
+                    e
+                );
+            }
+            failures.push(step_desc);
+        }
+    }
+
+    if !failures.is_empty() {
         bail!(
             "Lane '{}' completed with {} failure(s)",
             lane_name,

--- a/src/release.rs
+++ b/src/release.rs
@@ -201,24 +201,26 @@ fn preflight_checks(dir: &Path, allow_dirty: bool) -> Result<()> {
 }
 
 fn run_pre_lane(lane: &str, dry_run: bool, json: bool) -> Result<()> {
-    if !json {
-        println!(
-            "{} Running pre-release lane: {}",
-            style("🔄").bold(),
-            style(lane).cyan()
-        );
+    if json {
+        // Stdout is reserved for release's own JSON envelope. Run the lane
+        // silently; failure bails with a plain stderr error per envelope rules.
+        return crate::lanes::run_for_pre_release(lane, dry_run);
     }
+
+    println!(
+        "{} Running pre-release lane: {}",
+        style("🔄").bold(),
+        style(lane).cyan()
+    );
 
     let action = crate::lanes::LaneAction::Run {
         name: lane.to_string(),
         dry_run,
-        json,
+        json: false,
     };
     crate::lanes::run(action)?;
 
-    if !json {
-        println!("{} Pre-release lane passed", style("✅").green().bold());
-    }
+    println!("{} Pre-release lane passed", style("✅").green().bold());
     Ok(())
 }
 

--- a/tests/release.rs
+++ b/tests/release.rs
@@ -105,4 +105,112 @@ fn cli_release_dry_run_json_no_bump_flag() {
     );
 }
 
+#[test]
+fn cli_release_dry_run_json_with_pre_lane_emits_single_envelope() {
+    // Regression: --pre-lane combined with --json must not emit a second
+    // (lane) JSON envelope on stdout. The release envelope is the only thing
+    // a consumer should have to parse.
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[tasks]\necho = \"echo hi\"\n\n[lanes.smoke]\ndescription = \"smoke\"\nsteps = [\"echo\"]\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let output = run_fledge_in(
+        tmp.path(),
+        &[
+            "release",
+            "0.2.0",
+            "--dry-run",
+            "--json",
+            "--pre-lane",
+            "smoke",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "release --dry-run --json --pre-lane failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("expected exactly one JSON envelope on stdout. error: {e}\nstdout:\n{stdout}")
+    });
+    assert_eq!(parsed["action"].as_str(), Some("release"));
+    assert_eq!(parsed["dry_run"].as_bool(), Some(true));
+}
+
+#[test]
+fn cli_release_json_with_failing_pre_lane_bails_with_plain_stderr() {
+    // Failure path: lane fails -> release bails. Stdout stays empty (no
+    // partial envelope), stderr carries a plain-text error, exit is non-zero.
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[tasks]\nfail = \"exit 1\"\n\n[lanes.busted]\ndescription = \"busted\"\nsteps = [\"fail\"]\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let output = run_fledge_in(
+        tmp.path(),
+        &[
+            "release",
+            "0.2.0",
+            "--json",
+            "--pre-lane",
+            "busted",
+            "--no-bump",
+            "--no-tag",
+            "--no-changelog",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when pre-lane fails"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout on lane failure, got: {stdout}"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("busted"),
+        "expected lane name in stderr, got: {stderr}"
+    );
+}
+
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `fledge release --json --pre-lane <lane>` no longer emits a second JSON envelope on stdout. The release envelope is the contract; the lane is an internal gate.
- New `crate::lanes::run_for_pre_release(name, dry_run)` runs steps with subprocess output suppressed and emits no envelope of its own. Failure bails with plain stderr per the envelope rules.
- Adds the missing `templates init` / `templates create` / `templates publish` rows to the AGENTS.md core-commands table.
- Tightens the error-output rule: `lanes run --json` does emit a final envelope on failure, so "exit code is the contract, not stdout presence."
- New regression tests: `cli_release_dry_run_json_with_pre_lane_emits_single_envelope`, `cli_release_json_with_failing_pre_lane_bails_with_plain_stderr`.

Follow-up to #283 — review found the lane envelope leaked into stdout when combined with `--json`, breaking single-object JSON parsers.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — all 856 tests pass
- [x] `fledge spec check` — 29 specs, 0 errors
- [x] `fledge lanes run pre-commit` passes
- [x] Manual: `fledge release --dry-run --json --pre-lane smoke` emits one envelope; failing lane produces empty stdout + plain stderr + non-zero exit