### PR TITLE
fix: pre-1.0 blocking bugs and security issues

### DIFF
--- a/fledge.toml
+++ b/fledge.toml
@@ -12,7 +12,7 @@ docs-build = "mdbook build docs"
 docs-serve = "mdbook serve docs --open"
 
 [tasks.validate-templates]
-cmd = "cargo run -- validate-template templates/"
+cmd = "cargo run -- templates validate templates/"
 description = "Validate all built-in templates"
 
 [lanes.ci]

--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -1,6 +1,6 @@
 ---
 module: config
-version: 9
+version: 10
 status: active
 files:
   - src/config.rs
@@ -32,6 +32,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `config_path` | Returns the platform-appropriate path to the config file |
 | `save` | Serializes config to TOML and writes to disk, creating parent directories if needed |
 | `get` | Returns a config value by dotted key (e.g. `defaults.author`), or `None` if unset/unknown. List keys return newline-separated values |
+| `is_secret_key` | Returns whether a dotted key holds a secret value (e.g. `github.token`, `ai.ollama.api_key`) that should be redacted in display |
 | `is_valid_key` | Returns whether a dotted key is recognized (scalar or list) |
 | `valid_keys_hint` | Returns a static string listing all valid config keys for use in error messages |
 | `set` | Sets a scalar config value by dotted key; errors on list keys or unknown keys |
@@ -71,6 +72,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 | `Config::config_path` | `() -> PathBuf` | Returns path to config file |
 | `Config::save` | `(&self) -> Result<()>` | Serialize config to TOML and write to disk, creating parent dirs if needed |
 | `Config::get` | `(&self, key: &str) -> Option<String>` | Get a config value by dotted key. List keys return newline-separated values |
+| `Config::is_secret_key` | `(key: &str) -> bool` | Returns true for keys that hold secrets (e.g. `github.token`, `ai.ollama.api_key`), used by `config get` to redact output |
 | `Config::is_valid_key` | `(key: &str) -> bool` | Check whether a dotted key is recognized |
 | `Config::valid_keys_hint` | `() -> &'static str` | Returns a static hint string listing all valid config keys |
 | `Config::set` | `(&mut self, key: &str, value: &str) -> Result<()>` | Set a scalar config value, errors on list or unknown keys |
@@ -205,6 +207,7 @@ Manages global user configuration from `~/.config/fledge/config.toml`. Provides 
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 10 | 2026-04-30 | Add `Config::is_secret_key(key) -> bool` — identifies keys whose values should be redacted in display (e.g. `github.token`, `ai.ollama.api_key`). Used by `config get` to avoid printing plaintext secrets to stdout |
 | 9 | 2026-04-26 | Document `valid_keys_hint()`, returns a static string listing all valid config keys, used by `handle_config` in main.rs for error messages |
 | 8 | 2026-04-24 | Add `ai.ollama.timeout_seconds` scalar (default 600). Mirrors the existing `FLEDGE_AI_TIMEOUT` env var so Ollama timeouts are tunable without env vars; env still wins. `set` parses as `u64` and rejects non-integer input; `unset` restores the 600s default |
 | 7 | 2026-04-23 | Add `[ai]` section, `ai.provider` (scalar, `claude`/`ollama` only), `ai.claude.model`, `ai.ollama.host`, `ai.ollama.api_key`, `ai.ollama.model`. Defaults preserve pre-v0.13 Claude-only behavior. `add_to_list`/`remove_from_list` now route through `is_valid_key` so new scalar keys get the right error message |

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,10 @@ impl Config {
         }
     }
 
