### PR TITLE
fix(1.0)!: finalize envelope shapes before tagging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge plugins audit --json` | `{schema_version: 1, audit: [{name, version, trust_tier, capabilities, has_lifecycle_hooks, ...}]}` | Capability/hook audit |
 | `fledge plugins search --json` | `{schema_version: 1, results: [{name, full_name, stars, trust_tier, ...}]}` | GitHub search for `fledge-plugin`-tagged repos |
 | `fledge plugins validate --json` | `{schema_version: 1, path, plugin_name, errors, warnings}` | CI gate before publish |
-| `fledge lanes list --json` | `{schema_version: 1, lanes: [{name, description, steps, fail_fast, source?, trust_tier}]}` | Discovering lanes available to run |
+| `fledge lanes list --json` | `{schema_version: 1, lanes: [{name, description, step_count, fail_fast, source?, trust_tier}]}`. `step_count` is an integer; full step detail lives in `lanes run --dry-run --json` | Discovering lanes available to run |
 | `fledge lanes search --json` | `{schema_version: 1, results: [...]}` (same shape as plugins search) | GitHub search for `fledge-lane`-tagged repos |
 | `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps: [...], failures: [...]}` | Running the project's own CI pipeline |
 | `fledge lanes validate --json` | `{schema_version: 1, path, lane_count, errors, warnings}` | CI gate before publish |
@@ -79,7 +79,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge templates validate --json` | `{schema_version: 1, reports: [{path, template, errors, warnings}]}` | CI gate before publish |
 | `fledge templates init <template> --json` | `{schema_version: 1, action: "init", project: {name, path}, template: {name, source, version}, variables_used, files_created, git_initialized, hooks_run}` | Scaffolding a new project |
 | `fledge templates create --json` | `{schema_version: 1, action: "create", path, name, description, render_patterns, include_hooks, include_prompts, files_created}` | Creating a new template skeleton |
-| `fledge templates publish --json` | `{schema_version: 1, action: "publish", repo: {owner, name, url, created, private}, template: {description}, topic, use_hint}` | Publishing a template repo |
+| `fledge templates publish --json` | `{schema_version: 1, action: "publish", cancelled, repo: {owner, name, url, created, private}, template: {description}, topic, use_hint}`. Same key set on success and cancelled paths; `cancelled: true` when the user declines a confirmation | Publishing a template repo |
 | `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}`. Branch name the agent just created | Branch scripting |
 | `fledge work pr --json` | `{schema_version: 1, action: "work_pr", url, number, title, head, base, draft}`. PR URL to report back | After agent finishes a task |
 | `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}`. Current state of the branch | Pre-action sanity check |

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 16
+version: 17
 status: active
 files:
   - src/lanes.rs
@@ -231,6 +231,7 @@ $ fledge lanes run ci --json --dry-run
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 17 | 2026-04-26 | **Breaking (1.0 contract finalize):** (a) `lanes list --json` renames `steps` (integer count) to `step_count`. The bare key `steps` read like an array but emitted a count, surprising consumers — full step detail lives in `lanes run --dry-run --json`. (b) `lanes import --json` renames `tier` to `trust_tier` to match every other plugin/lane envelope. Last-chance shape break before tagging 1.0 |
 | 16 | 2026-04-26 | Add `run_for_pre_release(name, dry_run)` — a silent lane executor used by `release --json --pre-lane <name>` so the release JSON envelope is the only thing on stdout. Subprocess stdout/stderr is redirected to null; failure bails with a plain stderr error and non-zero exit. Pretty-print release path is unchanged and still goes through `LaneAction::Run` |
 | 15 | 2026-04-26 | `lanes run --json --dry-run` now emits a `{schema_version: 1, lane, description, total_steps, fail_fast, dry_run: true, steps: [{step, kind, name, items?}]}` envelope. Previously it ignored `--json` and printed prose, breaking the contract that `--json` always means parseable stdout. Per-step `duration_ms` is omitted in dry-run mode (no execution). Behavioral example for the per-step shape on real runs (`steps: [{step, name, success, duration_ms, error}, ...]`) also documented |
 | 14 | 2026-04-26 | `lanes import --json` envelope tightened: `file` is now always the computed `.fledge/lanes/<safe_name>.toml` path (string, never null), and a new `written: bool` field signals whether the file was actually created (false when every lane was skipped). Previously `file: null` in the all-skipped case implied the path wasn't computable, but it's a pure function of source — null was misleading |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 15
