### PR TITLE
docs: fix work --json schema errors in AGENTS.md and agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge templates create --json` | `{schema_version: 1, action: "create", path, name, description, render_patterns, include_hooks, include_prompts, files_created}` | Creating a new template skeleton |
 | `fledge templates publish --json` | `{schema_version: 1, action: "publish", cancelled, repo: {owner, name, url, created, private}, template: {description}, topic, use_hint}`. Same key set on success and cancelled paths; `cancelled: true` when the user declines a confirmation | Publishing a template repo |
 | `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}`. `issue` is `null` when no `--issue` flag was passed; all other fields always present | Branch scripting |
-| `fledge work commit --json` | `{schema_version: 2, action: "work_commit", hash, message, branch}`. Commit hash to report back | After writing code |
+| `fledge work commit --json` | `{schema_version: 1, action: "work_commit", hash, message, branch}`. Commit hash to report back | After writing code |
 | `fledge work push --json` | `{schema_version: 1, action: "work_push", branch, remote, force}`. Confirms the push | After committing |
 | `fledge work status --json` | `{schema_version: 2, action: "work_status", branch, default, ahead, behind, dirty}`. `dirty` is uncommitted file count; no PR field | Pre-action sanity check |
 

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -59,8 +59,9 @@ Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 | `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps, failures}` |
 | `fledge lanes validate --json` | `{schema_version: 1, path, lane_count, errors, warnings}` |
 | `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}` |
+| `fledge work commit --json` | `{schema_version: 1, action: "work_commit", hash, message, branch}` |
 | `fledge work push --json` | `{schema_version: 1, action: "work_push", branch, remote, force}` |
-| `fledge work status --json` | `{schema_version: 1, action: "work_status", branch, default, ahead, behind, pr?}` |
+| `fledge work status --json` | `{schema_version: 2, action: "work_status", branch, default, ahead, behind, dirty}` |
 
 ### Plugin commands with `--json` (after `plugins install --defaults`)
 


### PR DESCRIPTION
## Summary

- `AGENTS.md`: `work commit --json` had `schema_version: 2` — source constant `WORK_COMMIT_SCHEMA` is `1`
- `docs/src/agents.md`: `work status --json` had wrong version (`1` instead of `2`), spurious `pr?` field (removed in pure-git workflow), and missing `dirty` field
- `docs/src/agents.md`: `work commit --json` row was missing from the JSON output table entirely

All three fixes verified against `src/work.rs` constants and JSON output structs.

## Test plan
- [x] Verified `WORK_COMMIT_SCHEMA = 1` and `WORK_STATUS_SCHEMA = 2` in `src/work.rs`
- [x] Verified actual JSON fields emitted by `work commit` and `work status` handlers
- [x] Pre-commit checks passed (specs, fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)