### PR TITLE
fix(templates): implement copy glob, lock prompt order, add v1 compat policies

### DIFF
--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 19
+version: 20
 status: active
 files:
   - src/lanes/mod.rs
@@ -265,6 +265,27 @@ $ fledge lanes run ci --json --dry-run
 | Validate empty parallel | Parallel group has no items | Validation error |
 | Validate circular deps | Task deps form a cycle | Validation error |
 
+## Compatibility Policy
+
+`lanes v1` is the stable schema that ships with fledge 1.0. To protect
+project authors and lane-repo publishers from breakage, the following rules
+govern how the lane TOML schema and `LaneDef`/`Step`/`ParallelItem` Rust types
+may evolve within the v1 major version:
+
+1. **Additive-only step kinds.** The current `Step` variants — `TaskRef` (bare string), `Inline` (`{ run = "..." }`), and `Parallel` (`{ parallel = [...] }`) — are locked. New step kinds may be added at any time, but each must use a unique discriminator key in the inline-table form (e.g. `{ matrix = [...] }`, `{ when = "..." }`) so the existing untagged enum continues to deserialize older lanes unchanged.
+2. **No field removal.** Once shipped, every field on `[lanes.<name>]` (`description`, `steps`, `fail_fast`) and on each `[tasks.<name>]` (`cmd`, `deps`, `env`, `dir`) must continue to be parsed. Removing a field is a breaking change and requires a new schema version.
+3. **No field retyping.** A field's TOML type is locked once shipped. The bare-string form of `TaskRef` and the inline-table forms of `Inline`/`Parallel` are part of the wire contract and cannot change shape.
+4. **New optional fields are allowed.** Both fledge and lane consumers must tolerate unknown fields on known sections — additive optional fields do not require a version bump.
+5. **Parallel + fail_fast semantics are locked.** In-flight siblings always finish (no cancellation). `fail_fast` governs only what happens *after* a step or group completes — never mid-execution. Documented in invariant 4.
+6. **`fail_fast` defaults to `true`.** Changing the default is a breaking change.
+7. **Trust-tier classification is part of the contract.** A source string ending in `<owner>/<repo>` (with optional `@<ref>`) is the canonical form. Future variations (multi-host, hashed pins) must classify under the existing `Official | Team | Unverified` tiers.
+8. **`--json` envelope shapes are versioned per-command.** Adding fields is additive within a given command's `schema_version`. Renaming or removing fields bumps that command's `schema_version` (see `LANES_*_SCHEMA` constants).
+9. **Imported lane file naming is locked.** `.fledge/lanes/<safe>.toml` with the `# Imported from <source>` first-line marker is part of the v1 contract — fledge uses both for trust classification and for round-trip integrity.
+
+Any change that cannot be expressed under these rules requires a new schema
+version declared explicitly (e.g. `[fledge] lanes_version = 2`); v1 lane
+files continue to load against v1 semantics indefinitely.
+
 ## Dependencies
 
 - `run` module (reuses task execution, project detection)
@@ -276,6 +297,7 @@ $ fledge lanes run ci --json --dry-run
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 20 | 2026-05-01 | **1.0 contract finalize:** Add Compatibility Policy locking the lanes v1 schema. Future Step variants must use unique discriminator keys in inline-table form so the untagged enum keeps deserializing older lanes. Field removal/retyping bumps schema; parallel + fail_fast semantics, fail_fast default, imported-lane file naming, and trust-tier classification are all locked. No code change |
 | 19 | 2026-04-29 | Document all submodule exports (community, create, defaults, execute, publish, validate) after splitting lanes.rs into lanes/ module folder |
 | 18 | 2026-04-27 | **Breaking (1.0 contract finalize, follow-up):** `lanes publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `lanes_published`, `topic`, `import_hint`); `cancelled: true` when the user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` covers it). Mirrors the same fix landed for `plugins publish` and `templates publish` in the previous commit |
 | 17 | 2026-04-26 | **Breaking (1.0 contract finalize):** (a) `lanes list --json` renames `steps` (integer count) to `step_count`. The bare key `steps` read like an array but emitted a count, surprising consumers, full step detail lives in `lanes run --dry-run --json`. (b) `lanes import --json` renames `tier` to `trust_tier` to match every other plugin/lane envelope. Last-chance shape break before tagging 1.0 |

