### PR TITLE
docs: top up CHANGELOG Unreleased with #327–#330; fix release spec typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Compatibility Policies** locking the v1 contracts for templates, lanes, and the introspect schema, mirroring the existing `fledge-v1` plugin protocol policy (#324). Additive-only sections, no field removal/retyping, locked precedence rules, locked iteration order. Future `Step` variants in lanes must use unique discriminator keys; future templates manifest sections are tolerated as unknown fields.
 - **`[files] copy` glob** in template manifests (#324). Was documented and present in built-in templates but silently dropped at parse time. Now fully implemented with explicit precedence: `ignore` → `.tera` → `copy` → `render` → default-copy. A copy-matched file bypasses Tera even when a `render` glob would otherwise catch it.
-- **`--trust-hooks` flag** for `fledge templates init` (#326). Authorizes `post_create` hook execution from **remote** templates without an interactive prompt. Also settable via `FLEDGE_TRUST_HOOKS=1`. Local-template hooks are still gated by `--yes` (the user authored them); remote-template hooks need explicit hook-trust because they run arbitrary shell commands from a third-party source.
+- **`--trust-hooks` flag** for `fledge templates init` (#326). Authorizes `post_create` hook execution from **ad-hoc remote** templates (`--template owner/repo` not in config) without an interactive prompt. Also settable via `FLEDGE_TRUST_HOOKS=1`. Curated-path templates — built-ins, `templates.paths`, and configured `templates.repos` — still take `--yes` consent because the trust decision happened when the source was added to config (#327 sharpened the boundary documentation).
 - **Stderr secret redaction** (#326). `redact_secrets()` strips `Authorization:`, `x-access-token:`, `Bearer`, and credentialed URLs from raw subprocess stderr before it lands in user-facing error messages. Wired into `remote.rs` (the only authenticated-git site).
+- **`documentation` field in `Cargo.toml`** (#328) — crates.io now shows the GitHub Pages URL (`https://corvidlabs.github.io/fledge/`) alongside the existing repo and homepage links.
 
 ### Changed
 
 - **`fledge introspect --json`** now propagates inherited `global = true` flags down to every descendant subcommand's `args` array, marked `global: true` (#325). Previously, agents reading `plugins.list.args` saw an empty array even though `--json` (a `Plugins`-level global) and `--non-interactive` (a root-level global) both work there. Each node's `args` is now the complete set of flags accepted at that level. The wire format and `INTROSPECT_SCHEMA_VERSION` are unchanged — `global: true` was always part of the v1 shape; this fix uses it as intended. Child redeclaration of an inherited arg by name keeps the local copy (no duplicates).
+- **`introspect` `takes_value` field is now correct for value-taking flags** (#329). The previous probe (`arg.get_num_args().map(|n| n.takes_values()).unwrap_or(false)`) returned `None` for the vast majority of clap-derive args, so every `Option<String>`, `PathBuf`, and `Vec<String>` flag (e.g. `--template <TEMPLATE>`, `--scope <SCOPE>`, `--with-specs <NAMES>`) was wrongly reported as a boolean. `value_name` was suppressed by the dependent guard. Switched to positive-matching on `ArgAction::Set | Append` — boolean flags correctly stay `false`, value-takers correctly report `true` with their `value_name`. Wire format and `schema_version` unchanged. Caught by independent third-pass review pre-tag.
+- **`fledge release --dry-run --json` `files_to_bump` is now accurate** (#330). Previously the dry-run reported only language-detected candidates (e.g. `["Cargo.toml"]`) while the real release also processed `[release].files` from `fledge.toml` (e.g. `flake.nix`), so the preview lied about which files would change. The detection path now mirrors the bumper's logic.
 - **`prompts` iteration order in `template.toml`** is now alphabetical-by-key (#324). Was random across runs (`HashMap`); now `BTreeMap`. Multi-prompt templates ask questions in a stable order. Single-prompt templates are unaffected.
 
 ### Security
@@ -28,15 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- README, mdBook docs, AGENTS.md, CONTRIBUTING.md and module specs synchronized for 1.0.
+- **README, mdBook docs (`docs/src/`), AGENTS.md, CONTRIBUTING.md, and module specs** synchronized for 1.0 (#327). Highest-impact fixes: `[files]` precedence in `template-authoring.md` (was "first match wins / default renders" — both wrong), bundled-template count (6 → 8 with names listed), `FLEDGE_NON_INTERACTIVE` added to env vars table, Ship pillar `work` subcommands updated (`pr` removed, `commit`/`push` added), CONTRIBUTING.md release process replaced with `fledge release` workflow, CHANGELOG.md misplaced stale `[Unreleased]` block removed.
+- **Local vs Remote hook-consent boundary clarified** (#327 follow-up). The split is "how you reached the template", not "where its bytes live": curated path (built-ins, `templates.paths`, `templates.repos`) takes `--yes`; ad-hoc remote (`--template owner/repo` not in config) takes `--trust-hooks`.
+- **Three rustdoc warnings cleaned** (#328). Bracket pairs in clap doc comments (`provider[:model]`, `[Deprecated]`, `owner/repo[@ref]`) were misread as intra-doc-link syntax. Wrapped in backticks; `cargo doc` now produces zero warnings.
 
 ### Spec bumps
 
-- `templates` v7 → v8 (Compatibility Policy, locked precedence, prompt ordering)
-- `lanes` v19 → v20 (Compatibility Policy)
-- `introspect` v2 → v3 (invariant 5 flipped: globals propagate)
-- `init` v8 → v9 (`--trust-hooks` consent split)
-- `work` v11 → v12 (`--scope` validation)
+- `templates` v7 → v8 (Compatibility Policy, locked precedence, prompt ordering) — #324
+- `lanes` v19 → v20 (Compatibility Policy) — #324
+- `introspect` v2 → v3 (invariant 5 flipped: globals propagate) — #325
+- `introspect` v3 → v4 (`takes_value` now accurate for value-taking flags) — #329
+- `init` v8 → v9 (`--trust-hooks` consent split, `trust_hooks: bool` on `InitOptions`) — #326
+- `init` v9 → v10 (Local/Remote consent boundary documentation sharpening) — #327
+- `work` v11 → v12 (`--scope` validation) — #326
+- `release` v4 → v5 (dry-run `files_to_bump` accuracy) — #330
 
 ## [v0.17.0] - 2026-04-29
 

--- a/specs/release/release.spec.md
+++ b/specs/release/release.spec.md
@@ -62,8 +62,7 @@ Provides a unified release workflow: version bumping across language ecosystems,
 ```
 Given a Cargo.toml with version = "0.8.0"
 When fledge release patch
-Then Cargo.toml is updated to version = "0.9.0" (wait, patch)
-Actually: version = "0.8.1"
+Then Cargo.toml is updated to version = "0.8.1"
 And CHANGELOG.md is created/updated with commits since last tag
 And a commit "chore: release v0.8.1" is created
 And an annotated tag v0.8.1 is created


### PR DESCRIPTION
## Summary

Last polish pass before tagging 1.0.0.

### CHANGELOG.md `[Unreleased]` top-up

The Unreleased section was last refreshed in #327, before #328, #329, and #330 landed (#330 still open). Topping it up so the auto-generated v1.0.0 entry captures everything when `fledge release major` regenerates it.

Added entries for:
- **#327** doc accuracy sweep + Local/Remote consent boundary sharpening
- **#328** rustdoc cleanup + `documentation = "..."` URL on `Cargo.toml`
- **#329** introspect `takes_value` last-mile blocker (was returning `false` for every value-taking flag)
- **#330** release dry-run `files_to_bump` accuracy

Updated the Spec bumps list to match current state:
- `introspect` v3 → v4 (#329, on top of v2 → v3 from #325)
- `init` v9 → v10 (#327 follow-up consent boundary doc, on top of v8 → v9 from #326)
- `release` v4 → v5 (#330)

Each spec bump line now also cites the PR for traceability.

### Release spec typo fix

`specs/release/release.spec.md` "Bump patch version in Rust project" behavioral example had an embarrassing leftover edit:

```
Then Cargo.toml is updated to version = "0.9.0" (wait, patch)
Actually: version = "0.8.1"
```

Cleaned up to just the correct end state. No spec version bump for the typo fix — it doesn't change the documented contract; it cleans up a stale parenthetical that should have been resolved before commit.

### Stacking note

This PR is based on `main` (which doesn't yet have #330). When #330 merges first, this PR will show a conflict on the `release.spec.md` version-frontmatter line (#330 bumps it 4 → 5; my edit doesn't touch that line). Standard rebase resolves it.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 890 passed, 0 failed, 1 ignored (no test changes; same totals as main)
- [x] `fledge spec check` — 29 specs, 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)