### PR TITLE
fix(plugin): security hardening for 1.0 — hook gates + output caps

### DIFF
--- a/specs/plugin/plugin-protocol.spec.md
+++ b/specs/plugin/plugin-protocol.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin-protocol
-version: 2
+version: 3
 status: active
 files:
   - src/protocol.rs
@@ -426,6 +426,7 @@ Fledge ignores outbound messages with unknown `type` values (forward-compatible)
 11. Capabilities default to `false` — plugins must explicitly declare what they need
 12. Exec, store/load, and metadata are blocked unless the corresponding capability is granted
 13. Granted capabilities are persisted in `plugins.toml` and included in the `init` message
+14. Exec command stdout and stderr are each capped at 10 MB (`MAX_EXEC_OUTPUT_SIZE`). Output beyond the cap is silently truncated to prevent a plugin from exhausting host memory
 
 ## Behavioral Examples
 
@@ -568,3 +569,4 @@ These are not part of v1 but are designed to be additive under the policy above:
 | 1 | 2026-04-22 | Initial spec — fledge-v1 protocol with prompt, confirm, select, progress, log, output, store/load, exec, metadata |
 | 1.1 | 2026-04-22 | Add capability manifest — exec, store, metadata capabilities with enforcement and install-time approval |
 | 2 | 2026-04-25 | Add Compatibility Policy — `fledge-v1` is additive-only within v1; field removal or retyping requires `fledge-v2`. Locks the 1.0 plugin contract |
+| 3 | 2026-04-27 | Security: exec command stdout/stderr capped at 10 MB each (`MAX_EXEC_OUTPUT_SIZE`) to prevent OOM from unbounded plugin output. Invariant 14 added |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -29,7 +29,6 @@ Plugin system for community extensions. Plugins are external executables that re
 | `DEFAULT_PLUGINS` | Curated list of plugin sources installed by `fledge plugins install --defaults` |
 | `PluginOptions` | Options for the plugin subcommand |
 | `PluginAction` | Enum of plugin operations: Install, Remove, Update, List, Search, Run, Publish, Create, Validate, Audit |
-| `PluginEntry` | Installed plugin record (name, source, version, installed date, commands, pinned_ref) |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 
 ### Structs & Enums
@@ -38,7 +37,7 @@ Plugin system for community extensions. Plugins are external executables that re
 |------|-------------|
 | `PluginOptions` | CLI options: `action`, `json` |
 | `PluginAction` | Enum: Install, Remove, Update, List, Audit, Search, Run, Publish, Create, Validate |
-| `PluginEntry` | Installed plugin record: name, source, version, installed date, commands, pinned_ref |
+| `PluginEntry` | (private) Installed plugin record: name, source, version, installed date, commands, pinned_ref |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 | `PluginManifest` | (private) Parsed `plugin.toml`: name, version, description, commands, hooks |
 

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 16
+version: 17
 status: active
 files:
   - src/plugin.rs
@@ -96,7 +96,9 @@ Plugins can register hooks for lifecycle events beyond install/remove:
 | `post_work_start` | After `fledge work start` creates a branch | Set up git hooks, configure branch-specific env |
 | `pre_pr` | Before `fledge work pr` pushes and creates PR | Run lint, format, security scans before PR creation |
 
-Lifecycle hooks are called across all installed plugins. Hooks are optional — plugins only participate in events they declare.
+Lifecycle hooks are called across all installed plugins. Hooks are optional — plugins only participate in events they declare. **Protocol plugins** (those declaring `protocol = "fledge-v1"`) must have the `exec` capability granted to run lifecycle hooks; without it, hooks are silently skipped. Non-protocol plugins (no capability model) run hooks unconditionally.
+
+During `fledge plugins install`, hooks are displayed alongside capabilities in the approval prompt so users see exactly what shell commands will execute before granting permission.
 
 ### Trust Tiers
 
