### PR TITLE
fix: post-review cleanup (clippy, flaky tests, lanes import, timeouts)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,13 @@ All checks in the `pre-commit` lane must pass before submitting a PR.
 ### 5. Submit a Pull Request
 
 ```bash
-fledge work pr --title "Add my feature"
+# Push your branch first
+fledge work push
+
+# Open a PR (requires fledge-plugin-github)
+fledge github prs create --title "Add my feature"
+# or infer title and body from your commits:
+fledge github prs create --fill
 ```
 
 In your PR description:
@@ -85,7 +91,7 @@ Look for issues labeled [`good first issue`](https://github.com/CorvidLabs/fledg
 
 ### Templates
 
-Create new templates and publish them with `fledge publish`! See the [Template Authoring Guide](https://corvidlabs.github.io/fledge/template-authoring.html) for the full format.
+Create new templates and publish them with `fledge templates publish`! See the [Template Authoring Guide](https://corvidlabs.github.io/fledge/template-authoring.html) for the full format.
 
 ### Plugins
 
@@ -146,11 +152,13 @@ Every module has a spec in `specs/<module>/`. The spec is the source of truth fo
 
 ### Dependencies
 
-Check dependency health with:
+Dependency commands ship in `fledge-plugin-deps` (part of the default plugin
+set). Install once, then check dependency health:
 
 ```bash
-fledge deps              # list all dependencies
-fledge deps --outdated   # check for outdated deps
+fledge plugins install --defaults   # one-time, gets github/deps/metrics
+fledge deps                         # report dependency status
+fledge deps --outdated              # show outdated entries
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Not every fledge user is on GitHub or runs a polyglot project. The core stays ti
 
 ## Built-in templates
 
-`rust-cli`, `ts-bun`, `python-cli`, `go-cli`, `ts-node`, `static-site`
+`rust-cli`, `ts-bun`, `python-cli`, `go-cli`, `ts-node`, `static-site`, `kotlin-kmp`, `kotlin-ktor-api`
 
 Browse community templates: `fledge templates search <keyword>`
 

--- a/docs/src/templates.md
+++ b/docs/src/templates.md
@@ -14,6 +14,8 @@ These ship with the binary. Always there, no setup needed:
 | `go-cli` | Go CLI with Cobra |
 | `ts-node` | TypeScript on Node with tsx and Biome |
 | `static-site` | Vanilla HTML/CSS/JS, no dependencies |
+| `kotlin-kmp` | Kotlin Multiplatform library |
+| `kotlin-ktor-api` | Kotlin Ktor HTTP API |
 
 For Angular, MCP server, Deno, Swift, monorepo, and more, check the [official template repo](https://github.com/CorvidLabs/fledge-templates):
 

--- a/fledge.toml
+++ b/fledge.toml
@@ -4,7 +4,7 @@
 [tasks]
 build = "cargo build"
 test = "cargo test"
-lint = "cargo clippy -- -D warnings"
+lint = "cargo clippy --all-targets -- -D warnings"
 fmt = "cargo fmt --check"
 fmt-fix = "cargo fmt"
 spec-check = "cargo run -- spec check"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -36,6 +36,15 @@ pub fn run(opts: ChangelogOptions) -> Result<()> {
     let tags = list_tags()?;
 
     if tags.is_empty() {
+        if opts.json {
+            let envelope = serde_json::json!({
+                "schema_version": CHANGELOG_SCHEMA,
+                "action": "changelog",
+                "releases": [],
+            });
+            println!("{}", serde_json::to_string_pretty(&envelope)?);
+            return Ok(());
+        }
         println!(
             "{} No tags found. Tag a release first: {}",
             style("*").cyan().bold(),

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,18 @@
 use anyhow::{bail, Result};
 use std::process::Command;
+use std::time::Duration;
+
+/// Default timeout for GitHub API requests. Without this, a wedged endpoint
+/// or network drop hangs `lanes search`, `templates search`, `plugins search`,
+/// `lanes import`, and the publish flows indefinitely.
+const GITHUB_API_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn github_api_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(GITHUB_API_TIMEOUT))
+        .build()
+        .into()
+}
 
 #[cfg(test)]
 fn parse_repo_url(url: &str) -> Result<(String, String)> {
@@ -61,7 +74,9 @@ pub fn github_api_get(
         }
     }
 
-    let mut request = ureq::get(&url)
+    let agent = github_api_agent();
+    let mut request = agent
+        .get(&url)
         .header("Accept", "application/vnd.github.v3+json")
         .header("User-Agent", "fledge-cli");
 

--- a/src/lanes/community.rs
+++ b/src/lanes/community.rs
@@ -107,7 +107,7 @@ pub(crate) fn search_lanes(keyword: Option<&str>, author: Option<&str>, json: bo
     Ok(())
 }
 
-pub(crate) fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
+pub(crate) fn import_lanes(source: &str, yes: bool, json: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let local_path = cwd.join("fledge.toml");
 
@@ -154,6 +154,22 @@ pub(crate) fn import_lanes(source: &str, _yes: bool, json: bool) -> Result<()> {
                 "  {} Only import lanes from sources you trust.\n",
                 style("*").yellow()
             );
+        }
+    }
+
+    if !yes && tier != crate::trust::TrustTier::Official {
+        if !crate::utils::is_interactive() {
+            bail!(
+                "Importing community lanes requires confirmation in non-interactive mode.\n  \
+                 Use --yes to acknowledge that lanes can execute arbitrary commands."
+            );
+        }
+        let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
+            .with_prompt(format!("Import lanes from '{display_source}'?"))
+            .default(false)
+            .interact()?;
+        if !confirm {
+            bail!("Lane import cancelled.");
         }
     }
 

--- a/src/lanes/tests.rs
+++ b/src/lanes/tests.rs
@@ -972,6 +972,7 @@ fn imported_lanes_get_source_tracked() {
     )
     .unwrap();
 
+    let _guard = crate::test_support::cwd_lock();
     let prev = std::env::current_dir().unwrap();
     std::env::set_current_dir(tmp.path()).unwrap();
     let config = load_lane_config().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,9 @@ mod versioning;
 mod watch;
 mod work;
 
+#[cfg(test)]
+mod test_support;
+
 use cli::*;
 
 fn main() {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -2,9 +2,23 @@ use anyhow::{bail, Context, Result};
 use console::style;
 use serde_json::json;
 use std::path::Path;
+use std::time::Duration;
+
+/// Default timeout for GitHub publish API requests. Without this, a wedged
+/// endpoint hangs the publish flows indefinitely.
+const PUBLISH_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn publish_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(PUBLISH_TIMEOUT))
+        .build()
+        .into()
+}
 
 pub fn get_authenticated_user(token: &str) -> Result<String> {
-    let text = ureq::get("https://api.github.com/user")
+    let agent = publish_agent();
+    let text = agent
+        .get("https://api.github.com/user")
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "fledge-cli")
@@ -25,7 +39,9 @@ pub fn get_authenticated_user(token: &str) -> Result<String> {
 
 pub fn check_repo_exists(owner: &str, repo: &str, token: &str) -> Result<bool> {
     let url = format!("https://api.github.com/repos/{}/{}", owner, repo);
-    let result = ureq::get(&url)
+    let agent = publish_agent();
+    let result = agent
+        .get(&url)
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "fledge-cli")
@@ -59,7 +75,9 @@ pub fn create_github_repo(
 
     let json_body = serde_json::to_string(&body).context("serializing request body")?;
 
-    let result = ureq::post(&url)
+    let agent = publish_agent();
+    let result = agent
+        .post(&url)
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "fledge-cli")
@@ -81,7 +99,9 @@ pub fn create_github_repo(
 pub fn set_repo_topic(owner: &str, repo: &str, topic: &str, token: &str) -> Result<()> {
     let url = format!("https://api.github.com/repos/{}/{}/topics", owner, repo);
 
-    let text = ureq::get(&url)
+    let agent = publish_agent();
+    let text = agent
+        .get(&url)
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "fledge-cli")
@@ -111,7 +131,8 @@ pub fn set_repo_topic(owner: &str, repo: &str, topic: &str, token: &str) -> Resu
 
     let json_body = serde_json::to_string(&body).context("serializing topics")?;
 
-    ureq::put(&url)
+    agent
+        .put(&url)
         .header("Authorization", &format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "fledge-cli")

--- a/src/release/tests.rs
+++ b/src/release/tests.rs
@@ -1,906 +1,904 @@
-#[cfg(test)]
-mod tests {
-    use super::super::*;
-    use std::fs;
-    use std::path::Path;
-    use std::process::Command;
-    use std::sync::Mutex;
-    use tempfile::TempDir;
+use super::*;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
 
-    use crate::versioning::parse_version;
+use crate::test_support::cwd_lock;
+use crate::versioning::parse_version;
 
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
-
-    fn with_cwd<F: FnOnce() -> R, R>(dir: &Path, f: F) -> R {
-        let _guard = CWD_LOCK.lock().unwrap();
-        let saved = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir).unwrap();
-        let result = f();
-        let _ = std::env::set_current_dir(saved);
-        result
+fn with_cwd<F: FnOnce() -> R, R>(dir: &Path, f: F) -> R {
+    let _guard = cwd_lock();
+    let saved = std::env::current_dir().unwrap();
+    std::env::set_current_dir(dir).unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    let _ = std::env::set_current_dir(saved);
+    match result {
+        Ok(r) => r,
+        Err(payload) => std::panic::resume_unwind(payload),
     }
+}
 
-    fn init_git_repo(dir: &Path) {
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-    }
+fn init_git_repo(dir: &Path) {
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+}
 
-    fn commit_file(dir: &Path, name: &str, content: &str) {
-        fs::write(dir.join(name), content).unwrap();
-        Command::new("git")
-            .args(["add", name])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", &format!("add {name}")])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-    }
+fn commit_file(dir: &Path, name: &str, content: &str) {
+    fs::write(dir.join(name), content).unwrap();
+    Command::new("git")
+        .args(["add", name])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", &format!("add {name}")])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+}
 
-    #[test]
-    fn apply_bump_major() {
-        let v = parse_version("1.2.3").unwrap();
-        let bumped = version::apply_bump(&v, "major").unwrap();
-        assert_eq!(bumped.to_string(), "2.0.0");
-    }
+#[test]
+fn apply_bump_major() {
+    let v = parse_version("1.2.3").unwrap();
+    let bumped = version::apply_bump(&v, "major").unwrap();
+    assert_eq!(bumped.to_string(), "2.0.0");
+}
 
-    #[test]
-    fn apply_bump_minor() {
-        let v = parse_version("1.2.3").unwrap();
-        let bumped = version::apply_bump(&v, "minor").unwrap();
-        assert_eq!(bumped.to_string(), "1.3.0");
-    }
+#[test]
+fn apply_bump_minor() {
+    let v = parse_version("1.2.3").unwrap();
+    let bumped = version::apply_bump(&v, "minor").unwrap();
+    assert_eq!(bumped.to_string(), "1.3.0");
+}
 
-    #[test]
-    fn apply_bump_patch() {
-        let v = parse_version("1.2.3").unwrap();
-        let bumped = version::apply_bump(&v, "patch").unwrap();
-        assert_eq!(bumped.to_string(), "1.2.4");
-    }
+#[test]
+fn apply_bump_patch() {
+    let v = parse_version("1.2.3").unwrap();
+    let bumped = version::apply_bump(&v, "patch").unwrap();
+    assert_eq!(bumped.to_string(), "1.2.4");
+}
 
-    #[test]
-    fn apply_bump_from_zero() {
-        let v = parse_version("0.0.0").unwrap();
-        assert_eq!(
-            version::apply_bump(&v, "major").unwrap().to_string(),
-            "1.0.0"
-        );
-        assert_eq!(
-            version::apply_bump(&v, "minor").unwrap().to_string(),
-            "0.1.0"
-        );
-        assert_eq!(
-            version::apply_bump(&v, "patch").unwrap().to_string(),
-            "0.0.1"
-        );
-    }
+#[test]
+fn apply_bump_from_zero() {
+    let v = parse_version("0.0.0").unwrap();
+    assert_eq!(
+        version::apply_bump(&v, "major").unwrap().to_string(),
+        "1.0.0"
+    );
+    assert_eq!(
+        version::apply_bump(&v, "minor").unwrap().to_string(),
+        "0.1.0"
+    );
+    assert_eq!(
+        version::apply_bump(&v, "patch").unwrap().to_string(),
+        "0.0.1"
+    );
+}
 
-    #[test]
-    fn apply_bump_invalid_level() {
-        let v = parse_version("1.2.3").unwrap();
-        assert!(version::apply_bump(&v, "mega").is_err());
-    }
+#[test]
+fn apply_bump_invalid_level() {
+    let v = parse_version("1.2.3").unwrap();
+    assert!(version::apply_bump(&v, "mega").is_err());
+}
 
-    #[test]
-    fn extract_toml_version_basic() {
-        let content = r#"
+#[test]
+fn extract_toml_version_basic() {
+    let content = r#"
 [package]
 name = "my-app"
 version = "0.5.0"
 edition = "2021"
 "#;
-        assert_eq!(
-            toml_utils::extract_toml_version(content),
-            Some("0.5.0".to_string())
-        );
-    }
+    assert_eq!(
+        toml_utils::extract_toml_version(content),
+        Some("0.5.0".to_string())
+    );
+}
 
-    #[test]
-    fn extract_toml_version_not_found() {
-        assert_eq!(toml_utils::extract_toml_version("name = \"foo\""), None);
-    }
+#[test]
+fn extract_toml_version_not_found() {
+    assert_eq!(toml_utils::extract_toml_version("name = \"foo\""), None);
+}
 
-    #[test]
-    fn detect_version_files_rust() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("Cargo.toml"),
-            "[package]\nversion = \"0.1.0\"",
-        )
-        .unwrap();
-        let files = bump::detect_version_files(tmp.path());
-        assert_eq!(files, vec!["Cargo.toml"]);
-    }
+#[test]
+fn detect_version_files_rust() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nversion = \"0.1.0\"",
+    )
+    .unwrap();
+    let files = bump::detect_version_files(tmp.path());
+    assert_eq!(files, vec!["Cargo.toml"]);
+}
 
-    #[test]
-    fn detect_version_files_node() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join("package.json"), r#"{"version": "1.0.0"}"#).unwrap();
-        let files = bump::detect_version_files(tmp.path());
-        assert_eq!(files, vec!["package.json"]);
-    }
+#[test]
+fn detect_version_files_node() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("package.json"), r#"{"version": "1.0.0"}"#).unwrap();
+    let files = bump::detect_version_files(tmp.path());
+    assert_eq!(files, vec!["package.json"]);
+}
 
-    #[test]
-    fn detect_version_files_empty() {
-        let tmp = TempDir::new().unwrap();
-        let files = bump::detect_version_files(tmp.path());
-        assert!(files.is_empty());
-    }
+#[test]
+fn detect_version_files_empty() {
+    let tmp = TempDir::new().unwrap();
+    let files = bump::detect_version_files(tmp.path());
+    assert!(files.is_empty());
+}
 
-    #[test]
-    fn detect_version_files_multiple() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join("Cargo.toml"), "version = \"0.1.0\"").unwrap();
-        fs::write(tmp.path().join("package.json"), "{}").unwrap();
-        let files = bump::detect_version_files(tmp.path());
-        assert_eq!(files.len(), 2);
-    }
+#[test]
+fn detect_version_files_multiple() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("Cargo.toml"), "version = \"0.1.0\"").unwrap();
+    fs::write(tmp.path().join("package.json"), "{}").unwrap();
+    let files = bump::detect_version_files(tmp.path());
+    assert_eq!(files.len(), 2);
+}
 
-    #[test]
-    fn classify_conventional_commits() {
-        assert_eq!(
-            changelog::classify_for_changelog("feat: add release"),
-            "Features"
-        );
-        assert_eq!(
-            changelog::classify_for_changelog("fix: handle null"),
-            "Fixes"
-        );
-        assert_eq!(
-            changelog::classify_for_changelog("docs: update readme"),
-            "Documentation"
-        );
-        assert_eq!(
-            changelog::classify_for_changelog("chore: bump deps"),
-            "Chores"
-        );
-        assert_eq!(
-            changelog::classify_for_changelog("feat(cli): add flag"),
-            "Features"
-        );
-        assert_eq!(changelog::classify_for_changelog("random message"), "Other");
-    }
+#[test]
+fn classify_conventional_commits() {
+    assert_eq!(
+        changelog::classify_for_changelog("feat: add release"),
+        "Features"
+    );
+    assert_eq!(
+        changelog::classify_for_changelog("fix: handle null"),
+        "Fixes"
+    );
+    assert_eq!(
+        changelog::classify_for_changelog("docs: update readme"),
+        "Documentation"
+    );
+    assert_eq!(
+        changelog::classify_for_changelog("chore: bump deps"),
+        "Chores"
+    );
+    assert_eq!(
+        changelog::classify_for_changelog("feat(cli): add flag"),
+        "Features"
+    );
+    assert_eq!(changelog::classify_for_changelog("random message"), "Other");
+}
 
-    #[test]
-    fn strip_prefix_simple() {
-        assert_eq!(
-            changelog::strip_conventional_prefix("feat: add release"),
-            "add release"
-        );
-        assert_eq!(
-            changelog::strip_conventional_prefix("fix(core): null check"),
-            "null check"
-        );
-        assert_eq!(
-            changelog::strip_conventional_prefix("update readme"),
-            "update readme"
-        );
-    }
+#[test]
+fn strip_prefix_simple() {
+    assert_eq!(
+        changelog::strip_conventional_prefix("feat: add release"),
+        "add release"
+    );
+    assert_eq!(
+        changelog::strip_conventional_prefix("fix(core): null check"),
+        "null check"
+    );
+    assert_eq!(
+        changelog::strip_conventional_prefix("update readme"),
+        "update readme"
+    );
+}
 
-    #[test]
-    fn strip_prefix_no_space_after_colon() {
-        assert_eq!(
-            changelog::strip_conventional_prefix("feat:add release"),
-            "add release"
-        );
-        assert_eq!(
-            changelog::strip_conventional_prefix("fix(core):null check"),
-            "null check"
-        );
-    }
+#[test]
+fn strip_prefix_no_space_after_colon() {
+    assert_eq!(
+        changelog::strip_conventional_prefix("feat:add release"),
+        "add release"
+    );
+    assert_eq!(
+        changelog::strip_conventional_prefix("fix(core):null check"),
+        "null check"
+    );
+}
 
-    #[test]
-    fn read_cargo_version_test() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("Cargo.toml"),
-            "[package]\nname = \"test\"\nversion = \"3.2.1\"\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_cargo_version(tmp.path()).unwrap(), "3.2.1");
-    }
+#[test]
+fn read_cargo_version_test() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"3.2.1\"\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_cargo_version(tmp.path()).unwrap(), "3.2.1");
+}
 
-    #[test]
-    fn read_package_json_version_test() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("package.json"),
-            r#"{"name": "test", "version": "2.0.0"}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            version::read_package_json_version(tmp.path()).unwrap(),
-            "2.0.0"
-        );
-    }
+#[test]
+fn read_package_json_version_test() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("package.json"),
+        r#"{"name": "test", "version": "2.0.0"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        version::read_package_json_version(tmp.path()).unwrap(),
+        "2.0.0"
+    );
+}
 
-    #[test]
-    fn read_python_version_test() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("pyproject.toml"),
-            "[project]\nname = \"test\"\nversion = \"1.5.0\"\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_python_version(tmp.path()).unwrap(), "1.5.0");
-    }
+#[test]
+fn read_python_version_test() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("pyproject.toml"),
+        "[project]\nname = \"test\"\nversion = \"1.5.0\"\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_python_version(tmp.path()).unwrap(), "1.5.0");
+}
 
-    #[test]
-    fn bump_cargo_toml() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"Cargo.toml".to_string()));
-        let content = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
-        assert!(content.contains("version = \"0.2.0\""));
-    }
+#[test]
+fn bump_cargo_toml() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
+    let new_ver = parse_version("0.2.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"Cargo.toml".to_string()));
+    let content = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+    assert!(content.contains("version = \"0.2.0\""));
+}
 
-    #[test]
-    fn bump_package_json() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "package.json",
-            r#"{"name": "test", "version": "1.0.0"}"#,
-        );
-        let new_ver = parse_version("1.1.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"package.json".to_string()));
-        let content = fs::read_to_string(tmp.path().join("package.json")).unwrap();
-        assert!(content.contains("\"1.1.0\""));
-    }
+#[test]
+fn bump_package_json() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "package.json",
+        r#"{"name": "test", "version": "1.0.0"}"#,
+    );
+    let new_ver = parse_version("1.1.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"package.json".to_string()));
+    let content = fs::read_to_string(tmp.path().join("package.json")).unwrap();
+    assert!(content.contains("\"1.1.0\""));
+}
 
-    #[test]
-    fn bump_pyproject_toml() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "pyproject.toml",
-            "[project]\nname = \"test\"\nversion = \"0.3.0\"\n",
-        );
-        let new_ver = parse_version("0.4.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"pyproject.toml".to_string()));
-    }
+#[test]
+fn bump_pyproject_toml() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "pyproject.toml",
+        "[project]\nname = \"test\"\nversion = \"0.3.0\"\n",
+    );
+    let new_ver = parse_version("0.4.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"pyproject.toml".to_string()));
+}
 
-    #[test]
-    fn detect_version_from_plugin_toml() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
+#[test]
+fn detect_version_from_plugin_toml() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
             tmp.path(),
             "plugin.toml",
             "[plugin]\nname = \"fledge-deploy\"\nversion = \"0.3.0\"\n\n[[commands]]\nname = \"deploy\"\nbinary = \"bin/deploy\"\n",
         );
-        let v = version::detect_current_version(tmp.path()).unwrap();
-        assert_eq!(v.to_string(), "0.3.0");
-    }
+    let v = version::detect_current_version(tmp.path()).unwrap();
+    assert_eq!(v.to_string(), "0.3.0");
+}
 
-    #[test]
-    fn bump_plugin_toml_only_touches_plugin_section() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        // Manifest has version inside [plugin] AND a `version` key elsewhere
-        // (a `[[commands]]` table) — the bumper must only rewrite the [plugin]
-        // one.
-        let manifest = "[plugin]\nname = \"fledge-deploy\"\nversion = \"0.1.0\"\n\n[[commands]]\nname = \"deploy\"\nbinary = \"bin/deploy\"\nversion = \"99.99.99\"\n";
-        commit_file(tmp.path(), "plugin.toml", manifest);
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"plugin.toml".to_string()));
-        let updated = fs::read_to_string(tmp.path().join("plugin.toml")).unwrap();
-        assert!(updated.contains("[plugin]\nname = \"fledge-deploy\"\nversion = \"0.2.0\""));
-        // The bogus `version` on the command row stays put.
-        assert!(updated.contains("version = \"99.99.99\""));
-    }
+#[test]
+fn bump_plugin_toml_only_touches_plugin_section() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    // Manifest has version inside [plugin] AND a `version` key elsewhere
+    // (a `[[commands]]` table) — the bumper must only rewrite the [plugin]
+    // one.
+    let manifest = "[plugin]\nname = \"fledge-deploy\"\nversion = \"0.1.0\"\n\n[[commands]]\nname = \"deploy\"\nbinary = \"bin/deploy\"\nversion = \"99.99.99\"\n";
+    commit_file(tmp.path(), "plugin.toml", manifest);
+    let new_ver = parse_version("0.2.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"plugin.toml".to_string()));
+    let updated = fs::read_to_string(tmp.path().join("plugin.toml")).unwrap();
+    assert!(updated.contains("[plugin]\nname = \"fledge-deploy\"\nversion = \"0.2.0\""));
+    // The bogus `version` on the command row stays put.
+    assert!(updated.contains("version = \"99.99.99\""));
+}
 
-    #[test]
-    fn bump_plugin_toml_with_cargo_toml_keeps_them_in_sync() {
-        // Rust plugins (e.g. fledge-plugin-metrics) carry both manifests and
-        // expect both to bump together.
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "plugin.toml",
-            "[plugin]\nname = \"x\"\nversion = \"0.1.0\"\n",
-        );
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
-        );
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"plugin.toml".to_string()));
-        assert!(result.files_bumped.contains(&"Cargo.toml".to_string()));
-        let plugin = fs::read_to_string(tmp.path().join("plugin.toml")).unwrap();
-        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
-        assert!(plugin.contains("version = \"0.2.0\""));
-        assert!(cargo.contains("version = \"0.2.0\""));
-    }
+#[test]
+fn bump_plugin_toml_with_cargo_toml_keeps_them_in_sync() {
+    // Rust plugins (e.g. fledge-plugin-metrics) carry both manifests and
+    // expect both to bump together.
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "plugin.toml",
+        "[plugin]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    );
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    );
+    let new_ver = parse_version("0.2.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"plugin.toml".to_string()));
+    assert!(result.files_bumped.contains(&"Cargo.toml".to_string()));
+    let plugin = fs::read_to_string(tmp.path().join("plugin.toml")).unwrap();
+    let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+    assert!(plugin.contains("version = \"0.2.0\""));
+    assert!(cargo.contains("version = \"0.2.0\""));
+}
 
-    #[test]
-    fn extract_versioned_section_skips_other_tables() {
-        let toml = "[plugin]\nname = \"x\"\nversion = \"0.1.0\"\n\n[[commands]]\nname = \"y\"\nversion = \"99.0.0\"\n";
-        assert_eq!(
-            toml_utils::extract_versioned_toml_section(toml, "plugin"),
-            Some("0.1.0".to_string())
-        );
-    }
+#[test]
+fn extract_versioned_section_skips_other_tables() {
+    let toml = "[plugin]\nname = \"x\"\nversion = \"0.1.0\"\n\n[[commands]]\nname = \"y\"\nversion = \"99.0.0\"\n";
+    assert_eq!(
+        toml_utils::extract_versioned_toml_section(toml, "plugin"),
+        Some("0.1.0".to_string())
+    );
+}
 
-    #[test]
-    fn extract_versioned_section_returns_none_when_section_absent() {
-        let toml = "[plugin]\nname = \"x\"\n";
-        assert_eq!(
-            toml_utils::extract_versioned_toml_section(toml, "plugin"),
-            None
-        );
-    }
+#[test]
+fn extract_versioned_section_returns_none_when_section_absent() {
+    let toml = "[plugin]\nname = \"x\"\n";
+    assert_eq!(
+        toml_utils::extract_versioned_toml_section(toml, "plugin"),
+        None
+    );
+}
 
-    #[test]
-    fn replace_versioned_section_returns_none_when_no_match() {
-        let toml = "[other]\nversion = \"1.0.0\"\n";
-        assert_eq!(
-            toml_utils::replace_versioned_toml_section(toml, "plugin", "2.0.0"),
-            None
-        );
-    }
+#[test]
+fn replace_versioned_section_returns_none_when_no_match() {
+    let toml = "[other]\nversion = \"1.0.0\"\n";
+    assert_eq!(
+        toml_utils::replace_versioned_toml_section(toml, "plugin", "2.0.0"),
+        None
+    );
+}
 
-    #[test]
-    fn replace_versioned_section_preserves_trailing_newline() {
-        let toml = "[plugin]\nversion = \"0.1.0\"\n";
-        let out = toml_utils::replace_versioned_toml_section(toml, "plugin", "0.2.0").unwrap();
-        assert_eq!(out, "[plugin]\nversion = \"0.2.0\"\n");
-    }
+#[test]
+fn replace_versioned_section_preserves_trailing_newline() {
+    let toml = "[plugin]\nversion = \"0.1.0\"\n";
+    let out = toml_utils::replace_versioned_toml_section(toml, "plugin", "0.2.0").unwrap();
+    assert_eq!(out, "[plugin]\nversion = \"0.2.0\"\n");
+}
 
-    #[test]
-    fn bump_release_files_flake_nix() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
-        commit_file(
-            tmp.path(),
-            "flake.nix",
-            "{ pname = \"x\"; version = \"0.1.0\"; }\n",
-        );
-        commit_file(
-            tmp.path(),
-            "fledge.toml",
-            "[release]\nfiles = [\"flake.nix\"]\n",
-        );
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"flake.nix".to_string()));
-        let content = fs::read_to_string(tmp.path().join("flake.nix")).unwrap();
-        assert!(content.contains("version = \"0.2.0\""));
-    }
+#[test]
+fn bump_release_files_flake_nix() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
+    commit_file(
+        tmp.path(),
+        "flake.nix",
+        "{ pname = \"x\"; version = \"0.1.0\"; }\n",
+    );
+    commit_file(
+        tmp.path(),
+        "fledge.toml",
+        "[release]\nfiles = [\"flake.nix\"]\n",
+    );
+    let new_ver = parse_version("0.2.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"flake.nix".to_string()));
+    let content = fs::read_to_string(tmp.path().join("flake.nix")).unwrap();
+    assert!(content.contains("version = \"0.2.0\""));
+}
 
-    #[test]
-    fn preflight_checks_not_git() {
-        let tmp = TempDir::new().unwrap();
-        assert!(preflight_checks(tmp.path(), false).is_err());
-    }
+#[test]
+fn preflight_checks_not_git() {
+    let tmp = TempDir::new().unwrap();
+    assert!(preflight_checks(tmp.path(), false).is_err());
+}
 
-    #[test]
-    fn preflight_checks_clean() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "test.txt", "hello");
-        assert!(preflight_checks(tmp.path(), false).is_ok());
-    }
+#[test]
+fn preflight_checks_clean() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "test.txt", "hello");
+    assert!(preflight_checks(tmp.path(), false).is_ok());
+}
 
-    #[test]
-    fn preflight_checks_dirty_allowed() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "test.txt", "hello");
-        fs::write(tmp.path().join("dirty.txt"), "untracked").unwrap();
-        assert!(preflight_checks(tmp.path(), true).is_ok());
-    }
+#[test]
+fn preflight_checks_dirty_allowed() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "test.txt", "hello");
+    fs::write(tmp.path().join("dirty.txt"), "untracked").unwrap();
+    assert!(preflight_checks(tmp.path(), true).is_ok());
+}
 
-    #[test]
-    fn preflight_checks_dirty_blocked() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "test.txt", "hello");
-        fs::write(tmp.path().join("dirty.txt"), "untracked").unwrap();
-        assert!(preflight_checks(tmp.path(), false).is_err());
-    }
+#[test]
+fn preflight_checks_dirty_blocked() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "test.txt", "hello");
+    fs::write(tmp.path().join("dirty.txt"), "untracked").unwrap();
+    assert!(preflight_checks(tmp.path(), false).is_err());
+}
 
-    #[test]
-    fn resolve_explicit_version() {
-        let tmp = TempDir::new().unwrap();
-        let v = version::resolve_target_version(tmp.path(), "2.0.0").unwrap();
-        assert_eq!(v.to_string(), "2.0.0");
-    }
+#[test]
+fn resolve_explicit_version() {
+    let tmp = TempDir::new().unwrap();
+    let v = version::resolve_target_version(tmp.path(), "2.0.0").unwrap();
+    assert_eq!(v.to_string(), "2.0.0");
+}
 
-    #[test]
-    fn resolve_bump_from_cargo() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"1.0.0\"\n",
-        );
-        let v = version::resolve_target_version(tmp.path(), "minor").unwrap();
-        assert_eq!(v.to_string(), "1.1.0");
-    }
+#[test]
+fn resolve_bump_from_cargo() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"1.0.0\"\n",
+    );
+    let v = version::resolve_target_version(tmp.path(), "minor").unwrap();
+    assert_eq!(v.to_string(), "1.1.0");
+}
 
-    #[test]
-    fn dry_run_no_changes() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
+#[test]
+fn dry_run_no_changes() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
 
-        let tmp_path = tmp.path().to_path_buf();
-        let result = with_cwd(&tmp_path, || {
-            run(ReleaseOptions {
-                bump: "patch".to_string(),
-                dry_run: true,
-                no_tag: false,
-                no_changelog: false,
-                no_bump: false,
-                push: false,
-                pre_lane: None,
-                allow_dirty: false,
-                json: false,
-            })
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let result = with_cwd(&tmp_path, || {
+        run(ReleaseOptions {
+            bump: "patch".to_string(),
+            dry_run: true,
+            no_tag: false,
+            no_changelog: false,
+            no_bump: false,
+            push: false,
+            pre_lane: None,
+            allow_dirty: false,
+            json: false,
+        })
+    });
 
-        assert!(result.is_ok());
-        let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
-        assert!(content.contains("0.1.0"), "dry run should not modify files");
-    }
+    assert!(result.is_ok());
+    let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
+    assert!(content.contains("0.1.0"), "dry run should not modify files");
+}
 
-    #[test]
-    fn full_release_flow() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
+#[test]
+fn full_release_flow() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
 
-        Command::new("git")
-            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    Command::new("git")
+        .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        commit_file(tmp.path(), "src.rs", "fn main() {}");
+    commit_file(tmp.path(), "src.rs", "fn main() {}");
 
-        let tmp_path = tmp.path().to_path_buf();
-        let result = with_cwd(&tmp_path, || {
-            run(ReleaseOptions {
-                bump: "minor".to_string(),
-                dry_run: false,
-                no_tag: false,
-                no_changelog: false,
-                no_bump: false,
-                push: false,
-                pre_lane: None,
-                allow_dirty: false,
-                json: false,
-            })
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let result = with_cwd(&tmp_path, || {
+        run(ReleaseOptions {
+            bump: "minor".to_string(),
+            dry_run: false,
+            no_tag: false,
+            no_changelog: false,
+            no_bump: false,
+            push: false,
+            pre_lane: None,
+            allow_dirty: false,
+            json: false,
+        })
+    });
 
-        assert!(result.is_ok());
+    assert!(result.is_ok());
 
-        let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
-        assert!(content.contains("version = \"0.2.0\""));
+    let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
+    assert!(content.contains("version = \"0.2.0\""));
 
-        assert!(tmp_path.join("CHANGELOG.md").exists());
+    assert!(tmp_path.join("CHANGELOG.md").exists());
 
-        let tag_output = Command::new("git")
-            .args(["tag", "-l", "v0.2.0"])
-            .current_dir(&tmp_path)
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&tag_output.stdout).contains("v0.2.0"));
-    }
+    let tag_output = Command::new("git")
+        .args(["tag", "-l", "v0.2.0"])
+        .current_dir(&tmp_path)
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&tag_output.stdout).contains("v0.2.0"));
+}
 
-    #[test]
-    fn release_tag_only_project() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "main.go", "package main");
+#[test]
+fn release_tag_only_project() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "main.go", "package main");
 
-        Command::new("git")
-            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    Command::new("git")
+        .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        commit_file(tmp.path(), "main_test.go", "package main");
+    commit_file(tmp.path(), "main_test.go", "package main");
 
-        let tmp_path = tmp.path().to_path_buf();
-        let result = with_cwd(&tmp_path, || {
-            run(ReleaseOptions {
-                bump: "patch".to_string(),
-                dry_run: false,
-                no_tag: false,
-                no_changelog: false,
-                no_bump: false,
-                push: false,
-                pre_lane: None,
-                allow_dirty: false,
-                json: false,
-            })
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let result = with_cwd(&tmp_path, || {
+        run(ReleaseOptions {
+            bump: "patch".to_string(),
+            dry_run: false,
+            no_tag: false,
+            no_changelog: false,
+            no_bump: false,
+            push: false,
+            pre_lane: None,
+            allow_dirty: false,
+            json: false,
+        })
+    });
 
-        assert!(result.is_ok());
+    assert!(result.is_ok());
 
-        let tag_output = Command::new("git")
-            .args(["tag", "-l", "v0.1.1"])
-            .current_dir(&tmp_path)
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&tag_output.stdout).contains("v0.1.1"));
-    }
+    let tag_output = Command::new("git")
+        .args(["tag", "-l", "v0.1.1"])
+        .current_dir(&tmp_path)
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&tag_output.stdout).contains("v0.1.1"));
+}
 
-    #[test]
-    fn changelog_entry_format() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "a.txt", "a");
+#[test]
+fn changelog_entry_format() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "a.txt", "a");
 
-        Command::new("git")
-            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    Command::new("git")
+        .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        fs::write(tmp.path().join("b.txt"), "b").unwrap();
-        Command::new("git")
-            .args(["add", "b.txt"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", "feat: add feature b"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    fs::write(tmp.path().join("b.txt"), "b").unwrap();
+    Command::new("git")
+        .args(["add", "b.txt"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "feat: add feature b"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        let tmp_path = tmp.path().to_path_buf();
-        let version = parse_version("0.2.0").unwrap();
-        let result = with_cwd(&tmp_path, || {
-            changelog::generate_changelog_entry(&tmp_path, &version, false)
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let version = parse_version("0.2.0").unwrap();
+    let result = with_cwd(&tmp_path, || {
+        changelog::generate_changelog_entry(&tmp_path, &version, false)
+    });
 
-        assert!(result.is_ok());
-        let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
-        assert!(cl.contains("[v0.2.0]"));
-        assert!(cl.contains("### Features"));
-        assert!(cl.contains("add feature b"));
-    }
+    assert!(result.is_ok());
+    let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
+    assert!(cl.contains("[v0.2.0]"));
+    assert!(cl.contains("### Features"));
+    assert!(cl.contains("add feature b"));
+}
 
-    #[test]
-    fn changelog_appends_to_existing() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
+#[test]
+fn changelog_appends_to_existing() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
 
-        let existing = "# Changelog\n\n## [v0.1.0] - 2024-01-01\n\n### Features\n\n- initial\n";
-        commit_file(tmp.path(), "CHANGELOG.md", existing);
+    let existing = "# Changelog\n\n## [v0.1.0] - 2024-01-01\n\n### Features\n\n- initial\n";
+    commit_file(tmp.path(), "CHANGELOG.md", existing);
 
-        Command::new("git")
-            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    Command::new("git")
+        .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        fs::write(tmp.path().join("new.txt"), "new").unwrap();
-        Command::new("git")
-            .args(["add", "new.txt"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", "fix: patch bug"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    fs::write(tmp.path().join("new.txt"), "new").unwrap();
+    Command::new("git")
+        .args(["add", "new.txt"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "fix: patch bug"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        let tmp_path = tmp.path().to_path_buf();
-        let version = parse_version("0.1.1").unwrap();
-        with_cwd(&tmp_path, || {
-            changelog::generate_changelog_entry(&tmp_path, &version, false).unwrap();
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let version = parse_version("0.1.1").unwrap();
+    with_cwd(&tmp_path, || {
+        changelog::generate_changelog_entry(&tmp_path, &version, false).unwrap();
+    });
 
-        let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
-        assert!(cl.contains("[v0.1.1]"));
-        assert!(cl.contains("[v0.1.0]"));
-        let pos_new = cl.find("[v0.1.1]").unwrap();
-        let pos_old = cl.find("[v0.1.0]").unwrap();
-        assert!(
-            pos_new < pos_old,
-            "new entry should appear before old entry"
-        );
-    }
+    let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
+    assert!(cl.contains("[v0.1.1]"));
+    assert!(cl.contains("[v0.1.0]"));
+    let pos_new = cl.find("[v0.1.1]").unwrap();
+    let pos_old = cl.find("[v0.1.0]").unwrap();
+    assert!(
+        pos_new < pos_old,
+        "new entry should appear before old entry"
+    );
+}
 
-    #[test]
-    fn read_maven_version_test() {
-        let tmp = TempDir::new().unwrap();
-        let pom = r#"<?xml version="1.0"?>
+#[test]
+fn read_maven_version_test() {
+    let tmp = TempDir::new().unwrap();
+    let pom = r#"<?xml version="1.0"?>
 <project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>test</artifactId>
     <version>1.3.0</version>
 </project>"#;
-        fs::write(tmp.path().join("pom.xml"), pom).unwrap();
-        assert_eq!(version::read_maven_version(tmp.path()).unwrap(), "1.3.0");
-    }
+    fs::write(tmp.path().join("pom.xml"), pom).unwrap();
+    assert_eq!(version::read_maven_version(tmp.path()).unwrap(), "1.3.0");
+}
 
-    #[test]
-    fn read_gradle_version_test() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("build.gradle.kts"),
-            "plugins { id(\"java\") }\nversion = \"2.1.0\"\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_gradle_version(tmp.path()).unwrap(), "2.1.0");
-    }
+#[test]
+fn read_gradle_version_test() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("build.gradle.kts"),
+        "plugins { id(\"java\") }\nversion = \"2.1.0\"\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_gradle_version(tmp.path()).unwrap(), "2.1.0");
+}
 
-    #[test]
-    fn custom_release_files() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
+#[test]
+fn custom_release_files() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
 
-        let fledge_toml = r#"
+    let fledge_toml = r#"
 [release]
 files = ["version.txt"]
 "#;
-        commit_file(tmp.path(), "fledge.toml", fledge_toml);
-        commit_file(tmp.path(), "version.txt", "version = \"0.1.0\"");
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
+    commit_file(tmp.path(), "fledge.toml", fledge_toml);
+    commit_file(tmp.path(), "version.txt", "version = \"0.1.0\"");
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
 
-        let new_ver = parse_version("0.2.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"version.txt".to_string()));
+    let new_ver = parse_version("0.2.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"version.txt".to_string()));
 
-        let content = fs::read_to_string(tmp.path().join("version.txt")).unwrap();
-        assert!(content.contains("0.2.0"));
-    }
+    let content = fs::read_to_string(tmp.path().join("version.txt")).unwrap();
+    assert!(content.contains("0.2.0"));
+}
 
-    #[test]
-    fn read_gemspec_version_test() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("my_gem.gemspec"),
-            r#"
+#[test]
+fn read_gemspec_version_test() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("my_gem.gemspec"),
+        r#"
 Gem::Specification.new do |s|
   s.name = "my_gem"
   s.version = "1.4.2"
   s.summary = "A test gem"
 end
 "#,
-        )
+    )
+    .unwrap();
+    assert_eq!(version::read_gemspec_version(tmp.path()).unwrap(), "1.4.2");
+}
+
+#[test]
+fn read_gemspec_version_single_quotes() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("my_gem.gemspec"),
+        "Gem::Specification.new do |s|\n  s.version = '2.0.1'\nend\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_gemspec_version(tmp.path()).unwrap(), "2.0.1");
+}
+
+#[test]
+fn read_python_version_from_setup_cfg() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("setup.cfg"),
+        "[metadata]\nname = my_pkg\nversion = 3.1.0\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_python_version(tmp.path()).unwrap(), "3.1.0");
+}
+
+#[test]
+fn read_python_version_pyproject_takes_priority() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("pyproject.toml"),
+        "[project]\nname = \"test\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("setup.cfg"),
+        "[metadata]\nversion = 2.0.0\n",
+    )
+    .unwrap();
+    assert_eq!(version::read_python_version(tmp.path()).unwrap(), "1.0.0");
+}
+
+#[test]
+fn duplicate_tag_prevented() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "test.txt", "hello");
+
+    Command::new("git")
+        .args(["tag", "-a", "v1.0.0", "-m", "v1.0.0"])
+        .current_dir(tmp.path())
+        .output()
         .unwrap();
-        assert_eq!(version::read_gemspec_version(tmp.path()).unwrap(), "1.4.2");
-    }
 
-    #[test]
-    fn read_gemspec_version_single_quotes() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("my_gem.gemspec"),
-            "Gem::Specification.new do |s|\n  s.version = '2.0.1'\nend\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_gemspec_version(tmp.path()).unwrap(), "2.0.1");
-    }
+    let version = parse_version("1.0.0").unwrap();
+    let result = git::create_tag(tmp.path(), &version, false);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("already exists"),
+        "expected 'already exists' error, got: {err}"
+    );
+}
 
-    #[test]
-    fn read_python_version_from_setup_cfg() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("setup.cfg"),
-            "[metadata]\nname = my_pkg\nversion = 3.1.0\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_python_version(tmp.path()).unwrap(), "3.1.0");
-    }
+#[test]
+fn bump_setup_cfg() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "setup.cfg",
+        "[metadata]\nname = test\nversion = 0.5.0\n",
+    );
+    commit_file(tmp.path(), "pyproject.toml", "[build-system]\n");
 
-    #[test]
-    fn read_python_version_pyproject_takes_priority() {
-        let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("pyproject.toml"),
-            "[project]\nname = \"test\"\nversion = \"1.0.0\"\n",
-        )
-        .unwrap();
-        fs::write(
-            tmp.path().join("setup.cfg"),
-            "[metadata]\nversion = 2.0.0\n",
-        )
-        .unwrap();
-        assert_eq!(version::read_python_version(tmp.path()).unwrap(), "1.0.0");
-    }
+    let new_ver = parse_version("0.6.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"setup.cfg".to_string()));
+    let content = fs::read_to_string(tmp.path().join("setup.cfg")).unwrap();
+    assert!(content.contains("0.6.0"));
+}
 
-    #[test]
-    fn duplicate_tag_prevented() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "test.txt", "hello");
-
-        Command::new("git")
-            .args(["tag", "-a", "v1.0.0", "-m", "v1.0.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
-
-        let version = parse_version("1.0.0").unwrap();
-        let result = git::create_tag(tmp.path(), &version, false);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("already exists"),
-            "expected 'already exists' error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn bump_setup_cfg() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "setup.cfg",
-            "[metadata]\nname = test\nversion = 0.5.0\n",
-        );
-        commit_file(tmp.path(), "pyproject.toml", "[build-system]\n");
-
-        let new_ver = parse_version("0.6.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"setup.cfg".to_string()));
-        let content = fs::read_to_string(tmp.path().join("setup.cfg")).unwrap();
-        assert!(content.contains("0.6.0"));
-    }
-
-    #[test]
-    fn bump_pom_xml() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        let pom = r#"<?xml version="1.0"?>
+#[test]
+fn bump_pom_xml() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    let pom = r#"<?xml version="1.0"?>
 <project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>test</artifactId>
     <version>1.0.0</version>
 </project>"#;
-        commit_file(tmp.path(), "pom.xml", pom);
+    commit_file(tmp.path(), "pom.xml", pom);
 
-        let new_ver = parse_version("1.1.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result.files_bumped.contains(&"pom.xml".to_string()));
-        let content = fs::read_to_string(tmp.path().join("pom.xml")).unwrap();
-        assert!(content.contains("<version>1.1.0</version>"));
-    }
+    let new_ver = parse_version("1.1.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result.files_bumped.contains(&"pom.xml".to_string()));
+    let content = fs::read_to_string(tmp.path().join("pom.xml")).unwrap();
+    assert!(content.contains("<version>1.1.0</version>"));
+}
 
-    #[test]
-    fn bump_gradle() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "build.gradle.kts",
-            "plugins { id(\"java\") }\nversion = \"0.3.0\"\n",
-        );
+#[test]
+fn bump_gradle() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "build.gradle.kts",
+        "plugins { id(\"java\") }\nversion = \"0.3.0\"\n",
+    );
 
-        let new_ver = parse_version("0.4.0").unwrap();
-        let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
-        assert!(result
-            .files_bumped
-            .contains(&"build.gradle.kts".to_string()));
-        let content = fs::read_to_string(tmp.path().join("build.gradle.kts")).unwrap();
-        assert!(content.contains("\"0.4.0\""));
-    }
+    let new_ver = parse_version("0.4.0").unwrap();
+    let result = bump::bump_version_files(tmp.path(), &new_ver).unwrap();
+    assert!(result
+        .files_bumped
+        .contains(&"build.gradle.kts".to_string()));
+    let content = fs::read_to_string(tmp.path().join("build.gradle.kts")).unwrap();
+    assert!(content.contains("\"0.4.0\""));
+}
 
-    #[test]
-    fn changelog_created_fresh() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(tmp.path(), "a.txt", "a");
+#[test]
+fn changelog_created_fresh() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(tmp.path(), "a.txt", "a");
 
-        let tmp_path = tmp.path().to_path_buf();
-        let version = parse_version("0.1.0").unwrap();
-        with_cwd(&tmp_path, || {
-            changelog::generate_changelog_entry(&tmp_path, &version, false).unwrap();
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let version = parse_version("0.1.0").unwrap();
+    with_cwd(&tmp_path, || {
+        changelog::generate_changelog_entry(&tmp_path, &version, false).unwrap();
+    });
 
-        let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
-        assert!(cl.starts_with("# Changelog"));
-        assert!(cl.contains("[v0.1.0]"));
-    }
+    let cl = fs::read_to_string(tmp_path.join("CHANGELOG.md")).unwrap();
+    assert!(cl.starts_with("# Changelog"));
+    assert!(cl.contains("[v0.1.0]"));
+}
 
-    #[test]
-    fn release_with_no_tag_flag() {
-        let tmp = TempDir::new().unwrap();
-        init_git_repo(tmp.path());
-        commit_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
-        );
+#[test]
+fn release_with_no_tag_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    commit_file(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    );
 
-        Command::new("git")
-            .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
-            .current_dir(tmp.path())
-            .output()
-            .unwrap();
+    Command::new("git")
+        .args(["tag", "-a", "v0.1.0", "-m", "v0.1.0"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
-        commit_file(tmp.path(), "src.rs", "fn main() {}");
+    commit_file(tmp.path(), "src.rs", "fn main() {}");
 
-        let tmp_path = tmp.path().to_path_buf();
-        let result = with_cwd(&tmp_path, || {
-            run(ReleaseOptions {
-                bump: "patch".to_string(),
-                dry_run: false,
-                no_tag: true,
-                no_changelog: true,
-                no_bump: false,
-                push: false,
-                pre_lane: None,
-                allow_dirty: false,
-                json: false,
-            })
-        });
+    let tmp_path = tmp.path().to_path_buf();
+    let result = with_cwd(&tmp_path, || {
+        run(ReleaseOptions {
+            bump: "patch".to_string(),
+            dry_run: false,
+            no_tag: true,
+            no_changelog: true,
+            no_bump: false,
+            push: false,
+            pre_lane: None,
+            allow_dirty: false,
+            json: false,
+        })
+    });
 
-        assert!(result.is_ok());
+    assert!(result.is_ok());
 
-        let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
-        assert!(content.contains("version = \"0.1.1\""));
+    let content = fs::read_to_string(tmp_path.join("Cargo.toml")).unwrap();
+    assert!(content.contains("version = \"0.1.1\""));
 
-        let tag_output = Command::new("git")
-            .args(["tag", "-l", "v0.1.1"])
-            .current_dir(&tmp_path)
-            .output()
-            .unwrap();
-        assert!(
-            String::from_utf8_lossy(&tag_output.stdout)
-                .trim()
-                .is_empty(),
-            "no tag should be created with --no-tag"
-        );
-    }
+    let tag_output = Command::new("git")
+        .args(["tag", "-l", "v0.1.1"])
+        .current_dir(&tmp_path)
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&tag_output.stdout)
+            .trim()
+            .is_empty(),
+        "no tag should be created with --no-tag"
+    );
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,20 @@
+//! Test-only helpers shared across modules.
+//!
+//! Lives at the crate root so multiple test modules can serialize on the same
+//! `cwd_lock()`. Tests in different modules run on parallel threads, and
+//! mutating `std::env::current_dir` is process-global; without a shared
+//! mutex, `release::tests` and `lanes::tests` race each other and one
+//! observes the other's temp dir mid-flight.
+
+use std::sync::Mutex;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the process-wide cwd mutex. Hold the returned guard for the
+/// duration of any block that calls `std::env::set_current_dir`.
+pub(crate) fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+    // Recover from a poisoned lock — a previous test panicked while holding
+    // it. The protected state is just "who's currently mutating cwd," and
+    // a panic doesn't corrupt that, so it's safe to take over.
+    CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}


### PR DESCRIPTION
## Summary

A handful of fixes surfaced by a full review of the project. None change happy-path behavior — together they close a CI gap, a flaky test, an auth-bypass on community lane import, and several unbounded network calls.

- **Clippy gap.** `fledge.toml`'s `lint = "cargo clippy -- -D warnings"` skipped test code. Bumped to `--all-targets`, fixed the `module_inception` it surfaces in `src/release/tests.rs` (drops the redundant inner `mod tests {}` so the path is `release::tests::*` instead of `release::tests::tests::*`).
- **Flaky `release::tests::full_release_flow`.** The cwd `Mutex` lived inside `release/tests.rs`, but `lanes/tests.rs` mutates `std::env::current_dir` without it — they raced on parallel cargo runs. Hoisted into a new `src/test_support.rs` so both modules share a lock; wrapped `with_cwd`'s closure in `catch_unwind` so a panicking test still restores cwd.
- **`lanes import` confirmation gate.** The function took `_yes: bool` (unused); the "Lanes can execute arbitrary commands" warning was print-only. Now matches `plugin install` — non-Official sources prompt for confirmation interactively, bail with a `--yes`-required error in non-interactive mode.
- **HTTP timeouts.** Every `ureq` GitHub call in `src/github.rs` and `src/publish.rs` now uses a shared 30s `timeout_global`. A wedged endpoint no longer hangs `lanes/templates/plugins search`, `lanes import`, or the publish flow indefinitely.
- **`changelog --json` on no-tags repo.** Emits the empty envelope `{schema_version:1, action:"changelog", releases:[]}` instead of falling through to human text.
- **Docs.** `README.md` + `docs/src/templates.md` add the `kotlin-kmp` and `kotlin-ktor-api` built-ins. `CONTRIBUTING.md` drops obsolete `fledge work pr` and `fledge publish` references, notes that `fledge deps` ships in the default plugin set.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 693 unit + 177 integration green, 3 consecutive runs (the `full_release_flow` flake did not reproduce)
- [x] `fledge lanes run pre-commit`
- [x] `fledge changelog --json` on a fresh tag-less git repo prints the empty envelope
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)