+    pub fn is_secret_key(key: &str) -> bool {
+        matches!(key, "github.token" | "ai.ollama.api_key")
+    }
+
     pub fn is_valid_key(key: &str) -> bool {
         matches!(
             key,

--- a/src/config_cmds.rs
+++ b/src/config_cmds.rs
@@ -16,9 +16,16 @@ pub fn handle_config(action: ConfigAction) -> Result<()> {
                     config::Config::valid_keys_hint()
                 );
             }
-            match config.get(&key) {
-                Some(value) if !value.is_empty() => println!("{}", value),
-                _ => println!("{} {} is not set", style("*").cyan().bold(), key),
+            if config::Config::is_secret_key(&key) {
+                match config.get(&key) {
+                    Some(v) if !v.is_empty() => println!("***"),
+                    _ => println!("{} {} is not set", style("*").cyan().bold(), key),
+                }
+            } else {
+                match config.get(&key) {
+                    Some(value) if !value.is_empty() => println!("{}", value),
+                    _ => println!("{} {} is not set", style("*").cyan().bold(), key),
+                }
             }
         }
         ConfigAction::Set { key, value } => {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -280,11 +280,10 @@ pub fn run(opts: PluginOptions) -> Result<()> {
 pub fn run_lifecycle_hook(event: &str) -> Result<()> {
     let registry = load_registry()?;
     for entry in &registry.plugins {
-        // Protocol plugins need exec capability to run hooks
-        if let Some(ref caps) = entry.capabilities {
-            if !caps.exec {
-                continue;
-            }
+        // Require explicit exec = true; plugins without capabilities declared cannot run hooks
+        match &entry.capabilities {
+            Some(caps) if caps.exec => {}
+            _ => continue,
         }
 
         let plugin_dir = plugins_dir().join(&entry.name);

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -91,9 +91,14 @@ fn clone_repo(
         let credentials = format!("x-access-token:{}", t);
         let encoded = base64::engine::general_purpose::STANDARD.encode(&credentials);
         let header_value = format!("Authorization: Basic {}", encoded);
-        cmd.env("GIT_CONFIG_COUNT", "1")
-            .env("GIT_CONFIG_KEY_0", "http.extraheader")
-            .env("GIT_CONFIG_VALUE_0", &header_value);
+        let existing_count: u32 = std::env::var("GIT_CONFIG_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let idx = existing_count;
+        cmd.env("GIT_CONFIG_COUNT", (existing_count + 1).to_string())
+            .env(format!("GIT_CONFIG_KEY_{idx}"), "http.extraheader")
+            .env(format!("GIT_CONFIG_VALUE_{idx}"), &header_value);
     }
 
     let output = cmd.output().context("running git clone")?;

--- a/src/review.rs
+++ b/src/review.rs
@@ -236,8 +236,19 @@ pub fn run(options: ReviewOptions) -> Result<()> {
     }
     let mut indexed: Vec<(usize, PanelResult)> = handles
         .into_iter()
-        .map(|h| h.join().expect("review thread panicked"))
-        .collect();
+        .map(|h| {
+            h.join().map_err(|e| {
+                let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                    s.to_string()
+                } else if let Some(s) = e.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "unknown panic".to_string()
+                };
+                anyhow::anyhow!("review thread panicked: {}", msg)
+            })
+        })
+        .collect::<Result<_>>()?;
     indexed.sort_by_key(|(i, _)| *i);
     let results: Vec<PanelResult> = indexed.into_iter().map(|(_, r)| r).collect();
 

--- a/src/spec/commands.rs
+++ b/src/spec/commands.rs
@@ -155,7 +155,11 @@ pub(crate) fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         if total_errors > 0 || (strict && total_warnings > 0) {
-            std::process::exit(1);
+            bail!(
+                "spec check failed: {} error(s), {} warning(s)",
+                total_errors,
+                total_warnings
+            );
         }
         return Ok(());
     }
@@ -229,7 +233,11 @@ pub(crate) fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
                 style("(warnings treated as errors in strict mode)").dim()
             );
         }
-        std::process::exit(1);
+        bail!(
+            "spec check failed: {} error(s), {} warning(s)",
+            total_errors,
+            total_warnings
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Fixes all 6 blocking/security issues flagged in the 1.0.0 readiness review.

**Blocking bugs**
- `fledge.toml`: `validate-templates` task called `validate-template` (non-existent subcommand) — fixed to `templates validate`
- `spec/commands.rs`: two `std::process::exit(1)` calls bypassed the anyhow error handler — replaced with `bail!()`
- `review.rs`: `h.join().expect(...)` would crash the process on thread panic — now propagates as `anyhow::Error`

**Security**
- `config_cmds.rs` + `config.rs`: `fledge config get github.token` printed plaintext secrets to stdout — now prints `***` for `github.token` and `ai.ollama.api_key`
- `plugin/mod.rs`: lifecycle hooks ran unconditionally for plugins without a `capabilities` block, allowing arbitrary code execution without declaring `exec = true` — fixed to require explicit `exec = true`
- `remote.rs`: hardcoded `GIT_CONFIG_COUNT=1` clobbered pre-existing git auth in CI — now reads existing count and increments

## Test plan

- [ ] `cargo build` — clean
- [ ] `cargo test` — 765 passing, 0 failed
- [ ] `cargo clippy -- -D warnings` — 0 warnings
- [ ] `cargo fmt --check` — clean
- [ ] `fledge config get github.token` prints `***` when set, `* github.token is not set` when not set
- [ ] `fledge lanes run ci` succeeds (validate-templates task no longer calls bad subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: Jackdaw | Model: Sonnet 4.6