### PR TITLE
docs: update documentation for v0.16.0 changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge deps --json` | `fledge-plugin-deps` | Dependency report from the ecosystem tool (`cargo outdated`, `npm audit`, ...) |
 | `fledge metrics --json` / `--churn --json` / `--tests --json` | `fledge-plugin-metrics` | LOC summary (tokei), per-file churn, test/source ratio |
 
-Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `ai use`, `config *`, `completions`. If you need structured output from one of these, add it via a spec + PR. It's an accepted pattern.
+Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `watch`, `ai use`, `config *` (including `config edit`, an interactive editor), `completions`. If you need structured output from one of these, add it via a spec + PR. It's an accepted pattern.
 
 **Envelope contract.** Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -268,7 +268,7 @@ fledge lanes validate --json
 Manage `~/.config/fledge/config.toml`.
 
 ```
-fledge config <get|set|unset|add|remove|list|path|init>
+fledge config <get|set|unset|add|remove|edit|list|path|init>
 ```
 
 | Subcommand | What it does |
@@ -278,18 +278,22 @@ fledge config <get|set|unset|add|remove|list|path|init>
 | `unset <key>` | Delete a value |
 | `add <key> <value>` | Append to a list (`templates.paths`, `templates.repos`) |
 | `remove <key> <value>` | Remove from a list |
+| `edit` | Interactively browse and edit config values (requires TTY) |
 | `list` | Show everything |
 | `path` | Print config file path |
 | `init [--preset <name>]` | Initialize config (presets: `corvidlabs`) |
 
 **Valid keys:**
-- `defaults.author`: `defaults.github_org`, `defaults.license`
+- `defaults.author`, `defaults.github_org`, `defaults.license`
 - `github.token`
-- `templates.paths`: `templates.repos`
+- `templates.paths`, `templates.repos`
+- `ai.provider`, `ai.claude.model`
+- `ai.ollama.host`, `ai.ollama.api_key`, `ai.ollama.model`, `ai.ollama.timeout_seconds`
 
 ```bash
 fledge config set defaults.author "Leif"
 fledge config add templates.repos "CorvidLabs/fledge-templates"
+fledge config edit                                  # interactive config editor
 fledge config list
 ```
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -54,6 +54,33 @@ repos = ["CorvidLabs/fledge-templates", "myorg/templates"]
 | `paths` | Local directories with templates |
 | `repos` | GitHub repos to pull templates from (`owner/repo`) |
 
+### [ai]
+
+AI provider and model settings. Written by `fledge ai use` or `fledge config set`/`edit`:
+
+```toml
+[ai]
+provider = "ollama"             # "claude" or "ollama"
+
+[ai.claude]
+model = "opus-4.7"             # model name passed to claude CLI
+
+[ai.ollama]
+host = "http://localhost:11434" # Ollama API endpoint (always normalized to include scheme)
+model = "qwen3-coder:480b-cloud"
+api_key = "sk-..."             # for Ollama Cloud / authenticated endpoints
+timeout_seconds = 600          # request timeout (default: 600)
+```
+
+| Key | What it does | Default |
+|-----|-------------|---------|
+| `ai.provider` | Active LLM backend | `claude` |
+| `ai.claude.model` | Model name for Claude CLI | Claude CLI default |
+| `ai.ollama.host` | Ollama API endpoint URL | `http://localhost:11434` |
+| `ai.ollama.model` | Ollama model name | `llama3.2:latest` |
+| `ai.ollama.api_key` | Bearer token for authenticated endpoints | (none) |
+| `ai.ollama.timeout_seconds` | Request timeout in seconds | `600` |
+
 ### [github]
 
 ```toml
@@ -92,6 +119,18 @@ repos = ["CorvidLabs/fledge-templates", "my-org/my-templates"]
 
 [github]
 token = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+[ai]
+provider = "ollama"
+
+[ai.claude]
+model = "opus-4.7"
+
+[ai.ollama]
+host = "https://ollama.com"
+model = "qwen3-coder:480b-cloud"
+api_key = "sk-your-key"
+timeout_seconds = 600
 ```
 
 ## Environment Variables