+version: 16
 status: active
 files:
   - src/plugin.rs
@@ -288,6 +288,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 16 | 2026-04-26 | **Breaking (1.0 contract finalize):** (a) `plugins install --json` (single + defaults) renames the per-plugin `tier` field to `trust_tier` to match every other plugin envelope (`list`, `audit`, `search`). (b) `plugins publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `plugin`, `topic`, `install_hint`); `cancelled` is `true` when the user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` already covers it). Consumers can now read the same keys regardless of cancel/success. Last-chance shape break before tagging 1.0 |
 | 15 | 2026-04-25 | **Breaking (tier C, #272):** `plugins list/audit/search/validate --json` outputs migrated from bare top-level arrays to `{schema_version: 1, <resource>: [...]}` envelopes (`plugins`, `audit`, `results`, and validate report flattened with schema_version). Last-chance shape break before 1.0 freezes the contract. AGENTS.md and integration tests updated in lockstep |
 | 14 | 2026-04-25 | Tier B follow-up: `plugins create` and `plugins publish` honour `--json` and emit a `{schema_version:1, action, ...}` envelope. `create` reports `path/name/description/files_created`; `publish` reports `repo/template/topic/install_hint` plus a `cancelled: true` shape on user-declined update prompts. Invariant 11 widened to enumerate `create` and `publish`. |
 | 13 | 2026-04-25 | `--json` now actually emits structured output for `install`, `install --defaults`, `remove`, and `update` (previously the global flag was accepted but silently ignored — agents passing `--json` got ANSI-coloured prose back, a 1.0 footgun caught by the multi-model readiness review). All four emit a `{schema_version: 1, action, ...}` envelope on stdout; warnings stay on stderr; failure paths still exit non-zero so agents can't misclassify them. Invariant 11 rewritten to enumerate the full coverage. |

--- a/specs/templates/templates.spec.md
+++ b/specs/templates/templates.spec.md
@@ -1,6 +1,6 @@
 ---
 module: templates
-version: 5
+version: 6
 status: active
 files:
   - src/templates.rs
@@ -154,3 +154,4 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | 2026-04-18 | CorvidAgent | v3: Add discover_templates_with_repos for remote GitHub template support |
 | 2026-04-20 | CorvidAgent | v4: Add check_requirements for template tool dependency checking |
 | 2026-04-25 | 0xLeif | v5: Remove `load_templates_from_dir_pub` (was only used by deleted `templates update` and `templates publish`); now an internal `fn` |
+| 2026-04-26 | 0xLeif | v6: **Breaking (1.0 contract finalize):** `templates publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `template`, `topic`, `use_hint`). `cancelled` is `true` when user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` covers it). Consumers can now read the same keys regardless of cancel/success |

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -309,7 +309,7 @@ fn list_lanes(lanes: &BTreeMap<String, LaneDef>, json: bool) -> Result<()> {
                 let mut entry = serde_json::json!({
                     "name": name,
                     "description": lane.description,
-                    "steps": lane.steps.len(),
+                    "step_count": lane.steps.len(),
                     "fail_fast": lane.fail_fast,
                 });
                 if let Some(ref src) = lane.source {
@@ -1288,7 +1288,7 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
                 "schema_version": 1,
                 "action": "import",
                 "source": display_source,
-                "tier": tier.label(),
+                "trust_tier": tier.label(),
                 "imported": [],
                 "skipped": skipped,
                 "file": relative_file,
@@ -1317,7 +1317,7 @@ fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
             "schema_version": 1,
             "action": "import",
             "source": display_source,
-            "tier": tier.label(),
+            "trust_tier": tier.label(),
             "imported": imported_lanes,
             "skipped": skipped,
             "file": relative_file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1668,8 +1668,14 @@ fn publish_template(
                             "owner": owner,
                             "name": repo_name,
                             "url": format!("https://github.com/{owner}/{repo_name}"),
-                            "exists": true,
+                            "created": false,
+                            "private": private,
                         },
+                        "template": {
+                            "description": desc,
+                        },
+                        "topic": "fledge-template",
+                        "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
                     });
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 } else {
@@ -1730,6 +1736,7 @@ fn publish_template(
         let result = serde_json::json!({
             "schema_version": 1,
             "action": "publish",
+            "cancelled": false,
             "repo": {
                 "owner": owner,
                 "name": repo_name,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -803,7 +803,7 @@ fn install_plugin(source: &str, force: bool, json: bool) -> Result<serde_json::V
         "name": entry.name,
         "source": entry.source,
         "version": entry.version,
-        "tier": tier.label(),
+        "trust_tier": tier.label(),
         "commands": entry.commands,
         "pinned_ref": entry.pinned_ref,
         "capabilities": entry.capabilities,
@@ -2166,8 +2166,16 @@ fn publish_plugin(
                             "owner": owner,
                             "name": repo_name,
                             "url": format!("https://github.com/{owner}/{repo_name}"),
-                            "exists": true,
+                            "created": false,
+                            "private": private,
                         },
+                        "plugin": {
+                            "name": manifest.plugin.name,
+                            "version": manifest.plugin.version,
+                            "description": desc,
+                        },
+                        "topic": "fledge-plugin",
+                        "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
                     });
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 } else {
@@ -2228,6 +2236,7 @@ fn publish_plugin(
         let result = serde_json::json!({
             "schema_version": 1,
             "action": "publish",
+            "cancelled": false,
             "repo": {
                 "owner": owner,
                 "name": repo_name,


### PR DESCRIPTION
## Summary

Three breaking envelope changes discovered in the pre-1.0 audit. PR A of three (B = doc-only AGENTS.md additions, C = tag 1.0).

### 1. Cancelled-path uniformity
`plugins publish --json` and `templates publish --json` previously emitted **different key sets** depending on whether the user confirmed or cancelled. Cancelled dropped `plugin`/`template`, `topic`, `install_hint`/`use_hint`, and replaced `created`/`private` with `exists`. Consumers couldn't read the same keys across outcomes.

Now both paths emit the full key set; `cancelled: bool` is the only discriminator.

```jsonc
// success and cancelled now share these keys
{
  "schema_version": 1,
  "action": "publish",
  "cancelled": false | true,
  "repo": {"owner", "name", "url", "created", "private"},
  "plugin" | "template": {...},
  "topic": "...",
  "install_hint" | "use_hint": "..."
}
```

### 2. ` tier` → `trust_tier`
`plugins install --json` (single + defaults) and `lanes import --json` were the holdouts. Every other plugin/lane envelope (`list`, `audit`, `search`) uses `trust_tier`. Standardize.

### 3. `lanes list --json steps` → `step_count`
The bare key `steps` read like an array but emitted `lane.steps.len()`. Full step detail lives in `lanes run --dry-run --json`. Renamed for clarity.

## Spec bumps

- `lanes` v17
- `plugin` v16
- `templates` v6

AGENTS.md updated for the changed shapes (`lanes list`, `templates publish`). The remaining doc gaps from the audit (missing rows for `lanes init/import/publish/create`, `plugins install/update/remove/publish/create`, plus `ai status` `*_source` clarification, `introspect` shape, `review` error case, `work start issue?`) are deferred to **PR B**.

## Test plan
- [x] `cargo build` clean
- [x] `fledge lanes run pre-commit` (fmt + clippy + test + spec-check) green locally
- [x] `specsync check --force --strict` reports 0 warnings
- [ ] CI green
- [ ] Post-merge: tag v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)