### PR TITLE
fix(plugin): error on unsupported protocol version instead of silent fallback

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -33,7 +33,7 @@ use update::update_plugins;
 use validate::validate_plugin;
 
 #[cfg(test)]
-use run_plugin::{resolve_plugin_source_dir, which_fledge_plugin};
+use run_plugin::{apply_protocol, resolve_plugin_source_dir, which_fledge_plugin};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -25,7 +25,7 @@ pub(super) fn run_plugin_cmd(name: &str, args: &[String]) -> Result<()> {
         })?;
 
     if let Some((plugin_name, plugin_version, plugin_dir, capabilities)) =
-        resolve_protocol_info(name)
+        resolve_protocol_info(name)?
     {
         return crate::protocol::run_protocol_plugin(
             &bin_path,
@@ -134,41 +134,65 @@ fn find_commands_for_plugin(plugin_name: &str) -> Option<Vec<String>> {
         .map(|p| p.commands.clone())
 }
 
-fn resolve_protocol_info(name: &str) -> Option<(String, String, PathBuf, PluginCapabilities)> {
-    let registry = load_registry().ok()?;
-    let entry = registry.plugins.iter().find(|p| {
+/// Check whether `protocol` is a known/supported value and return the protocol
+/// info tuple, `Ok(None)` for "no protocol declared" (legacy fallback), or
+/// `Err` when the plugin explicitly targets an unsupported protocol version.
+pub(super) fn apply_protocol(
+    protocol: Option<&str>,
+    plugin_name: String,
+    plugin_version: String,
+    plugin_dir: PathBuf,
+    caps: PluginCapabilities,
+) -> Result<Option<(String, String, PathBuf, PluginCapabilities)>> {
+    match protocol {
+        Some("fledge-v1") => Ok(Some((plugin_name, plugin_version, plugin_dir, caps))),
+        Some(unsupported) => bail!(
+            "Plugin '{}' requires protocol '{}' which is not supported by this version of fledge.\n  \
+             Update fledge to use this plugin: cargo install fledge",
+            plugin_name,
+            unsupported
+        ),
+        None => Ok(None),
+    }
+}
+
+fn resolve_protocol_info(
+    name: &str,
+) -> Result<Option<(String, String, PathBuf, PluginCapabilities)>> {
+    let registry = match load_registry() {
+        Ok(r) => r,
+        Err(_) => return Ok(None),
+    };
+    let entry = match registry.plugins.iter().find(|p| {
         p.name == name || p.name == format!("fledge-{name}") || p.commands.iter().any(|c| c == name)
-    })?;
+    }) {
+        Some(e) => e,
+        None => return Ok(None),
+    };
 
     let plugin_dir = plugins_dir().join(&entry.name);
     let manifest_path = plugin_dir.join("plugin.toml");
-    let content = std::fs::read_to_string(&manifest_path).ok()?;
-    let manifest: PluginManifest = toml::from_str(&content).ok()?;
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    let manifest: PluginManifest = match toml::from_str(&content) {
+        Ok(m) => m,
+        Err(_) => return Ok(None),
+    };
 
     let caps = entry
         .capabilities
         .clone()
         .unwrap_or_else(|| manifest.capabilities.clone());
 
-    match &manifest.plugin.protocol {
-        Some(proto) if proto == "fledge-v1" => Some((
-            manifest.plugin.name,
-            manifest.plugin.version,
-            plugin_dir,
-            caps,
-        )),
-        Some(proto) => {
-            eprintln!(
-                "{} Plugin '{}' requires protocol '{}' which is not supported.\n  Try updating fledge: {}",
-                style("Error:").red().bold(),
-                entry.name,
-                proto,
-                style("cargo install fledge").cyan()
-            );
-            None
-        }
-        None => None,
-    }
+    apply_protocol(
+        manifest.plugin.protocol.as_deref(),
+        manifest.plugin.name,
+        manifest.plugin.version,
+        plugin_dir,
+        caps,
+    )
 }
 
 pub(super) fn which_fledge_plugin(name: &str) -> Option<PathBuf> {

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -2,6 +2,56 @@ use super::*;
 use crate::trust::parse_source_ref;
 
 #[test]
+fn unsupported_protocol_version_returns_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let result = apply_protocol(
+        Some("fledge-v2"),
+        "my-plugin".to_string(),
+        "1.0.0".to_string(),
+        tmp.path().to_path_buf(),
+        PluginCapabilities::default(),
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("fledge-v2"),
+        "error should mention the protocol: {msg}"
+    );
+    assert!(
+        msg.contains("my-plugin"),
+        "error should mention the plugin: {msg}"
+    );
+}
+
+#[test]
+fn supported_protocol_fledge_v1_returns_info() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let result = apply_protocol(
+        Some("fledge-v1"),
+        "my-plugin".to_string(),
+        "1.0.0".to_string(),
+        tmp.path().to_path_buf(),
+        PluginCapabilities::default(),
+    );
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_some());
+}
+
+#[test]
+fn no_protocol_declared_returns_none_for_legacy_fallback() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let result = apply_protocol(
+        None,
+        "legacy-plugin".to_string(),
+        "1.0.0".to_string(),
+        tmp.path().to_path_buf(),
+        PluginCapabilities::default(),
+    );
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+}
+
+#[test]
 fn resolve_plugin_source_dir_walks_symlink_to_plugin_root() {
     // Mirror the post-install layout:
     //   <root>/plugins/my-plugin/bin/fledge-my-plugin     ← real binary


### PR DESCRIPTION
## Summary

- A plugin declaring `protocol = "fledge-v2"` (or any future unsupported version) previously printed a warning to stderr and silently fell back to legacy stdio execution — making the plugin appear to work while all protocol features were bypassed.
- Extracted `apply_protocol` helper that returns `Err` for an explicitly declared but unrecognised protocol, `Ok(None)` for no protocol (correct legacy fallback), and `Ok(Some(...))` for `fledge-v1`.
- Changed `resolve_protocol_info` to return `Result<Option<…>>` and propagated the error through the caller with `?`, so fledge now fails fast with a clear message telling the user to update.

## Test plan

- [x] `cargo test` — all existing tests pass, three new unit tests added
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New test `unsupported_protocol_version_returns_error`: verifies `protocol = "fledge-v2"` produces an `Err` naming both the plugin and the protocol
- [x] New test `supported_protocol_fledge_v1_returns_info`: verifies `fledge-v1` still works
- [x] New test `no_protocol_declared_returns_none_for_legacy_fallback`: verifies plugins without a protocol field still get legacy execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)