@@ -100,8 +139,13 @@ token = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
 |----------|-------------|
 | `FLEDGE_GITHUB_TOKEN` | GitHub token (highest priority) |
 | `GITHUB_TOKEN` | GitHub token (fallback after FLEDGE_GITHUB_TOKEN) |
+| `FLEDGE_AI_PROVIDER` | AI provider override (`claude` or `ollama`) |
+| `FLEDGE_AI_MODEL` | AI model override |
+| `FLEDGE_AI_TIMEOUT` | Ollama request timeout in seconds |
+| `OLLAMA_HOST` | Ollama API endpoint URL |
+| `OLLAMA_API_KEY` | Ollama Bearer token |
 
-If neither env var nor config is set, fledge falls back to `gh auth token` (GitHub CLI) automatically.
+If neither env var nor config is set, fledge falls back to `gh auth token` (GitHub CLI) automatically for GitHub operations.
 
 ## Project Configuration (fledge.toml)
 

--- a/docs/src/doctor.md
+++ b/docs/src/doctor.md
@@ -52,7 +52,7 @@ The Toolchains section is **informational**. Missing entries render dimmed (`· 
 $ fledge doctor
 
   fledge
-    ✅ fledge config 0.15.3, loaded
+    ✅ fledge config 0.16.0, loaded
 
   Git
     ✅ git 2.50.1
@@ -104,7 +104,7 @@ Returns a structured envelope:
   "sections": [
     {
       "name": "fledge",
-      "checks": [{"name": "fledge config", "status": "ok", "version": "0.15.3", "detail": "loaded", "fix": null}]
+      "checks": [{"name": "fledge config", "status": "ok", "version": "0.16.0", "detail": "loaded", "fix": null}]
     },
     {
       "name": "Toolchains",

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -91,13 +91,29 @@ fledge templates init my-app --template user/repo --refresh
 
 ## fledge review / fledge ask not working
 
-These commands use the Claude CLI. Make sure it's installed and authenticated:
+These commands use the active AI provider. Check which provider is configured:
+
+```bash
+fledge ai status
+fledge doctor        # the AI section will diagnose the issue
+```
+
+**If using Claude (default):** Make sure the `claude` CLI is installed and authenticated:
 
 ```bash
 claude --version
 ```
 
 If Claude isn't installed, see [Claude CLI docs](https://docs.anthropic.com/en/docs/claude-code/overview) for setup instructions.
+
+**If using Ollama:** Make sure the Ollama daemon is running and the host is correct:
+
+```bash
+fledge ai status                    # check host and model
+fledge ai models --provider ollama  # verify the endpoint is reachable
+```
+
+If the host is missing `http://`, fledge normalizes it automatically (as of v0.16.0). If using Ollama Cloud, make sure `OLLAMA_API_KEY` or `ai.ollama.api_key` is set.
 
 ## Clippy or fmt warnings in CI
 


### PR DESCRIPTION
## Summary

- Add `config edit` subcommand to CLI reference, AGENTS.md, and configuration docs
- Document all `ai.*` config keys (`ai.provider`, `ai.claude.model`, `ai.ollama.*`) and environment variables (`FLEDGE_AI_PROVIDER`, `FLEDGE_AI_MODEL`, `FLEDGE_AI_TIMEOUT`, `OLLAMA_HOST`, `OLLAMA_API_KEY`)
- Update `fledge doctor` example output version from 0.15.3 → 0.16.0
- Expand AI troubleshooting section to cover Ollama provider alongside Claude, including `fledge ai status` and host normalization guidance

## Files changed

- `AGENTS.md` — mention `config edit` in non-JSON commands list
- `docs/src/cli-reference.md` — add `edit` subcommand, AI config keys, example
- `docs/src/configuration.md` — add `[ai]` section with all keys/defaults, full config example, env vars table
- `docs/src/doctor.md` — bump version in example output to 0.16.0
- `docs/src/troubleshooting.md` — provider-aware AI troubleshooting with Ollama guidance