--- a/specs/templates/templates.spec.md
+++ b/specs/templates/templates.spec.md
@@ -1,6 +1,6 @@
 ---
 module: templates
-version: 7
+version: 8
 status: active
 files:
   - src/templates.rs
@@ -43,8 +43,8 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | `Template` | A discovered template with name, description, path, and manifest |
 | `TemplateManifest` | Parsed `template.toml` with info, prompts, and file rules |
 | `TemplateInfo` | Template name, description, version, min_fledge_version, and requires (tool dependencies) |
-| `PromptDef` | Custom prompt definition with message and optional default |
-| `FileRules` | Glob patterns for render, copy, and ignore |
+| `PromptDef` | Custom prompt definition with message and optional default. Stored in a `BTreeMap<String, PromptDef>` so iteration order is deterministic (alphabetical by key) |
+| `FileRules` | Glob patterns for render, copy, and ignore. Precedence: `ignore` short-circuits → `.tera` extension always renders → `copy` forces verbatim → `render` Tera-renders → default copies |
 | `Hooks` | Post-create lifecycle hooks (e.g., `npm install`, `bun install`) |
 
 ### Traits
@@ -65,14 +65,17 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 ## Invariants
 
 1. Templates are sorted alphabetically by name after discovery
-2. Files ending in `.tera` are always rendered and the extension is stripped
-3. Files matching `render` globs are rendered through Tera
-4. Files matching `ignore` globs are skipped entirely
-5. Tera expressions in file paths (e.g., `{{ project_name_pascal }}`) are resolved
-6. Parent directories are created automatically during rendering
-7. The list of created files returned by `render_template` is sorted alphabetically
-8. Directories without a `template.toml` are silently skipped during discovery
-9. Built-in template directory resolution checks exe-relative, then `CARGO_MANIFEST_DIR`, then falls back to `./templates`
+2. Files ending in `.tera` are always rendered and the extension is stripped — this is the explicit "render this" signal and overrides `copy`
+3. Files matching `copy` globs are copied verbatim (never run through Tera) even when a `render` glob would otherwise match them. The `.tera` extension still wins
+4. Files matching `render` globs (and not `copy`) are rendered through Tera
+5. Files matching `ignore` globs are skipped entirely (highest precedence after errors)
+6. Files that match no glob are copied as bytes (default)
+7. Tera expressions in file paths (e.g., `{{ project_name_pascal }}`) are resolved
+8. Parent directories are created automatically during rendering
+9. The list of created files returned by `render_template` is sorted alphabetically
+10. Directories without a `template.toml` are silently skipped during discovery
+11. Built-in template directory resolution checks exe-relative, then `CARGO_MANIFEST_DIR`, then falls back to `./templates`
+12. `prompts` are iterated in alphabetical order by key — multi-prompt templates ask questions in a stable order across runs
 
 ## Behavioral Examples
 
@@ -128,6 +131,26 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 | Template directory not readable | Returns IO error |
 | Tera expression in file path is invalid | Returns Tera rendering error |
 