@@ -170,6 +172,8 @@ pinned_ref = "v0.2.0"
 12. `fledge plugins install --defaults` (mutually exclusive with a positional source ref) installs every entry in the const `DEFAULT_PLUGINS` array. As of v0.15.2: `fledge-plugin-{github,deps,metrics}`. The earlier set also included `templates-remote` (re-absorbed into core `templates search`/`publish`) and `doctor` (re-absorbed into core `doctor` as the informational `Toolchains` section)
 13. The `--defaults` install loop reports per-plugin success/failure and continues on error so a single bad repo doesn't block the rest. Exits non-zero if any plugin failed; the trailing summary lists each failure with its error message
 14. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
+15. Protocol plugins without `exec` capability cannot run lifecycle hooks — `run_lifecycle_hook` skips them silently. Non-protocol plugins (no capability entry in the registry) are unaffected
+16. `plugin install` displays lifecycle hooks (with their shell commands) in the approval prompt alongside capabilities. Hooks-only plugins (no protocol capabilities) still require user approval before install completes
 
 ## Behavioral Examples
 
@@ -288,6 +292,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 17 | 2026-04-27 | Security: protocol plugins now require `exec` capability to run lifecycle hooks (previously hooks bypassed the capability gate). Install prompt displays hooks alongside capabilities for user approval. Invariants 15-16 added |
 | 16 | 2026-04-26 | **Breaking (1.0 contract finalize):** (a) `plugins install --json` (single + defaults) renames the per-plugin `tier` field to `trust_tier` to match every other plugin envelope (`list`, `audit`, `search`). (b) `plugins publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `plugin`, `topic`, `install_hint`); `cancelled` is `true` when the user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` already covers it). Consumers can now read the same keys regardless of cancel/success. Last-chance shape break before tagging 1.0 |
 | 15 | 2026-04-25 | **Breaking (tier C, #272):** `plugins list/audit/search/validate --json` outputs migrated from bare top-level arrays to `{schema_version: 1, <resource>: [...]}` envelopes (`plugins`, `audit`, `results`, and validate report flattened with schema_version). Last-chance shape break before 1.0 freezes the contract. AGENTS.md and integration tests updated in lockstep |
 | 14 | 2026-04-25 | Tier B follow-up: `plugins create` and `plugins publish` honour `--json` and emit a `{schema_version:1, action, ...}` envelope. `create` reports `path/name/description/files_created`; `publish` reports `repo/template/topic/install_hint` plus a `cancelled: true` shape on user-declined update prompts. Invariant 11 widened to enumerate `create` and `publish`. |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -29,6 +29,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `DEFAULT_PLUGINS` | Curated list of plugin sources installed by `fledge plugins install --defaults` |
 | `PluginOptions` | Options for the plugin subcommand |
 | `PluginAction` | Enum of plugin operations: Install, Remove, Update, List, Search, Run, Publish, Create, Validate, Audit |
+| `PluginEntry` | Installed plugin record (name, source, version, installed date, commands, pinned_ref) |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 
 ### Structs & Enums
@@ -37,7 +38,7 @@ Plugin system for community extensions. Plugins are external executables that re
 |------|-------------|
 | `PluginOptions` | CLI options: `action`, `json` |
 | `PluginAction` | Enum: Install, Remove, Update, List, Audit, Search, Run, Publish, Create, Validate |
-| `PluginEntry` | (private) Installed plugin record: name, source, version, installed date, commands, pinned_ref |
+| `PluginEntry` | Installed plugin record: name, source, version, installed date, commands, pinned_ref |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 | `PluginManifest` | (private) Parsed `plugin.toml`: name, version, description, commands, hooks |
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -110,7 +110,7 @@ struct PluginsRegistry {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-struct PluginEntry {
+pub struct PluginEntry {
     name: String,
     source: String,
     version: String,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -69,6 +69,40 @@ struct PluginHooks {
     pre_pr: Option<String>,
 }
 
+impl PluginHooks {
+    fn has_any(&self) -> bool {
+        self.build.is_some()
+            || self.post_install.is_some()
+            || self.post_remove.is_some()
+            || self.pre_init.is_some()
+            || self.post_work_start.is_some()
+            || self.pre_pr.is_some()
+    }
+
+    fn iter_defined(&self) -> Vec<(&str, &str)> {
+        let mut hooks = Vec::new();
+        if let Some(ref c) = self.build {
+            hooks.push(("build", c.as_str()));
+        }
+        if let Some(ref c) = self.post_install {
+            hooks.push(("post_install", c.as_str()));
+        }
+        if let Some(ref c) = self.post_remove {
+            hooks.push(("post_remove", c.as_str()));
+        }
+        if let Some(ref c) = self.pre_init {
+            hooks.push(("pre_init", c.as_str()));
+        }
+        if let Some(ref c) = self.post_work_start {
+            hooks.push(("post_work_start", c.as_str()));
+        }
+        if let Some(ref c) = self.pre_pr {
+            hooks.push(("pre_pr", c.as_str()));
+        }
+        hooks
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct PluginsRegistry {
     #[serde(default)]
@@ -196,6 +230,13 @@ pub fn resolve_plugin_command(name: &str) -> Option<PathBuf> {
 pub fn run_lifecycle_hook(event: &str) -> Result<()> {
     let registry = load_registry()?;
     for entry in &registry.plugins {
+        // Protocol plugins need exec capability to run hooks
+        if let Some(ref caps) = entry.capabilities {
+            if !caps.exec {
+                continue;
+            }
+        }
+
         let plugin_dir = plugins_dir().join(&entry.name);
         let manifest_path = plugin_dir.join("plugin.toml");
         if !manifest_path.exists() {
@@ -700,46 +741,69 @@ fn install_plugin(source: &str, force: bool, json: bool) -> Result<serde_json::V
 
     let caps = &manifest.capabilities;
     let has_caps = caps.exec || caps.store || caps.metadata;
-    if has_caps && manifest.plugin.protocol.is_some() {
+    let needs_cap_prompt = has_caps && manifest.plugin.protocol.is_some();
+    let has_hooks = manifest.hooks.has_any();
+
+    if needs_cap_prompt || has_hooks {
         if !json {
-            println!("\n  {} Requested capabilities:", style("*").cyan().bold());
-            if caps.exec {
-                println!("    {} exec — run shell commands", style("•").yellow());
+            if needs_cap_prompt {
+                println!("\n  {} Requested capabilities:", style("*").cyan().bold());
+                if caps.exec {
+                    println!("    {} exec — run shell commands", style("•").yellow());
+                }
+                if caps.store {
+                    println!(
+                        "    {} store — persist data between runs",
+                        style("•").yellow()
+                    );
+                }
+                if caps.metadata {
+                    println!(
+                        "    {} metadata — read project metadata and environment",
+                        style("•").yellow()
+                    );
+                }
             }
-            if caps.store {
-                println!(
-                    "    {} store — persist data between runs",
-                    style("•").yellow()
-                );
-            }
-            if caps.metadata {
-                println!(
-                    "    {} metadata — read project metadata and environment",
-                    style("•").yellow()
-                );
+            if has_hooks {
+                println!("\n  {} Lifecycle hooks:", style("*").cyan().bold());
+                for (name, cmd) in manifest.hooks.iter_defined() {
+                    println!(
+                        "    {} {} — {}",
+                        style("•").yellow(),
+                        name,
+                        style(cmd).dim()
+                    );
+                }
             }
             println!();
         }
         if force {
             eprintln!(
-                "  {} Capabilities auto-granted via --force",
+                "  {} Permissions auto-granted via --force",
                 style("WARN").yellow()
             );
         } else if !crate::utils::is_interactive() {
             fs::remove_dir_all(&plugin_dir).ok();
             bail!(
-                "Plugin capabilities require confirmation in non-interactive mode.\n  \
-                 Use --yes or --force to auto-grant capabilities."
+                "Plugin permissions require confirmation in non-interactive mode.\n  \
+                 Use --yes or --force to auto-grant."
             );
         } else {
+            let prompt_msg = if needs_cap_prompt && has_hooks {
+                "Grant capabilities and approve hooks?"
+            } else if needs_cap_prompt {
+                "Grant these capabilities?"
+            } else {
+                "Approve these hooks?"
+            };
             let confirm =
                 dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
-                    .with_prompt("Grant these capabilities?")
+                    .with_prompt(prompt_msg)
                     .default(true)
                     .interact()?;
             if !confirm {
                 fs::remove_dir_all(&plugin_dir).ok();
-                bail!("Plugin installation cancelled — capabilities not granted.");
+                bail!("Plugin installation cancelled.");
             }
         }
     }
@@ -3053,5 +3117,99 @@ build = "cargo build --release"
         assert_eq!(TrustTier::Official.label(), "official");
         assert_eq!(TrustTier::Team.label(), "team");
         assert_eq!(TrustTier::Unverified.label(), "unverified");
+    }
+
+    #[test]
+    fn hooks_has_any_detects_build() {
+        let hooks = PluginHooks {
+            build: Some("cargo build".into()),
+            ..Default::default()
+        };
+        assert!(hooks.has_any());
+    }
+
+    #[test]
+    fn hooks_has_any_detects_lifecycle() {
+        let hooks = PluginHooks {
+            pre_pr: Some("./check.sh".into()),
+            ..Default::default()
+        };
+        assert!(hooks.has_any());
+    }
+
+    #[test]
+    fn hooks_has_any_false_when_empty() {
+        let hooks = PluginHooks::default();
+        assert!(!hooks.has_any());
+    }
+
+    #[test]
+    fn hooks_iter_defined_returns_all_set_hooks() {
+        let hooks = PluginHooks {
+            build: Some("make".into()),
+            pre_pr: Some("lint".into()),
+            post_install: Some("setup.sh".into()),
+            ..Default::default()
+        };
+        let items = hooks.iter_defined();
+        assert_eq!(items.len(), 3);
+        assert!(items.contains(&("build", "make")));
+        assert!(items.contains(&("pre_pr", "lint")));
+        assert!(items.contains(&("post_install", "setup.sh")));
+    }
+
+    #[test]
+    fn hooks_iter_defined_empty_when_none() {
+        let hooks = PluginHooks::default();
+        assert!(hooks.iter_defined().is_empty());
+    }
+
+    #[test]
+    fn parse_manifest_with_hooks() {
+        let toml_str = r#"
+[plugin]
+name = "test-hooks"
+version = "1.0.0"
+
+[hooks]
+build = "cargo build --release"
+post_install = "scripts/setup.sh"
+pre_pr = "./lint.sh"
+"#;
+        let manifest: PluginManifest = toml::from_str(toml_str).unwrap();
+        assert!(manifest.hooks.has_any());
+        assert_eq!(
+            manifest.hooks.build.as_deref(),
+            Some("cargo build --release")
+        );
+        assert_eq!(
+            manifest.hooks.post_install.as_deref(),
+            Some("scripts/setup.sh")
+        );
+        assert_eq!(manifest.hooks.pre_pr.as_deref(), Some("./lint.sh"));
+        assert!(manifest.hooks.post_work_start.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_hooks_and_capabilities_together() {
+        let toml_str = r#"
+[plugin]
+name = "full-plugin"
+version = "2.0.0"
+protocol = "fledge-v1"
+
+[hooks]
+build = "make"
+pre_init = "./init-check.sh"
+
+[capabilities]
+exec = true
+store = false
+"#;
+        let manifest: PluginManifest = toml::from_str(toml_str).unwrap();
+        assert!(manifest.hooks.has_any());
+        assert!(manifest.capabilities.exec);
+        assert!(!manifest.capabilities.store);
+        assert_eq!(manifest.hooks.iter_defined().len(), 2);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -110,7 +110,7 @@ struct PluginsRegistry {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PluginEntry {
+struct PluginEntry {
     name: String,
     source: String,
     version: String,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -81,6 +81,9 @@ impl PluginHooks {
 
     fn iter_defined(&self) -> Vec<(&str, &str)> {
         let mut hooks = Vec::new();
+        if let Some(ref c) = self.pre_pr {
+            hooks.push(("pre_pr", c.as_str()));
+        }
         if let Some(ref c) = self.build {
             hooks.push(("build", c.as_str()));
         }
@@ -95,9 +98,6 @@ impl PluginHooks {
         }
         if let Some(ref c) = self.post_work_start {
             hooks.push(("post_work_start", c.as_str()));
-        }
-        if let Some(ref c) = self.pre_pr {
-            hooks.push(("pre_pr", c.as_str()));
         }
         hooks
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
@@ -570,6 +570,7 @@ const MAX_STORE_KEY_SIZE: usize = 256;
 const MAX_STORE_VALUE_SIZE: usize = 64 * 1024; // 64 KB per value
 const MAX_STORE_TOTAL_SIZE: usize = 1024 * 1024; // 1 MB total
 const MAX_STORE_KEY_COUNT: usize = 256;
+const MAX_EXEC_OUTPUT_SIZE: usize = 10 * 1024 * 1024; // 10 MB per stream
 
 fn handle_store(plugin_dir: &Path, key: &str, value: &str) -> Result<()> {
     if key.is_empty() {
@@ -958,11 +959,15 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<std::proces
             Ok(Some(_)) => {
                 let mut stdout = Vec::new();
                 let mut stderr = Vec::new();
-                if let Some(mut out) = child.stdout.take() {
-                    std::io::Read::read_to_end(&mut out, &mut stdout).ok();
+                if let Some(out) = child.stdout.take() {
+                    out.take(MAX_EXEC_OUTPUT_SIZE as u64)
+                        .read_to_end(&mut stdout)
+                        .ok();
                 }
-                if let Some(mut err) = child.stderr.take() {
-                    std::io::Read::read_to_end(&mut err, &mut stderr).ok();
+                if let Some(err) = child.stderr.take() {
+                    err.take(MAX_EXEC_OUTPUT_SIZE as u64)
+                        .read_to_end(&mut stderr)
+                        .ok();
                 }
                 let status = child
                     .wait()
@@ -1969,5 +1974,23 @@ metadata = false
         assert!(!caps.exec);
         assert!(!caps.store);
         assert!(!caps.metadata);
+    }
+
+    #[test]
+    fn exec_output_cap_is_10mb() {
+        assert_eq!(MAX_EXEC_OUTPUT_SIZE, 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn bounded_read_truncates_at_limit() {
+        use std::io::Cursor;
+        let data = vec![0xABu8; MAX_EXEC_OUTPUT_SIZE + 1024];
+        let reader = Cursor::new(data);
+        let mut buf = Vec::new();
+        reader
+            .take(MAX_EXEC_OUTPUT_SIZE as u64)
+            .read_to_end(&mut buf)
+            .unwrap();
+        assert_eq!(buf.len(), MAX_EXEC_OUTPUT_SIZE);
     }
 }


### PR DESCRIPTION
## Summary

- **Hook capability bypass**: Protocol plugins now need `exec` capability to run lifecycle hooks. Previously, a plugin without `exec` could still execute arbitrary shell commands via `[hooks]`
- **Install transparency**: `fledge plugins install` now displays lifecycle hooks alongside capabilities in the approval prompt so users see exactly what will execute
- **Unbounded output cap**: `wait_with_timeout` in the plugin protocol now caps stdout/stderr at 10 MB each via `.take()`, preventing a malicious plugin from OOM-ing the host
- **9 new unit tests** covering hooks introspection, manifest parsing, output cap contract, and bounded-read truncation

## Context

These are security blockers identified during multi-model 1.0 readiness review. All three were in the plugin system's trust boundary.

## Test plan

- [x] `cargo test` — all 9 new tests pass, full suite green
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] Manual: install a protocol plugin with hooks but without exec capability, verify hooks are skipped at runtime
- [ ] Manual: install a plugin with hooks, verify prompt shows hook commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)