### PR TITLE
fix: update spec files to reference new module paths post-refactor

### DIFF
--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -1,6 +1,6 @@
 ---
 module: main
-version: 9
+version: 10
 status: active
 files:
   - src/main.rs
@@ -46,9 +46,34 @@ CLI entry point. Defines the top-level `Cli` struct and `Commands` enum using cl
 
 ## Public API
 
-### Exported Functions
+### Structs & Enums
 
-No public exports — `main.rs` is the binary entry point.
+| Type | Source | Description |
+|------|--------|-------------|
+| `Cli` | `src/cli.rs` | Top-level clap `#[derive(Parser)]` struct. Holds the `--non-interactive` global flag and the `Commands` subcommand enum |
+| `Commands` | `src/cli.rs` | Enum of all top-level subcommands: Ai, Ask, Changelog, Completions, Config, Doctor, Introspect, Lanes, Plugins, Release, Review, Run, Spec, Templates, Watch, Work, and External (plugin pass-through) |
+| `TemplatesSubcommand` | `src/cli.rs` | Enum of `templates` subcommands: Init, Create, Validate, List, Search, Publish |
+| `SpecSubcommand` | `src/cli.rs` | Enum of `spec` subcommands: Check, Init, List, New, Show |
+| `WorkSubcommand` | `src/cli.rs` | Enum of `work` subcommands: Start, Pr, Status |
+| `AiSubcommand` | `src/cli.rs` | Enum of `ai` subcommands: Status, Models, Use |
+| `ConfigAction` | `src/cli.rs` | Enum of `config` subcommands: Get, Set, Unset, Add, Remove, Edit, List, Path, Init |
+| `LaneSubcommand` | `src/cli.rs` | Enum of `lanes` subcommands: Run, List, Init, Search, Import, Publish, Create, Validate, and External |
+| `PluginSubcommand` | `src/cli.rs` | Enum of `plugins` subcommands: Install, Remove, Update, List, Audit, Search, Run, Publish, Create, Validate |
+
+### Functions
+
+| Function | Source | Signature | Description |
+|----------|--------|-----------|-------------|
+| `handle_config` | `src/config_cmds.rs` | `(ConfigAction) -> Result<()>` | Dispatch `fledge config` subcommands (get, set, unset, add, remove, edit, list, path, init) |
+| `print_config_described` | `src/config_cmds.rs` | `(&str, &Option<impl Display>, &str)` | Print a single config key with its current value and description |
+| `print_config_value_described` | `src/config_cmds.rs` | `(&str, &impl Display, &str)` | Print a single config key with a non-optional value and description |
+| `print_config_list_described` | `src/config_cmds.rs` | `(&str, &[String], &str)` | Print a list config key with its values and description |
+| `interactive_config_edit` | `src/config_cmds.rs` | `() -> Result<()>` | Interactive TUI loop for editing config keys via dialoguer prompts |
+| `handle_templates` | `src/template_cmds.rs` | `(TemplatesSubcommand) -> Result<()>` | Dispatch `fledge templates` subcommands (init, create, validate, list, search, publish) |
+| `install_completions` | `src/template_cmds.rs` | `(Option<Shell>) -> Result<()>` | Generate and install shell completions for bash, zsh, or fish |
+| `list_templates` | `src/template_cmds.rs` | `(bool) -> Result<()>` | List available templates from configured sources. Bool controls JSON output |
+| `search_templates` | `src/template_cmds.rs` | `(Option<&str>, Option<&str>, usize, bool) -> Result<()>` | Search GitHub for community templates by query, author, limit, and JSON flag |
+| `publish_template` | `src/template_cmds.rs` | `(&Path, Option<&str>, bool, Option<&str>, bool, bool) -> Result<()>` | Validate and publish a template directory to GitHub with topic tagging |
 
 ## Behavioral Examples
 
