### PR TITLE
fix(ai): normalize Ollama host to include scheme

### DIFF
--- a/specs/llm/llm.spec.md
+++ b/specs/llm/llm.spec.md
@@ -1,6 +1,6 @@
 ---
 module: llm
-version: 2
+version: 3
 status: active
 files:
   - src/llm.rs
@@ -32,6 +32,7 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 | `ProviderOverride` | `{ provider: Option<String>, model: Option<String> }` — per-invocation overrides |
 | `resolve_provider_kind` | Determine active provider given config + override |
 | `build_provider` | Construct the concrete provider box from config + env + overrides |
+| `normalize_ollama_host` | Ensures `OllamaProvider.host` always has a scheme; prepends `http://` to bare `host:port` values |
 | `describe` | Human string: `"claude (sonnet-4.5)"` or `"ollama (llama3.3)"` |
 
 ### Structs & Enums
@@ -56,6 +57,7 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 |----------|-----------|-------------|
 | `resolve_provider_kind` | `(&Config, Option<&str>) -> Result<ProviderKind>` | CLI override > `FLEDGE_AI_PROVIDER` env > `ai.provider` config > `Claude` |
 | `build_provider` | `(&Config, &ProviderOverride) -> Result<Box<dyn LlmProvider>>` | Builds a concrete provider; model follows the same precedence order |
+| `normalize_ollama_host` | `(&str) -> String` | Trims whitespace and trailing `/`; prepends `http://` when no scheme is present |
 | `describe` | `(&dyn LlmProvider) -> String` | Pretty formatter for spinner messages and JSON payloads |
 | `ProviderKind::parse` | `(&str) -> Result<Self>` | Case-insensitive parse; trims whitespace |
 | `ProviderKind::as_str` | `(&self) -> &'static str` | `"claude"` or `"ollama"` |
@@ -64,7 +66,7 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 
 1. Precedence for active provider (highest to lowest): explicit CLI override > `FLEDGE_AI_PROVIDER` env var > `ai.provider` in config > default `"claude"`
 2. Precedence for active model follows the same order: CLI `--model` > `FLEDGE_AI_MODEL` env > per-provider config field > provider default
-3. `OllamaProvider.host` defaults to `http://localhost:11434`; a trailing slash is tolerated and stripped before path joining
+3. `OllamaProvider.host` defaults to `http://localhost:11434`; `normalize_ollama_host` trims whitespace, strips trailing slashes, and prepends `http://` when no scheme is present (so bare `localhost:11434` becomes `http://localhost:11434`)
 4. When `OllamaProvider.api_key` is set (via `OLLAMA_API_KEY` env or `ai.ollama.api_key` config), the request sends `Authorization: Bearer <key>`; otherwise no auth header is sent
 5. `ClaudeProvider` preserves the exact behavior `ask` / `review` had before this module existed: shells out to `claude --print <prompt>` with optional `--model <name>`
 6. `OllamaProvider.invoke` POSTs `{"model": ..., "prompt": ..., "stream": false}` to `<host>/api/generate` and parses `{"response": "..."}` from the reply
