### PR TITLE
release: prep v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.16.0] - 2026-04-26
+
+### Chores
+
+- lock 1.0 contracts (introspect schema, plugin protocol, lanes, llm, trust) (#270) (1360fc3)
+- update Homebrew formula to v0.15.3 (#269) (f4d95b3)
+
+### Documentation
+
+- close AGENTS.md envelope coverage gaps (#286) (24ef2fe)
+- sync README/AGENTS/docs to current state, drop em-dashes (#280) (1d7ac1c)
+- sync AGENTS.md + spec behavioral examples to envelope shape (#279) (52805a5)
+
+### Features
+
+- add --json flag (#281) (e30a6a3)
+- tier-D schema_version envelope on cross-cutting --json paths (#278) (0291aa8)
+- wrap --json outputs in schema_version envelope (tier C, BREAKING) (#274) (71f237a)
+- --json coverage across plugins, lanes, templates (tier A + B) (#273) (296064f)
+
+### Fixes
+
+- finalize envelope shapes before tagging (#285) (d5be3da)
+- silence pre-release lane on --json (single-envelope contract) (#284) (0dce714)
+- propagate --json to pre-release lane, document release JSON shapes (#283) (4c5b0bb)
+- address 1.0 readiness blockers from multi-model review (#282) (6b1234b)
+- honor --json on dry-run path (1.0 contract) (#277) (b781561)
+- tighten lanes import + templates list envelopes (#271 followups) (#276) (3d9799d)
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev-lifecycle CLI — scaffolding, tasks, lanes, plugins, and more."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "0.15.3";
+          version = "0.16.0";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary

Last pre-1.0 release. Cuts 0.16.0 so the new envelope contracts can be exercised from a tagged build before 1.0 freezes them.

### What's in 0.16.0 (since 0.15.3)

**Breaking envelope shapes (tier-D / 1.0 contract finalize):**
- `--json` outputs wrapped in `{schema_version: 1, ...}` envelopes across all cross-cutting paths
- Cancelled and success paths share the same key set on `plugins publish`, `templates publish`, `lanes publish`; `cancelled: bool` is the discriminator
- `tier` → `trust_tier` in `plugins install` and `lanes import`
- `lanes list --json` `steps` (integer count) → `step_count`

**New:**
- `fledge release --json` (dry-run + live envelopes)
- Silent pre-release lane gate so `release --json --pre-lane <name>` keeps stdout single-envelope
- `--no-bump` flag for tag-only releases

**Docs:**
- AGENTS.md: full machine-readable surface table, every documented envelope cross-checked against actual code emission

### Post-merge

- Tag `v0.16.0` on the squashed merge commit (`git tag -a v0.16.0 -m "Release v0.16.0" <sha>` + `git push origin v0.16.0`)
- Update Homebrew formula via the post-release workflow once binaries upload

## Test plan
- [x] `fledge lanes run pre-commit` (fmt + clippy + test + spec-check) green locally
- [x] `specsync check --force --strict` clean
- [ ] CI green
- [ ] Tag and verify install paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)