@@ -94,6 +119,7 @@ All modules are dependencies — main dispatches to every subcommand module. See
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 10 | 2026-04-29 | Document all public exports from `cli.rs`, `config_cmds.rs`, and `template_cmds.rs` now that these files are listed in spec frontmatter. No API changes |
 | 9 | 2026-04-26 | `templates list` empty case now exits 0 in both modes. JSON mode emits `{schema_version: 1, templates: [], hint}`; non-JSON prints "No templates configured" + hint. Previously both bailed with non-zero exit, breaking agents that call `templates list --json` defensively |
 | 8 | 2026-04-25 | **Breaking (tier C, #272):** `templates search --json` migrated from bare top-level array to `{schema_version: 1, results: [...]}`. Last-chance shape break before 1.0 |
 | 7 | 2026-04-25 | Tier-B `--json` envelopes for `templates list` and `templates publish` (handled inline in main.rs). Both emit `{schema_version: 1, ...}` matching the contract used by plugins/lanes/init/create_template. Failure paths still exit non-zero. Closes the gap where `templates list --json` previously errored with "unexpected argument" (#271) |

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -4,6 +4,9 @@ version: 9
 status: active
 files:
   - src/main.rs
+  - src/cli.rs
+  - src/config_cmds.rs
+  - src/template_cmds.rs
 
 db_tables: []
 depends_on:

--- a/specs/main/main.spec.md
+++ b/specs/main/main.spec.md
@@ -46,6 +46,30 @@ CLI entry point. Defines the top-level `Cli` struct and `Commands` enum using cl
 
 ## Public API
 
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `Cli` | Top-level clap `#[derive(Parser)]` struct. Holds the `--non-interactive` global flag and the `Commands` subcommand enum |
+| `Commands` | Enum of all top-level subcommands: Ai, Ask, Changelog, Completions, Config, Doctor, Introspect, Lanes, Plugins, Release, Review, Run, Spec, Templates, Watch, Work, and External (plugin pass-through) |
+| `TemplatesSubcommand` | Enum of `templates` subcommands: Init, Create, Validate, List, Search, Publish |
+| `SpecSubcommand` | Enum of `spec` subcommands: Check, Init, List, New, Show |
+| `WorkSubcommand` | Enum of `work` subcommands: Start, Pr, Status |
+| `AiSubcommand` | Enum of `ai` subcommands: Status, Models, Use |
+| `ConfigAction` | Enum of `config` subcommands: Get, Set, Unset, Add, Remove, Edit, List, Path, Init |
+| `LaneSubcommand` | Enum of `lanes` subcommands: Run, List, Init, Search, Import, Publish, Create, Validate, and External |
+| `PluginSubcommand` | Enum of `plugins` subcommands: Install, Remove, Update, List, Audit, Search, Run, Publish, Create, Validate |
+| `handle_config` | Dispatch `fledge config` subcommands (get, set, unset, add, remove, edit, list, path, init) |
+| `print_config_described` | Print a single config key with its current value and description |
+| `print_config_value_described` | Print a single config key with a non-optional value and description |
+| `print_config_list_described` | Print a list config key with its values and description |
+| `interactive_config_edit` | Interactive TUI loop for editing config keys via dialoguer prompts |
+| `handle_templates` | Dispatch `fledge templates` subcommands (init, create, validate, list, search, publish) |
+| `install_completions` | Generate and install shell completions for bash, zsh, or fish |
+| `list_templates` | List available templates from configured sources |
+| `search_templates` | Search GitHub for community templates by query, author, and limit |
+| `publish_template` | Validate and publish a template directory to GitHub with topic tagging |
+
 ### Structs & Enums
 
 | Type | Source | Description |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -40,6 +40,22 @@ Plugin system for community extensions. Plugins are external executables that re
 | `PluginOptions` | Options for the plugin subcommand |
 | `PluginAction` | Enum of plugin operations: Install, Remove, Update, List, Search, Run, Publish, Create, Validate, Audit |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
+| `install_action` | Top-level dispatcher for `fledge plugins install`. Routes single-source installs vs `--defaults` bulk installs |
+| `install_defaults` | Install every entry in `DEFAULT_PLUGINS` with per-plugin error collection |
+| `install_plugin` | Install a single plugin from source ref. Returns a JSON report for the caller to envelope |
+| `list_plugins` | List installed plugins with trust tier, version, and source info |
+| `audit_plugins` | Security audit of installed plugins — trust tiers, capabilities, hooks, and warnings |
+| `has_lifecycle_hooks` | Check whether a plugin has any lifecycle hooks defined in its manifest |
+| `get_lifecycle_hooks` | Return all lifecycle hooks for a plugin as (event, command) pairs |
+| `remove_plugin` | Remove an installed plugin: delete symlinks, run post_remove hook, clean up directory and registry |
+| `create_plugin` | Scaffold a new plugin directory with plugin.toml, entry-point script, README, and .gitignore |
+| `publish_plugin` | Validate and publish a plugin directory to GitHub with `fledge-plugin` topic |
+| `update_plugins` | Update installed plugins via git pull + rebuild. Supports single, all, or `--defaults` scope |
+| `find_latest_tag` | Fetch tags and return the latest version-sorted tag for a plugin repo |
+| `PluginValidationReport` | Validation result struct: path, plugin_name, errors, warnings. Serializable for `--json` output |
+| `validate_plugin` | Validate a plugin.toml manifest: check name, version, binaries, and hooks |
+| `print_plugin_report` | Print validation results in human or JSON format. Fails if errors (or warnings in strict mode) |
+| `search_plugins` | Search GitHub for plugins by query, author, limit with `fledge-plugin` topic filter |
 
 ### Structs & Enums
 
@@ -74,8 +90,6 @@ Plugin system for community extensions. Plugins are external executables that re
 | `validate_plugin` | `validate.rs` | `(&Path, bool, bool) -> Result<()>` | Validate a plugin.toml manifest: check name, version, binaries, and hooks |
 | `print_plugin_report` | `validate.rs` | `(&PluginValidationReport, bool, bool) -> Result<()>` | Print validation results in human or JSON format. Fails if errors (or warnings in strict mode) |
 | `search_plugins` | `search.rs` | `(Option<&str>, Option<&str>, usize, bool) -> Result<()>` | Search GitHub for plugins by query, author, limit with `fledge-plugin` topic filter |
-| `run_plugin_cmd` | `run_plugin.rs` | `(&str, &[String]) -> Result<()>` | Resolve and execute a plugin command, handling protocol plugins and FLEDGE_PLUGIN_DIR |
-| `run_hook` | `run_plugin.rs` | `(&Path, &str, &str) -> Result<()>` | Execute a lifecycle or build hook script within a plugin directory |
 
 ## Plugin Format
 

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 19
+version: 20
 status: active
 files:
   - src/plugin/mod.rs
@@ -50,14 +50,32 @@ Plugin system for community extensions. Plugins are external executables that re
 | `PluginEntry` | (private) Installed plugin record: name, source, version, installed date, commands, pinned_ref |
 | `PluginCapabilities` | Declared capabilities — exec, store, metadata (all default false) |
 | `PluginManifest` | (private) Parsed `plugin.toml`: name, version, description, commands, hooks |
+| `PluginValidationReport` | Validation result struct: path, plugin_name, errors, warnings. Serializable for `--json` output |
 
 ### Functions
 
-| Function | Signature | Description |
-|----------|-----------|-------------|
-| `run` | `(PluginOptions) -> Result<()>` | Main entry — dispatch to install/list/remove/run/audit |
-| `resolve_plugin_command` | `(&str) -> Option<PathBuf>` | Find plugin executable by command name |
-| `run_lifecycle_hook` | `(&str) -> Result<()>` | Run a named lifecycle hook across all installed plugins |
+| Function | Source | Signature | Description |
+|----------|--------|-----------|-------------|
+| `run` | `mod.rs` | `(PluginOptions) -> Result<()>` | Main entry — dispatch to install/list/remove/run/audit |
+| `resolve_plugin_command` | `mod.rs` | `(&str) -> Option<PathBuf>` | Find plugin executable by command name |
+| `run_lifecycle_hook` | `mod.rs` | `(&str) -> Result<()>` | Run a named lifecycle hook across all installed plugins |
+| `install_action` | `install.rs` | `(Option<&str>, bool, bool, bool) -> Result<()>` | Top-level dispatcher for `fledge plugins install`. Routes single-source installs vs `--defaults` bulk installs |
+| `install_defaults` | `install.rs` | `(bool, bool) -> Result<()>` | Install every entry in `DEFAULT_PLUGINS` with per-plugin error collection |
+| `install_plugin` | `install.rs` | `(&str, bool, bool) -> Result<Value>` | Install a single plugin from source ref. Returns a JSON report for the caller to envelope |
+| `list_plugins` | `list.rs` | `(bool) -> Result<()>` | List installed plugins with trust tier, version, and source info |
+| `audit_plugins` | `list.rs` | `(bool) -> Result<()>` | Security audit of installed plugins — trust tiers, capabilities, hooks, and warnings |
+| `has_lifecycle_hooks` | `list.rs` | `(&str) -> bool` | Check whether a plugin has any lifecycle hooks defined in its manifest |
+| `get_lifecycle_hooks` | `list.rs` | `(&str) -> Vec<(String, String)>` | Return all lifecycle hooks for a plugin as (event, command) pairs |
+| `remove_plugin` | `remove.rs` | `(&str, bool) -> Result<()>` | Remove an installed plugin: delete symlinks, run post_remove hook, clean up directory and registry |
+| `create_plugin` | `create.rs` | `(&str, &Path, Option<&str>, bool, bool) -> Result<()>` | Scaffold a new plugin directory with plugin.toml, entry-point script, README, and .gitignore |
+| `publish_plugin` | `publish.rs` | `(&Path, Option<&str>, bool, Option<&str>, bool, bool) -> Result<()>` | Validate and publish a plugin directory to GitHub with `fledge-plugin` topic |
+| `update_plugins` | `update.rs` | `(Option<&str>, bool, bool) -> Result<()>` | Update installed plugins via git pull + rebuild. Supports single, all, or `--defaults` scope |
+| `find_latest_tag` | `update.rs` | `(&Path) -> Option<String>` | Fetch tags and return the latest version-sorted tag for a plugin repo |
+| `validate_plugin` | `validate.rs` | `(&Path, bool, bool) -> Result<()>` | Validate a plugin.toml manifest: check name, version, binaries, and hooks |
+| `print_plugin_report` | `validate.rs` | `(&PluginValidationReport, bool, bool) -> Result<()>` | Print validation results in human or JSON format. Fails if errors (or warnings in strict mode) |
+| `search_plugins` | `search.rs` | `(Option<&str>, Option<&str>, usize, bool) -> Result<()>` | Search GitHub for plugins by query, author, limit with `fledge-plugin` topic filter |
+| `run_plugin_cmd` | `run_plugin.rs` | `(&str, &[String]) -> Result<()>` | Resolve and execute a plugin command, handling protocol plugins and FLEDGE_PLUGIN_DIR |
+| `run_hook` | `run_plugin.rs` | `(&Path, &str, &str) -> Result<()>` | Execute a lifecycle or build hook script within a plugin directory |
 
 ## Plugin Format
 
@@ -301,6 +319,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 20 | 2026-04-29 | Document all submodule exports (`install.rs`, `list.rs`, `remove.rs`, `create.rs`, `publish.rs`, `update.rs`, `validate.rs`, `search.rs`, `run_plugin.rs`) now listed in spec frontmatter. No API changes |
 | 19 | 2026-04-29 | Refactor: split `plugin.rs` into `plugin/` module (11 submodules). Spec files list narrowed to `mod.rs` only — internal items use module-private visibility so spec-sync sees exactly the 7 public API exports. No API changes |
 | 17 | 2026-04-27 | Security: protocol plugins now require `exec` capability to run lifecycle hooks (previously hooks bypassed the capability gate). Install prompt displays hooks alongside capabilities for user approval. Invariants 15-16 added |
 | 16 | 2026-04-26 | **Breaking (1.0 contract finalize):** (a) `plugins install --json` (single + defaults) renames the per-plugin `tier` field to `trust_tier` to match every other plugin envelope (`list`, `audit`, `search`). (b) `plugins publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `plugin`, `topic`, `install_hint`); `cancelled` is `true` when the user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` already covers it). Consumers can now read the same keys regardless of cancel/success. Last-chance shape break before tagging 1.0 |

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -4,6 +4,16 @@ version: 19
 status: active
 files:
   - src/plugin/mod.rs
+  - src/plugin/install.rs
+  - src/plugin/list.rs
+  - src/plugin/remove.rs
+  - src/plugin/run_plugin.rs
+  - src/plugin/create.rs
+  - src/plugin/publish.rs
+  - src/plugin/update.rs
+  - src/plugin/validate.rs
+  - src/plugin/search.rs
+  - src/plugin/tests.rs
 
 db_tables: []
 depends_on:

--- a/specs/trust/context.md
+++ b/specs/trust/context.md
@@ -17,8 +17,8 @@ spec: trust.spec.md
 
 - `src/trust.rs` — complete implementation (~100 LOC + tests)
 - `specs/trust/trust.spec.md` — formal API, invariants, and behavioral examples
-- `src/plugin.rs` — primary consumer; shows how tiers surface in `list`, `install`, and `audit`
-- `src/search.rs`, `src/lanes.rs`, `src/init.rs` — other consumers using `determine_trust_tier_from_owner`
+- `src/plugin/mod.rs` — primary consumer; shows how tiers surface in `list`, `install`, and `audit`
+- `src/search.rs`, `src/lanes/mod.rs`, `src/init.rs` — other consumers using `determine_trust_tier_from_owner`
 
 ## Current Status
 


### PR DESCRIPTION
## Summary
- **`specs/plugin/plugin.spec.md`** — added all 10 submodule files (`install.rs`, `list.rs`, `remove.rs`, etc.) that were missing from the `files:` frontmatter
- **`specs/main/main.spec.md`** — added `cli.rs`, `config_cmds.rs`, `template_cmds.rs` extracted during the main.rs refactor
- **`specs/trust/context.md`** — updated "Files to Read First" references from `src/plugin.rs` → `src/plugin/mod.rs` and `src/lanes.rs` → `src/lanes/mod.rs`

## Test plan
- [x] Pre-commit spec check passed
- [x] Clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)