### PR TITLE
fix(introspect): propagate inherited global args to descendant subcommands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 
 | Command | What you get | Use when |
 |---------|-------------|----------|
-| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args: [...], subcommands: [...]}`. Each subcommand recursively has the same shape; each arg has `name, long?, short?, aliases, help, required, takes_value, value_name, global?` | First contact with fledge |
+| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args: [...], subcommands: [...]}`. Each subcommand recursively has the same shape; each arg has `name, long?, short?, aliases, help, required, takes_value, value_name, global?`. Each node's `args` is the **complete set of flags accepted at that level**, including inherited globals from ancestors (marked `global: true`) — no need to walk up the parent chain | First contact with fledge |
 | `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [{name, version, status, sections, companions, ...}]}` | Orienting to a new codebase |
 | `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {name, version, status, sections, companions, ...}}` | Need structured view of one module |
 | `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs: [...], totals, strict}` | Spec-sync validation as data |

--- a/specs/introspect/introspect.spec.md
+++ b/specs/introspect/introspect.spec.md
@@ -1,6 +1,6 @@
 ---
 module: introspect
-version: 2
+version: 3
 status: active
 files:
   - src/introspect.rs
@@ -47,7 +47,7 @@ depends_on: []
 2. The top-level object includes a `schema_version: <integer>` field. The current value is `1`. The field is emitted at the same level as `name`, `about`, `args`, and `subcommands` (not nested) so existing consumers that read those keys continue to work — only consumers that need to gate on schema changes read `schema_version`
 3. The tree excludes clap's auto-generated `--help` and `--version` args and the `help` subcommand — they're uniform across all commands and would just add noise
 4. `value_name` is omitted for boolean flags (args where `takes_value == false`) so agents don't try to pass values where none is expected
-5. Global args (clap `global = true`) are emitted only on the command that declared them, with `global: true` to flag their scope — they are NOT mirrored onto every subcommand that inherits them
+5. Global args (clap `global = true`) propagate to every descendant subcommand's `args` array, retaining `global: true` on each appearance. An agent reading any node's `args` therefore sees the **complete set of flags accepted at that level**, including inherited ones, without having to walk up the parent chain. A child redeclaring an inherited arg by the same name keeps its own copy (no duplicates) — the local declaration wins
 6. Subcommand aliases (e.g. `plugin` for `plugins`) are surfaced in the `CommandNode.aliases` field; arg-level aliases (both long via `visible_alias` and short via `visible_short_alias`) are surfaced in `ArgNode.aliases`. Agents can therefore recognize both subcommand and flag shorthands (e.g. `--ni` for `--non-interactive`)
 7. Without `--json`, the output is a human-readable indented tree: each subcommand nested one level deeper, each arg on its own line with the flag form it takes (`-s, --long` or `<positional>`). Required args are prefixed with `*` as a visual marker
 8. `introspect` never touches the filesystem, network, git, or any external tool — it is a pure function of the compiled binary's clap configuration
