### PR TITLE
docs: add --ai flag to fledge github prs create

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -574,6 +574,7 @@ fledge github prs create [OPTIONS]
 - `--base <BRANCH>`: Base branch [default: repo default]
 - `--draft`: Open as draft
 - `--fill`: Infer title/body from commits
+- `--ai`: Generate title and body via AI (`fledge ask`) with interactive preview/edit
 - `--json`: Returns `{number, url, title}`
 
 ---

--- a/docs/src/github-integration.md
+++ b/docs/src/github-integration.md
@@ -37,6 +37,8 @@ fledge github prs --state closed
 fledge github prs view 256
 fledge github prs --json
 fledge github prs create --fill         # infer title/body from commits
+fledge github prs create --ai          # AI-generated title + body (via fledge ask) with preview
+fledge github prs create --ai --draft  # AI-generated, open as draft
 fledge github prs create --title "feat: new thing" --draft --json
 ```
 

--- a/docs/src/ship.md
+++ b/docs/src/ship.md
@@ -41,6 +41,8 @@ Use `fledge github prs create` (from `fledge-plugin-github`) or the `gh` CLI dir
 
 ```bash
 fledge github prs create --fill                              # infer title/body from commits
+fledge github prs create --ai                                # AI-generated title/body with preview
+fledge github prs create --ai --draft                        # AI-generated, open as draft
 fledge github prs create --title "..." --body "..." --draft  # scripted
 fledge github prs create --base develop
 ```


### PR DESCRIPTION
## Summary

- `github-integration.md` — added `--ai` and `--ai --draft` examples to the Pull Requests section
- `cli-reference.md` — added `--ai` to the Create options for `fledge github prs`
- `ship.md` — added `--ai` and `--ai --draft` to the "Open a PR" examples

The `--ai` flag was shipped in plugin v0.4.0 but was missing from all three docs pages. It generates a PR title and body using `fledge ask` (respects the configured LLM), then shows an interactive preview with confirm/edit/abort before creating.

## Test plan
- [ ] Verify `fledge github prs --help` shows `--ai`
- [ ] Verify `fledge github prs create --ai` works end-to-end on a branch with commits

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6