@@ -124,5 +126,6 @@ $ fledge review --provider claude --model opus-4
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-04-27 | Document `normalize_ollama_host` — ensures bare `host:port` values get an `http://` scheme; update invariant 3 to describe full normalization behavior |
 | 2 | 2026-04-24 | `OllamaProvider` gains a `timeout: Duration` field populated by `build_provider`; adds `ai.ollama.timeout_seconds` config fallback so the per-request timeout is tunable without env vars (`FLEDGE_AI_TIMEOUT` still wins) |
 | 1 | 2026-04-23 | Initial spec — provider abstraction with Claude + Ollama implementations, env-var and config resolution, CLI overrides |

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -174,13 +174,14 @@ fn resolve_ollama_model(config: &Config) -> (String, Source) {
 
 fn resolve_ollama_host(config: &Config) -> (String, Source) {
     if let Ok(v) = std::env::var("OLLAMA_HOST") {
-        return (v, Source::Env);
+        return (crate::llm::normalize_ollama_host(&v), Source::Env);
     }
+    let normalized = crate::llm::normalize_ollama_host(&config.ai.ollama.host);
     let default_host = "http://localhost:11434";
-    if config.ai.ollama.host == default_host {
+    if normalized == default_host {
         (default_host.to_string(), Source::Default)
     } else {
-        (config.ai.ollama.host.clone(), Source::ConfigFile)
+        (normalized, Source::ConfigFile)
     }
 }
 
@@ -333,7 +334,9 @@ fn models(provider: Option<String>, search: Option<String>, json: bool) -> Resul
 }
 
 fn list_ollama_models(config: &Config) -> Result<Vec<ModelEntry>> {
-    let host = std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone());
+    let host = crate::llm::normalize_ollama_host(
+        &std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone()),
+    );
     let url = format!("{}/api/tags", host.trim_end_matches('/'));
 
     let agent: ureq::Agent = ureq::Agent::config_builder()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -436,8 +436,9 @@ fn check_ai() -> Section {
         crate::llm::ProviderKind::Ollama => {
             // Ollama can be a remote endpoint; the CLI check above doesn't tell
             // us whether the configured host responds. Probe `/api/tags`.
-            let host =
+            let raw =
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone());
+            let host = crate::llm::normalize_ollama_host(&raw);
             if probe_ollama_host(&host) {
                 CheckStatus::Ok
             } else if ollama.status == CheckStatus::Ok {
@@ -454,8 +455,9 @@ fn check_ai() -> Section {
             Some("claude is the active provider and is reachable".to_string())
         }
         (crate::llm::ProviderKind::Ollama, CheckStatus::Ok) => {
-            let host =
+            let raw =
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone());
+            let host = crate::llm::normalize_ollama_host(&raw);
             let model =
                 std::env::var("FLEDGE_AI_MODEL").unwrap_or_else(|_| config.ai.ollama.model.clone());
             Some(format!(
@@ -463,8 +465,9 @@ fn check_ai() -> Section {
             ))
         }
         (crate::llm::ProviderKind::Ollama, CheckStatus::Error) => {
-            let host =
+            let raw =
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone());
+            let host = crate::llm::normalize_ollama_host(&raw);
             Some(format!(
                 "ollama CLI installed but endpoint {host} is not responding"
             ))

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,6 +29,16 @@ impl ProviderKind {
     }
 }
 
+/// Ensure a host string has a scheme; prepend `http://` when missing.
+pub fn normalize_ollama_host(host: &str) -> String {
+    let h = host.trim().trim_end_matches('/');
+    if h.starts_with("http://") || h.starts_with("https://") {
+        h.to_string()
+    } else {
+        format!("http://{h}")
+    }
+}
+
 /// An invokable LLM.
 pub trait LlmProvider: Send + Sync {
     /// Send a prompt, return the model's response as plain text.
@@ -223,8 +233,9 @@ pub fn build_provider(
                 .or_else(|| config.ai.claude.model.clone()),
         })),
         ProviderKind::Ollama => {
-            let host =
-                std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone());
+            let host = normalize_ollama_host(
+                &std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone()),
+            );
             let api_key = std::env::var("OLLAMA_API_KEY")
                 .ok()
                 .or_else(|| config.ai.ollama.api_key.clone());


### PR DESCRIPTION
## Summary
- `OLLAMA_HOST=localhost:11434` (without `http://`) caused "http: invalid format" errors from ureq
- Added `normalize_ollama_host()` helper in `llm.rs` that prepends `http://` when no scheme is present
- Applied across all 5 host resolution sites in `ai.rs`, `llm.rs`, and `doctor.rs`
- Also normalizes the config path in `resolve_ollama_host` so bare hosts from `config.toml` work too

## Test plan
- [x] `cargo test` — 865 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- spec check` — 29 specs, 0 errors
- [x] Tested `fledge ask` with Claude, Ollama local, and 3 Ollama Cloud models
- [x] Tested `fledge review` with Claude and Ollama
- [x] Tested `fledge doctor` — all AI checks pass
- [x] Verified bare `localhost:11434` now resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)