### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1] - 2026-05-01
+
+### Features
+
+- `plugins update --defaults` upgrades pinned default plugins to their latest tag (#336) (8edec91)
+
+### Fixes
+
+- bump fledge-plugin-github default pin from v0.2.1 to v0.4.0 (#335) (d0dc190)
+
+### Chores
+
+- update Homebrew formula to v1.0.0 (#334) (8db460c)
+
 ## [v1.0.0] - 2026-05-01
 
 ### Chores

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.0.0";
+          version = "1.0.1";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 in Cargo.toml and flake.nix
- Add CHANGELOG entry for v1.0.1

### What's in 1.0.1
- **feat:** `plugins update --defaults` upgrades pinned default plugins to their latest tag (#336)
- **fix:** bump fledge-plugin-github default pin from v0.2.1 to v0.4.0 (#335)
- **chore:** update Homebrew formula to v1.0.0 (#334)

## Post-merge
After merging, tag `v1.0.1` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)