### PR TITLE
fix(plugin): use shell-words for hook command parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indicatif = "0.17"
 sha2 = "0.11.0"
 base64 = "0.22"
 notify = "7"
+shell-words = "1.1.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -32,18 +32,8 @@ use search::search_plugins;
 use update::update_plugins;
 use validate::validate_plugin;
 
-// ─── Imports needed only in tests ───────────────────────────────────────────
-
-#[cfg(test)]
-use install::{install_defaults, install_plugin};
-#[cfg(test)]
-use list::{get_lifecycle_hooks, has_lifecycle_hooks};
 #[cfg(test)]
 use run_plugin::{resolve_plugin_source_dir, which_fledge_plugin};
-#[cfg(test)]
-use update::find_latest_tag;
-#[cfg(test)]
-use validate::{print_plugin_report, PluginValidationReport};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -95,11 +95,12 @@ pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()>
             .status()
             .with_context(|| format!("running {event} hook"))?
     } else {
-        let parts: Vec<&str> = hook.split_whitespace().collect();
+        let parts = shell_words::split(hook)
+            .with_context(|| format!("parsing {event} hook command: {hook}"))?;
         if parts.is_empty() {
             bail!("Empty hook command for {event}");
         }
-        Command::new(parts[0])
+        Command::new(&parts[0])
             .args(&parts[1..])
             .current_dir(plugin_dir)
             .env("FLEDGE_PLUGIN_DIR", plugin_dir)

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -897,3 +897,37 @@ store = false
     assert!(!manifest.capabilities.store);
     assert_eq!(manifest.hooks.iter_defined().len(), 2);
 }
+
+#[test]
+fn run_hook_handles_quoted_args_with_spaces() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let script = tmp.path().join("check.sh");
+    std::fs::write(
+        &script,
+        "#!/bin/sh\n[ \"$1\" = \"hello world\" ] || exit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let hook = format!("{} 'hello world'", script.display());
+    let result = run_hook(tmp.path(), &hook, "test");
+    assert!(
+        result.is_ok(),
+        "hook with quoted args should succeed: {result:?}"
+    );
+}
+
+#[test]
+fn run_hook_rejects_mismatched_quotes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let result = run_hook(tmp.path(), "echo 'unclosed", "test");
+    assert!(result.is_err(), "mismatched quotes should produce an error");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("parsing"),
+        "error should mention parsing: {msg}"
+    );
+}

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -899,7 +899,9 @@ store = false
 }
 
 #[test]
+#[cfg(unix)]
 fn run_hook_handles_quoted_args_with_spaces() {
+    use std::os::unix::fs::PermissionsExt;
     let tmp = tempfile::TempDir::new().unwrap();
     let script = tmp.path().join("check.sh");
     std::fs::write(
@@ -907,11 +909,7 @@ fn run_hook_handles_quoted_args_with_spaces() {
         "#!/bin/sh\n[ \"$1\" = \"hello world\" ] || exit 1\n",
     )
     .unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
     let hook = format!("{} 'hello world'", script.display());
     let result = run_hook(tmp.path(), &hook, "test");
     assert!(


### PR DESCRIPTION
## Summary

- Replaces `split_whitespace()` with `shell_words::split()` in `run_hook()` for parsing hook commands
- Adds `shell-words` v1.1.1 as a dependency
- Adds two tests: one verifying quoted args with spaces work, one verifying mismatched quotes produce a clear error

## Why

Hook commands like `build = "scripts/build.sh --flag 'value with spaces'"` were silently mangled by `split_whitespace()`, which splits on every space regardless of quoting. This would bite any plugin author using arguments with spaces. `shell_words::split()` handles single/double quotes and escaping correctly.

Identified as **E1 (High severity)** in the 1.0 release review.

## Test plan

- [x] `fledge lanes run check` passes (fmt, lint, 692 tests)
- [x] `run_hook_handles_quoted_args_with_spaces` — runs a real shell script that asserts `$1 == "hello world"` via `shell_words`
- [x] `run_hook_rejects_mismatched_quotes` — verifies unclosed quotes produce a descriptive error

---
🤖 Agent: CorvidAgent | Model: Opus 4.6