### PR TITLE
fix(release): dry-run files_to_bump must include [release].files extras

### DIFF
--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -1,6 +1,6 @@
 ---
 module: release
-version: 4
+version: 5
 status: active
 files:
   - src/release/mod.rs
@@ -134,7 +134,7 @@ Then version.txt is bumped alongside auto-detected files
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 4 | 2026-04-26 | Pre-release lane no longer pollutes `--json` stdout. When `--json` is set, `run_pre_lane` calls a new silent path `crate::lanes::run_for_pre_release(name, dry_run)` that runs steps with subprocess output suppressed and emits no envelope of its own. Fixes a double-envelope regression where `release --json --pre-lane <lane>` previously emitted lane and release envelopes back-to-back on stdout. Failure path unchanged: lane bails with a plain stderr error and exit code 1 |
+| 5 | 2026-05-01 | **1.0 contract finalize, last-mile fix:** `release --dry-run --json` `files_to_bump` array now includes `[release].files` extras (e.g. `flake.nix`) so the dry-run envelope accurately previews what a real run writes. Previously, `detect_version_files` only looked at the hardcoded language candidates while `bump_version_files` (the real write path) also processed `[release].files` from `fledge.toml` — so dry-run reported `["Cargo.toml"]` while a real run also bumped `flake.nix`. Mirrored the bumper's existence + version-line-regex check in the detection path. Three new tests pin the contract. Caught in independent third-pass review pre-tag |
 | 3 | 2026-04-26 | Add `--json` flag. `release X.Y.Z --dry-run --json` emits `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}`. `release X.Y.Z --json` (real run) emits `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}` and suppresses prose output. Helper functions (`generate_changelog_entry`, `create_release_commit`, `create_tag`, `push_release`) gained a `quiet` param threaded from `opts.json`. New integration tests `cli_release_dry_run_json_emits_envelope` and `cli_release_dry_run_json_no_bump_flag` |
 | 2 | 2026-04-25 | Recognize `plugin.toml` (`[plugin].version`) as a first-class fledge-ecosystem version source. Added `--no-bump` flag for tag-only releases. The plugin.toml bumper is section-scoped so other tables' `version` keys (e.g. on `[[commands]]`) aren't touched. Rust plugins with both `Cargo.toml` and `plugin.toml` get both bumped together. (#264) |
 | 1 | 2026-04-21 | Initial spec for the full release workflow with multi-language support |

--- a/src/release/bump.rs
+++ b/src/release/bump.rs
@@ -21,11 +21,48 @@ pub(super) fn detect_version_files(dir: &Path) -> Vec<String> {
         ("build.gradle.kts", "java-gradle"),
     ];
 
-    candidates
+    let mut files: Vec<String> = candidates
         .iter()
         .filter(|(name, _)| dir.join(name).exists())
         .map(|(name, _)| name.to_string())
-        .collect()
+        .collect();
+
+    // Mirror `bump_version_files`'s `[release].files` handling so the dry-run
+    // envelope reports the same set the real release would write. Without this,
+    // `release --dry-run --json` says `files_to_bump: ["Cargo.toml"]` while a
+    // subsequent real run also bumps `flake.nix` (or whatever else is listed),
+    // breaking the contract that dry-run accurately previews the release.
+    if let Ok(content) = std::fs::read_to_string(dir.join("fledge.toml")) {
+        if let Ok(parsed) = content.parse::<toml::Value>() {
+            if let Some(extras) = parsed
+                .get("release")
+                .and_then(|r| r.get("files"))
+                .and_then(|f| f.as_array())
+            {
+                // Same regex `bump_version_files` uses for extras — reporting
+                // only files that actually have a parseable version line keeps
+                // dry-run honest.
+                let re = Regex::new(r#"(?m)(version\s*[=:]\s*["']?)(\d+\.\d+\.\d+)"#).unwrap();
+                for entry in extras {
+                    let Some(name) = entry.as_str() else { continue };
+                    if files.iter().any(|f| f == name) {
+                        continue;
+                    }
+                    let path = dir.join(name);
+                    if !path.exists() {
+                        continue;
+                    }
+                    if let Ok(file_content) = std::fs::read_to_string(&path) {
+                        if re.is_match(&file_content) {
+                            files.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    files
 }
 
 pub(super) fn bump_version_files(dir: &Path, new_version: &Version) -> Result<BumpResult> {

--- a/src/release/tests.rs
+++ b/src/release/tests.rs
@@ -151,6 +151,81 @@ fn detect_version_files_multiple() {
 }
 
 #[test]
+fn detect_version_files_includes_release_files_extras() {
+    // Locks the dry-run-accuracy contract: the `--dry-run --json`
+    // `files_to_bump` array must match what a real release would write,
+    // including `[release].files` extras like `flake.nix`. Without this, the
+    // dry-run envelope lies — it reports only the language-detected files
+    // while a real run also bumps the extras.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("flake.nix"),
+        "{ pname = \"x\"; version = \"0.1.0\"; }\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[release]\nfiles = [\"flake.nix\"]\n",
+    )
+    .unwrap();
+
+    let files = bump::detect_version_files(tmp.path());
+    assert!(files.iter().any(|f| f == "Cargo.toml"));
+    assert!(
+        files.iter().any(|f| f == "flake.nix"),
+        "[release].files extras must show up in dry-run preview, got: {files:?}"
+    );
+}
+
+#[test]
+fn detect_version_files_skips_release_extras_without_version_line() {
+    // A `[release].files` entry that exists but has no parseable version line
+    // should NOT be reported by dry-run, because the real bumper wouldn't
+    // touch it either. This keeps dry-run honest about which files actually
+    // change.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(tmp.path().join("notes.txt"), "no version line here\n").unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[release]\nfiles = [\"notes.txt\"]\n",
+    )
+    .unwrap();
+
+    let files = bump::detect_version_files(tmp.path());
+    assert!(!files.iter().any(|f| f == "notes.txt"));
+}
+
+#[test]
+fn detect_version_files_skips_missing_release_extras() {
+    // A `[release].files` entry that doesn't exist on disk shouldn't be
+    // reported (it can't be bumped).
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("fledge.toml"),
+        "[release]\nfiles = [\"does-not-exist.nix\"]\n",
+    )
+    .unwrap();
+
+    let files = bump::detect_version_files(tmp.path());
+    assert!(!files.iter().any(|f| f == "does-not-exist.nix"));
+}
+
+#[test]
 fn classify_conventional_commits() {
     assert_eq!(
         changelog::classify_for_changelog("feat: add release"),


### PR DESCRIPTION
## Summary

Caught while running `fledge release major --dry-run --json` to prep the actual 1.0.0 release. The envelope reported:

```json
"files_to_bump": ["Cargo.toml"]
```

even though `[release].files = ["flake.nix"]` is set in `fledge.toml` and a real release would also write `flake.nix`. The discrepancy: `detect_version_files()` (dry-run preview path) only looked at hardcoded language candidates, while `bump_version_files()` (real write path) also processed `[release].files` from `fledge.toml`.

This is a v1 contract bug. The dry-run envelope is part of the release JSON contract (`schema_version: 1`). Agents reading it to predict a release would get wrong info, and shipping 1.0 with this baked in means fixing it later changes observable behavior — exactly the soft contract break we've been hunting all week.

## Fix

Mirror the bumper's `[release].files` logic in `detect_version_files`:
- Read `[release].files` from `fledge.toml`
- Skip entries already in the language-candidate list (no duplicates)
- Skip non-existent files (can't be bumped)
- Skip files with no parseable `version = "X.Y.Z"` line (the real bumper wouldn't touch them either)

### Verified on live binary

Before:
```json
"files_to_bump": ["Cargo.toml"]
```

After:
```json
"files_to_bump": ["Cargo.toml", "flake.nix"]
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo doc --no-deps` clean
- [x] `cargo test` — **893 passed, 0 failed, 1 ignored** (was 890, +3 new)
  - `detect_version_files_includes_release_files_extras`
  - `detect_version_files_skips_release_extras_without_version_line`
  - `detect_version_files_skips_missing_release_extras`
- [x] `fledge spec check` — 29 specs, 0 errors, 0 warnings (release spec → v5)
- [x] Live binary dry-run shows correct file list

🤖 Generated with [Claude Code](https://claude.com/claude-code)