+## Compatibility Policy
+
+`templates v1` is the stable manifest contract that ships with fledge 1.0. To
+protect template authors from breakage, the following rules govern how
+`template.toml` and the `Template`/`TemplateManifest` Rust API may evolve within
+the v1 major version:
+
+1. **Additive-only sections.** New top-level sections (`[plugins]`, `[ci]`, `[i18n]`, …) may be added at any time. Templates and fledge already tolerate unknown sections — serde's default deserializer ignores unknown fields, so older fledge ignores newer manifests' extra sections.
+2. **No field removal from existing sections.** Once shipped, every field on `[template]`, `[prompts.*]`, `[files]`, and `[hooks]` must continue to be parsed. Removing a field is a breaking change and requires a new manifest version.
+3. **No field retyping.** A field's TOML type (string, number, bool, table, array) is locked once shipped. Widening a string into a table, or a single value into an array, is a breaking change.
+4. **New optional fields are allowed.** Both fledge and template authors must tolerate unknown fields on known sections — additive optional fields do not require a version bump.
+5. **`files` precedence is locked.** `ignore` → `.tera` extension → `copy` → `render` → default-copy. Future glob categories (e.g. `binary`, `executable`) must slot into this precedence without changing the semantics of the existing four.
+6. **Prompt iteration order is locked.** Prompts iterate alphabetically by key. Templates that need a specific UX order should name their keys to sort that way (`01_name`, `02_description`).
+7. **`hooks` is additive.** New hook stages (`pre_create`, `pre_render`, `post_install`, …) may be added; existing `post_create` semantics must not change. New hooks default to a no-op when absent.
+8. **`min_fledge_version` is enforcement-only.** Once a template declares a minimum, fledge will refuse to render with an older version — this contract cannot relax.
+
+Any change that cannot be expressed under these rules requires a new manifest
+version declared explicitly (e.g. `[template] manifest_version = 2`); v1
+templates continue to render against v1 semantics indefinitely.
+
 ## Dependencies
 
 ### Consumes
@@ -152,7 +175,7 @@ Template discovery, loading, and rendering. Finds templates from built-in and us
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 7 | 2026-04-29 | Add `TEMPLATES_LIST_SCHEMA`, `TEMPLATES_SEARCH_SCHEMA`, `TEMPLATES_PUBLISH_SCHEMA` per-command schema version constants (crate-visible, used by `main.rs` for `--json` envelopes) |
+| 8 | 2026-05-01 | **1.0 contract finalize:** (a) Implement `[files] copy` glob — was documented and present in built-in templates but silently dropped. New precedence: `ignore` → `.tera` → `copy` → `render` → default-copy. Copy-matched files bypass Tera even when a render glob would otherwise catch them. (b) Switch `prompts` from `HashMap` to `BTreeMap` so multi-prompt templates ask questions in a stable alphabetical order across runs. (c) Add Compatibility Policy locking the templates v1 contract (additive-only sections, no field removal/retyping, locked precedence + iteration order) |
 | 6 | 2026-04-26 | **Breaking (1.0 contract finalize):** `templates publish --json` cancelled and success paths now share the same key set (`schema_version`, `action`, `cancelled`, `repo`, `template`, `topic`, `use_hint`). `cancelled` is `true` when user declines, `false` on success. The cancelled `repo.exists` field is removed (`created: false` covers it). Consumers can now read the same keys regardless of cancel/success |
 | 5 | 2026-04-25 | Remove `load_templates_from_dir_pub` (was only used by deleted `templates update` and `templates publish`); now an internal `fn` |
 | 4 | 2026-04-20 | Add `check_requirements` for template tool dependency checking |

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use include_dir::{include_dir, Dir};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use tera::Tera;
 use walkdir::WalkDir;