@@ -125,5 +125,6 @@ $ fledge introspect --json | jq '.subcommands[] | select(.aliases | length > 0) 
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3 | 2026-05-01 | **1.0 contract finalize:** invariant 5 flipped — global args (clap `global = true`) now propagate to every descendant subcommand's `args` array, marked `global: true` so agents can distinguish inherited from locally-declared. Previously, an agent reading `plugins.list.args` saw an empty array even though `--json` and `--non-interactive` are accepted there. Each node's `args` now reflects the **complete set of flags accepted at that level**. The wire format and `schema_version` are unchanged — `global: true` was always part of the v1 shape; this fix uses it as intended. Child redeclaration takes precedence over an inherited arg with the same name (no duplicates) |
 | 2 | 2026-04-25 | Add `schema_version: 1` to `--json` output (additive, emitted alongside existing top-level keys, not nested). Locks the agent-facing JSON shape for 1.0 |
 | 1 | 2026-04-23 | Initial spec, `fledge introspect` with pretty and JSON output for agent discoverability |

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -40,7 +40,7 @@ pub struct CommandNode {
     pub subcommands: Vec<CommandNode>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ArgNode {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,24 +59,48 @@ pub struct ArgNode {
 }
 
 fn build_tree(cmd: &Command) -> CommandNode {
+    build_tree_with_inherited(cmd, &[])
+}
+
+/// Walk the clap tree, threading inherited `global = true` args down through
+/// each subcommand. Each node's `args` is the union of the args declared on
+/// that command and any inherited globals from ancestors (deduplicated by
+/// name — a child re-declaring an arg keeps its own copy). Inherited args
+/// retain `global: true` so agents can distinguish them from locally-declared
+/// args if they want to.
+fn build_tree_with_inherited(cmd: &Command, inherited: &[ArgNode]) -> CommandNode {
+    let own_args: Vec<ArgNode> = cmd
+        .get_arguments()
+        .filter(|a| {
+            // Skip the implicit `--help` / `--version` globals — they're
+            // on every command and add noise.
+            let id = a.get_id().as_str();
+            id != "help" && id != "version"
+        })
+        .map(build_arg)
+        .collect();
+
+    let mut all_args = own_args;
+    for inherited_arg in inherited {
+        if !all_args.iter().any(|a| a.name == inherited_arg.name) {
+            all_args.push(inherited_arg.clone());
+        }
+    }
+
+    // Globals to pass to children: every arg currently visible at this level
+    // that is itself global. Locally-declared globals start propagating here;
+    // ancestor globals continue propagating.
+    let next_inherited: Vec<ArgNode> = all_args.iter().filter(|a| a.global).cloned().collect();
+
     CommandNode {
         name: cmd.get_name().to_string(),
         about: cmd.get_about().map(|s| s.to_string()),
         aliases: cmd.get_visible_aliases().map(|s| s.to_string()).collect(),
-        args: cmd
-            .get_arguments()
-            .filter(|a| {
-                // Skip the implicit `--help` / `--version` globals — they're
-                // on every command and add noise.
-                let id = a.get_id().as_str();
-                id != "help" && id != "version"
-            })
-            .map(build_arg)
-            .collect(),
+        args: all_args,
         subcommands: cmd
             .get_subcommands()
             .filter(|s| s.get_name() != "help")
-            .map(build_tree)
+            .map(|s| build_tree_with_inherited(s, &next_inherited))
             .collect(),
     }
 }
@@ -190,6 +214,103 @@ mod tests {
         let verbose = tree.args.iter().find(|a| a.name == "verbose").unwrap();
         assert!(verbose.global);
         assert_eq!(verbose.long.as_deref(), Some("verbose"));
+    }
+
+    #[test]
+    fn global_args_propagate_to_subcommands() {
+        // Locks the introspect contract: a `global = true` arg declared on a
+        // parent command appears on every descendant subcommand's `args`,
+        // marked `global: true`. Agents reading any node's args see the full
+        // set of flags accepted at that level.
+        let cmd = TestCli::command();
+        let tree = build_tree(&cmd);
+        let hello = tree.subcommands.iter().find(|s| s.name == "hello").unwrap();
+        let verbose = hello
+            .args
+            .iter()
+            .find(|a| a.name == "verbose")
+            .expect("inherited global should appear on subcommand");
+        assert!(verbose.global);
+    }
+
+    #[derive(clap::Parser)]
+    #[command(name = "deepcli")]
+    struct DeepCli {
+        #[arg(long, global = true)]
+        root_global: bool,
+
+        #[command(subcommand)]
+        command: DeepMid,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum DeepMid {
+        Mid {
+            #[arg(long, global = true)]
+            mid_global: bool,
+
+            #[command(subcommand)]
+            action: DeepLeaf,
+        },
+    }
+
+    #[derive(clap::Subcommand)]
+    enum DeepLeaf {
+        Leaf {
+            #[arg(long)]
+            leaf_local: bool,
+        },
+    }
+
+    #[test]
+    fn globals_propagate_through_multiple_levels() {
+        let cmd = DeepCli::command();
+        let tree = build_tree(&cmd);
+        let mid = tree.subcommands.iter().find(|s| s.name == "mid").unwrap();
+        let leaf = mid.subcommands.iter().find(|s| s.name == "leaf").unwrap();
+
+        // Leaf sees: its own arg, mid's global, root's global
+        assert!(leaf.args.iter().any(|a| a.name == "leaf_local"));
+        assert!(leaf.args.iter().any(|a| a.name == "mid_global" && a.global));
+        assert!(leaf
+            .args
+            .iter()
+            .any(|a| a.name == "root_global" && a.global));
+    }
+
+    #[derive(clap::Parser)]
+    #[command(name = "shadowcli")]
+    struct ShadowCli {
+        #[arg(long, global = true)]
+        json: bool,
+
+        #[command(subcommand)]
+        command: ShadowSub,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum ShadowSub {
+        /// Subcommand that redeclares `--json` with its own settings
+        Sub {
+            #[arg(long, help = "child's own json flag")]
+            json: bool,
+        },
+    }
+
+    #[test]
+    fn child_redeclaration_does_not_duplicate_inherited_arg() {
+        let cmd = ShadowCli::command();
+        let tree = build_tree(&cmd);
+        let sub = tree.subcommands.iter().find(|s| s.name == "sub").unwrap();
+        let json_args: Vec<&ArgNode> = sub.args.iter().filter(|a| a.name == "json").collect();
+        assert_eq!(
+            json_args.len(),
+            1,
+            "child redeclaring an inherited arg should not produce a duplicate, got: {:?}",
+            json_args
+        );
+        // The child's local declaration wins; help text comes from the child.
+        assert_eq!(json_args[0].help.as_deref(), Some("child's own json flag"));
     }
 
     #[test]

--- a/src/snapshots/fledge__introspect__tests__introspect_schema.snap
+++ b/src/snapshots/fledge__introspect__tests__introspect_schema.snap
@@ -1,6 +1,5 @@
 ---
 source: src/introspect.rs
-assertion_line: 259
 expression: output
 ---
 {
@@ -26,7 +25,19 @@ expression: output
       "name": "ai",
       "about": "Manage AI provider and model selection",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "status",
@@ -40,6 +51,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -72,6 +94,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -94,6 +127,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -152,6 +196,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -194,6 +249,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -217,6 +283,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -225,7 +302,19 @@ expression: output
       "name": "config",
       "about": "Manage global configuration",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "get",
@@ -238,6 +327,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -260,6 +360,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -275,6 +386,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -297,6 +419,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -319,6 +452,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -327,21 +471,57 @@ expression: output
           "name": "edit",
           "about": "Interactively edit config values",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
           "name": "list",
           "about": "Show all config values",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
           "name": "path",
           "about": "Show config file path",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
@@ -356,6 +536,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -374,6 +565,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -390,6 +592,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -398,7 +611,19 @@ expression: output
       "name": "lanes",
       "about": "Manage and run composable workflow pipelines",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "run",
@@ -427,6 +652,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -443,6 +679,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -459,6 +706,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -491,6 +749,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -523,6 +792,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -579,6 +859,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -629,6 +920,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -660,6 +962,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -675,6 +988,17 @@ expression: output
           "name": "json",
           "long": "json",
           "help": "Output as JSON",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
           "required": false,
           "takes_value": false,
           "global": true
@@ -717,6 +1041,25 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -732,6 +1075,25 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -755,6 +1117,25 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -763,14 +1144,54 @@ expression: output
           "name": "list",
           "about": "List installed plugins",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
           "name": "audit",
           "about": "Audit installed plugins — show trust tiers, capabilities, and hooks",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
@@ -802,6 +1223,25 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -825,6 +1265,25 @@ expression: output
               "takes_value": true,
               "value_name": "ARGS",
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -873,6 +1332,25 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -915,6 +1393,25 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "json",
+              "long": "json",
+              "help": "Output as JSON",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -946,6 +1443,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1027,6 +1535,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -1127,6 +1646,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -1175,6 +1705,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -1183,7 +1724,19 @@ expression: output
       "name": "spec",
       "about": "Manage specs (check, init, new)",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "check",
@@ -1205,6 +1758,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1213,7 +1777,19 @@ expression: output
           "name": "init",
           "about": "Initialize spec-sync configuration",
           "aliases": [],
-          "args": [],
+          "args": [
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
+            }
+          ],
           "subcommands": []
         },
         {
@@ -1228,6 +1804,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1243,6 +1830,17 @@ expression: output
               "required": true,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1266,6 +1864,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1276,7 +1885,19 @@ expression: output
       "name": "templates",
       "about": "Manage templates (init, create, validate, list, search, publish)",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "init",
@@ -1372,6 +1993,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1448,6 +2080,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1479,6 +2122,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1495,6 +2149,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1536,6 +2201,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1592,6 +2268,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1652,6 +2339,17 @@ expression: output
           "required": false,
           "takes_value": false,
           "global": false
+        },
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
         }
       ],
       "subcommands": []
@@ -1660,7 +2358,19 @@ expression: output
       "name": "work",
       "about": "Feature branch and PR workflow",
       "aliases": [],
-      "args": [],
+      "args": [
+        {
+          "name": "non_interactive",
+          "long": "non-interactive",
+          "aliases": [
+            "ni"
+          ],
+          "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+          "required": false,
+          "takes_value": false,
+          "global": true
+        }
+      ],
       "subcommands": [
         {
           "name": "start",
@@ -1715,6 +2425,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1791,6 +2512,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1816,6 +2548,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1832,6 +2575,17 @@ expression: output
               "required": false,
               "takes_value": false,
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []
@@ -1847,6 +2601,17 @@ expression: output
               "takes_value": true,
               "value_name": "ARGS",
               "global": false
+            },
+            {
+              "name": "non_interactive",
+              "long": "non-interactive",
+              "aliases": [
+                "ni"
+              ],
+              "help": "Run without prompts: treat every interactive confirmation as --yes, and bail with a clear error on prompts that have no default. Also settable via the FLEDGE_NON_INTERACTIVE env var",
+              "required": false,
+              "takes_value": false,
+              "global": true
             }
           ],
           "subcommands": []


### PR DESCRIPTION
## Summary

`fledge introspect --json` is the discovery API agents use to enumerate the CLI surface. Previously a clap `global = true` arg declared on a parent command was emitted only on that parent — not on the subcommands that actually accept it. So an agent reading `plugins.list.args` saw an empty array, even though `--json` (declared on `Plugins` with `global = true`) and `--non-interactive` (declared on the root) both work there.

Now each node's `args` reflects the **complete set of flags accepted at that level**, with inherited args retaining `global: true` so agents can distinguish them from locally-declared ones if they care. A child re-declaring an inherited arg by name keeps its own copy — local wins, no duplicates.

The wire format is unchanged: `global: true` was always part of the v1 introspect schema, this fix uses it as intended. `INTROSPECT_SCHEMA_VERSION` stays at 1.

### Before (root-only globals)
```
$ fledge introspect --json | jq '.subcommands[] | select(.name=="plugins").subcommands[] | select(.name=="list").args'
[]
```

### After
```
[
  { "name": "json", "long": "json", "global": true, ... },
  { "name": "non_interactive", "long": "non-interactive", "global": true, ... }
]
```

## Changes
- `src/introspect.rs`: `build_tree` threads inherited globals through recursion, dedupes by name
- `specs/introspect/introspect.spec.md` → v3: invariant 5 flipped, change-log entry
- `AGENTS.md`: row clarified — args list now includes inherited globals
- `src/snapshots/...introspect_schema.snap` regenerated

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — **879 passed, 0 failed** (+3 new tests)
  - `global_args_propagate_to_subcommands`
  - `globals_propagate_through_multiple_levels`
  - `child_redeclaration_does_not_duplicate_inherited_arg`
- [x] `fledge spec check` — 29 specs, 0 errors, 0 warnings
- [x] Live binary: `fledge plugins list` introspect node now reports both `--json` and `--non-interactive` with `global: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)