### PR TITLE
fix: bump fledge-plugin-github default pin to v0.4.0

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -47,7 +47,7 @@ use run_plugin::{apply_protocol, resolve_plugin_source_dir, which_fledge_plugin}
 /// Every entry is pinned to a release tag (`owner/repo@vX.Y.Z`).
 /// Bump the tag here when adopting a new plugin release.
 pub const DEFAULT_PLUGINS: &[&str] = &[
-    "CorvidLabs/fledge-plugin-github@v0.2.1",
+    "CorvidLabs/fledge-plugin-github@v0.4.0",
     "CorvidLabs/fledge-plugin-deps@v0.1.0",
     "CorvidLabs/fledge-plugin-metrics@v0.2.0",
 ];


### PR DESCRIPTION
## Summary
- Bumps `DEFAULT_PLUGINS` pin for `fledge-plugin-github` from v0.2.1 to v0.4.0
- Users running `fledge plugins install --defaults` were getting a 2-version-old release, missing `issues create`, `prs create`, and `--ai` features

## Test plan
- [x] `cargo test` — all 23 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified v0.4.0 tag exists on `CorvidLabs/fledge-plugin-github`

🤖 Generated with [Claude Code](https://claude.com/claude-code)