@@ -20,8 +20,12 @@ pub(crate) const TEMPLATES_PUBLISH_SCHEMA: u32 = 1;
 #[derive(Debug, Deserialize)]
 pub struct TemplateManifest {
     pub template: TemplateInfo,
+    /// Prompt definitions keyed by variable name. `BTreeMap` so iteration order is
+    /// deterministic (alphabetical by key) — locking this for the templates v1
+    /// contract means multi-prompt templates ask questions in a stable order
+    /// across runs.
     #[serde(default)]
-    pub prompts: HashMap<String, PromptDef>,
+    pub prompts: BTreeMap<String, PromptDef>,
     #[serde(default)]
     pub files: FileRules,
     #[serde(default)]
@@ -86,6 +90,13 @@ pub struct PromptDef {
 pub struct FileRules {
     #[serde(default)]
     pub render: Vec<String>,
+    /// Globs whose matches are copied verbatim (never run through Tera, even when
+    /// they would otherwise match a `render` glob). Use this to mark binary or
+    /// otherwise non-templated assets (`**/*.png`, `**/*.ico`, …) so a broad
+    /// `render = ["**/*"]` cannot accidentally corrupt them. A `.tera`
+    /// extension still wins — that's the explicit "render this" signal.
+    #[serde(default)]
+    pub copy: Vec<String>,
     #[serde(default)]
     pub ignore: Vec<String>,
 }
@@ -326,13 +337,25 @@ pub fn render_template(
             std::fs::create_dir_all(parent)?;
         }
 
-        let should_render = is_tera_ext
-            || template
+        // Precedence: `.tera` extension wins (explicit render signal), then
+        // `copy` (explicit verbatim signal), then `render` globs, then default
+        // (copy as bytes). `ignore` was already short-circuited above.
+        let force_copy = !is_tera_ext
+            && template
                 .manifest
                 .files
-                .render
+                .copy
                 .iter()
                 .any(|g| matches_glob(g, &rel_string));
+
+        let should_render = is_tera_ext
+            || (!force_copy
+                && template
+                    .manifest
+                    .files
+                    .render
+                    .iter()
+                    .any(|g| matches_glob(g, &rel_string)));
 
         if should_render {
             let content = std::fs::read_to_string(entry.path())
@@ -553,6 +576,44 @@ ignore = ["template.toml", "**/*.bak"]
     }
 
     #[test]
+    fn parse_manifest_with_copy_rules() {
+        let toml_str = r#"
+[template]
+name = "test"
+description = "Test"
+
+[files]
+render = ["**/*"]
+copy = ["**/*.png", "**/*.ico"]
+"#;
+        let manifest: TemplateManifest = toml::from_str(toml_str).unwrap();
+        assert_eq!(manifest.files.copy, vec!["**/*.png", "**/*.ico"]);
+    }
+
+    #[test]
+    fn prompts_iterate_in_deterministic_order() {
+        // Locks the templates v1 contract: prompt iteration is alphabetical
+        // by key, so multi-prompt templates ask questions in a stable order.
+        let toml_str = r#"
+[template]
+name = "test"
+description = "Test"
+
+[prompts.zebra]
+message = "Zebra?"
+
+[prompts.alpha]
+message = "Alpha?"
+
+[prompts.mango]
+message = "Mango?"
+"#;
+        let manifest: TemplateManifest = toml::from_str(toml_str).unwrap();
+        let keys: Vec<&str> = manifest.prompts.keys().map(|s| s.as_str()).collect();
+        assert_eq!(keys, vec!["alpha", "mango", "zebra"]);
+    }
+
+    #[test]
     fn parse_invalid_manifest_errors() {
         let result: Result<TemplateManifest, _> = toml::from_str("not valid toml");
         assert!(result.is_err());
@@ -747,6 +808,84 @@ ignore = ["template.toml"]
 
         let content = fs::read_to_string(target.join("image.png")).unwrap();
         assert_eq!(content, "binary-data-here");
+    }
+
+    #[test]
+    fn copy_glob_overrides_render_glob() {
+        // Locks templates v1 contract: a file matching both render and copy is
+        // copied verbatim. Without this, a broad `render = ["**/*"]` would
+        // corrupt binary assets even when the author explicitly listed them
+        // under `copy`.
+        let tmp = TempDir::new().unwrap();
+        let tpl_dir = tmp.path().join("templates");
+        fs::create_dir(&tpl_dir).unwrap();
+
+        let raw_bytes = "{{ this_is_not_a_template }}";
+        make_test_template(
+            &tpl_dir,
+            "force-copy",
+            &[("logo.png", raw_bytes)],
+            r#"
+[template]
+name = "force-copy"
+description = "Test"
+
+[files]
+render = ["**/*"]
+copy = ["**/*.png"]
+ignore = ["template.toml"]
+"#,
+        );
+
+        let template = load_test_template(&tpl_dir, "force-copy");
+        let target = tmp.path().join("output");
+        fs::create_dir(&target).unwrap();
+
+        let ctx = tera::Context::new();
+        let files = render_template(&template, &target, &ctx).unwrap();
+        assert!(files.contains(&PathBuf::from("logo.png")));
+
+        let content = fs::read_to_string(target.join("logo.png")).unwrap();
+        assert_eq!(
+            content, raw_bytes,
+            "copy glob should bypass Tera even when render glob matches"
+        );
+    }
+
+    #[test]
+    fn tera_extension_wins_over_copy_glob() {
+        // `.tera` is the explicit "render this" signal — it overrides copy.
+        let tmp = TempDir::new().unwrap();
+        let tpl_dir = tmp.path().join("templates");
+        fs::create_dir(&tpl_dir).unwrap();
+
+        make_test_template(
+            &tpl_dir,
+            "tera-wins",
+            &[("config.toml.tera", "name = \"{{ project_name }}\"")],
+            r#"
+[template]
+name = "tera-wins"
+description = "Test"
+
+[files]
+copy = ["**/*"]
+ignore = ["template.toml"]
+"#,
+        );
+
+        let template = load_test_template(&tpl_dir, "tera-wins");
+        let target = tmp.path().join("output");
+        fs::create_dir(&target).unwrap();
+
+        let mut ctx = tera::Context::new();
+        ctx.insert("project_name", "rendered");
+
+        let files = render_template(&template, &target, &ctx).unwrap();
+        assert!(files.contains(&PathBuf::from("config.toml")));
+
+        let content = fs::read_to_string(target.join("config.toml")).unwrap();
+        assert_eq!(content, "name = \"rendered\"");
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -159,12 +159,19 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
 
         let rel_string = rel_str.to_string();
         let is_tera_ext = rel_string.ends_with(".tera");
-        let should_render = is_tera_ext
-            || manifest
+        let force_copy = !is_tera_ext
+            && manifest
                 .files
-                .render
+                .copy
                 .iter()
                 .any(|g| matches_glob_pub(g, &rel_string));
+        let should_render = is_tera_ext
+            || (!force_copy
+                && manifest
+                    .files
+                    .render
+                    .iter()
+                    .any(|g| matches_glob_pub(g, &rel_string)));
 
         if should_render {
             let file_content = match std::fs::read_to_string(entry.path()) {


### PR DESCRIPTION
## Summary

Two pre-1.0 blockers in the templates schema, plus Compatibility Policy sections locking the v1 contracts for templates and lanes.

- **`[files] copy` was documented but silently dropped.** Built-in templates (`rust-cli`, `static-site`, …) ship `copy = ["**/*.png", …]` and `create_template` scaffolds it into every new template, but `FileRules` had no `copy` field, so serde dropped it. Now wired through `render_template` + `validate` with explicit precedence: `ignore → .tera → copy → render → default-copy`. A copy-matched file bypasses Tera even when a render glob would otherwise catch it, so `render = ["**/*"]` no longer corrupts binary assets.
- **`prompts: HashMap` had non-deterministic iteration order.** Multi-prompt templates asked questions in random order across runs. Switched to `BTreeMap` — alphabetical-by-key, deterministic, no new dep.
- **Compatibility Policy sections** added to `specs/templates/templates.spec.md` (v8) and `specs/lanes/lanes.spec.md` (v20) mirroring `specs/plugin/plugin-protocol.spec.md`'s policy: additive-only sections, no field removal or retyping, locked file-rule precedence + prompt iteration order, locked parallel/fail_fast semantics, discriminator-key rule for future `Step` variants.

Both code fixes are breaking the moment 1.0 ships (HashMap iteration becomes contractual; future templates that rely on `copy` being a no-op are theoretical but possible). Landing now.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 876 passed, 0 failed (+4 new tests)
  - `parse_manifest_with_copy_rules`
  - `prompts_iterate_in_deterministic_order`
  - `copy_glob_overrides_render_glob`
  - `tera_extension_wins_over_copy_glob`
- [x] `fledge spec check` — 29 specs, 0 errors, 0 warnings
- [x] End-to-end: `fledge templates init testproj --template static-site` renders correctly with copy globs honored
- [x] `fledge templates validate <built-in templates>` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)