### PR TITLE
fix: install script respects detected architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,16 +67,17 @@ detect_arch() {
     case "$uname_m" in
         x86_64|amd64)  echo "x86_64" ;;
         aarch64|arm64) echo "aarch64" ;;
-        *) err "unsupported architecture: $uname_m" ;;
+        i386|i686)     err "32-bit systems are not supported — fledge requires a 64-bit OS" ;;
+        *)             err "unsupported architecture: $uname_m" ;;
     esac
 }
 
 artifact_name() {
     local os="$1" arch="$2"
     case "$os" in
-        linux)   echo "fledge-linux-x86_64" ;;
+        linux)   echo "fledge-linux-$arch" ;;
         macos)   echo "fledge-macos-$arch" ;;
-        windows) echo "fledge-windows-x86_64.exe" ;;
+        windows) echo "fledge-windows-$arch.exe" ;;
     esac
 }
 


### PR DESCRIPTION
## Summary
- `artifact_name()` now uses the detected `$arch` for Linux and Windows instead of hardcoding `x86_64`
- Adds explicit detection of 32-bit systems (`i386`/`i686`) with a clear error message instead of the generic "unsupported architecture"
- When aarch64 Linux or Windows binaries are published in the future, the script will just work

## Test plan
- [ ] Run `install.sh` on x86_64 Linux — should download `fledge-linux-x86_64`
- [ ] Run `install.sh` on aarch64 Linux — should attempt `fledge-linux-aarch64` (will fail until we publish that binary)
- [ ] Run `install.sh` on a 32-bit system — should show "32-bit systems are not supported"

🤖 Generated with [Claude Code](https://claude.com/claude-code)