### PR TITLE
docs: add consolidated fledge.toml reference page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Scaffold: Templates](./templates.md)
   - [Template Authoring Guide](./template-authoring.md)
 - [Run: Tasks and Lanes](./lanes.md)
+  - [`fledge.toml` Reference](./fledge-toml.md)
 - [Spec: Spec-sync](./spec.md)
 - [AI: Ask and Review](./review.md)
 - [Ship: Branch, PR, Release](./ship.md)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -152,11 +152,13 @@ If neither env var nor config is set, fledge falls back to `gh auth token` (GitH
 
 ## Project Configuration (fledge.toml)
 
-Per-project settings live in `fledge.toml` in your project root. This file defines tasks, lanes, and project metadata. It's created by `fledge run --init` or `fledge templates init`.
+Per-project settings live in `fledge.toml` in your project root. This file defines tasks, lanes, and release behavior. It's created by `fledge run --init`, `fledge lanes init`, or `fledge templates init`.
 
-For task and lane configuration, see:
-- [Run: Tasks and Lanes](./lanes.md) — defining lanes, step types, parallel groups, importing community lanes
-- [Extend: Plugins](./plugins.md) — extending fledge with community plugins
+For the full schema (every section, every key, every default), see the [`fledge.toml` Reference](./fledge-toml.md).
+
+Topical guides:
+- [Run: Tasks and Lanes](./lanes.md) — defining tasks/lanes, step types, parallel groups, importing community lanes
+- [Extend: Plugins](./plugins.md) — `plugin.toml` and the plugin ecosystem
 
 ## Priority Order
 

--- a/docs/src/fledge-toml.md
+++ b/docs/src/fledge-toml.md
@@ -1,0 +1,320 @@
+# `fledge.toml` Reference
+
+`fledge.toml` lives in your project root and defines tasks, lanes, and release behavior. It's read by `fledge run`, `fledge lanes`, `fledge release`, and `fledge watch`. Plugins with the `metadata` capability can read it through the `fledge_config` metadata key.
+
+If no `fledge.toml` exists, `fledge run` falls back to language-aware auto-detection. As soon as the file exists, it takes full precedence — there is no merging with auto-detection.
+
+For plugin manifests (`plugin.toml`), see [Extend: Plugins](./plugins.md). For global user config (`~/.config/fledge/config.toml`), see [Configuration](./configuration.md).
+
+## Creating it
+
+```bash
+fledge run --init                  # starter file with detected tasks
+fledge lanes init                  # adds default lanes for your stack
+fledge templates init my-app       # included in scaffolded projects
+```
+
+## File layout at a glance
+
+```toml
+schema_version = 1                  # optional, currently unused
+
+[tasks]                             # individual commands you can run
+build = "cargo build"
+
+[tasks.test]                        # full form
+cmd = "cargo test"
+description = "Run the test suite"
+deps = ["build"]
+env = { RUST_LOG = "debug" }
+dir = "."
+
+[lanes.ci]                          # named pipelines that chain tasks
+description = "Full CI pipeline"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+  "build",
+]
+fail_fast = true
+
+[release]                           # extra files to bump on `fledge release`
+files = ["flake.nix"]
+```
+
+That's the entire schema. Everything else on this page expands one of these sections.
+
+## `[tasks]`
+
+Tasks are the building blocks. Lanes reference them by name, and you run them directly with `fledge run <name>`.
+
+### Short form
+
+A bare command string:
+
+```toml
+[tasks]
+build = "cargo build"
+test = "cargo test"
+lint = "cargo clippy --all-targets -- -D warnings"
+```
+
+Short-form tasks have no description, no deps, no env, no working directory.
+
+### Full form
+
+A table when you need more than a command:
+
+```toml
+[tasks.deploy]
+cmd = "cargo install --path ."
+description = "Build and install locally"
+deps = ["test"]
+env = { RUST_LOG = "info" }
+dir = "crates/cli"
+```
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `cmd` | string | yes | — | Shell command. Run via `sh -c` (Unix) or `cmd /C` (Windows). |
+| `description` | string | no | (uses `cmd`) | Shown by `fledge run --list`. |
+| `deps` | array of strings | no | `[]` | Tasks to run first. Resolved recursively. Cycles are detected and rejected. |
+| `env` | table | no | `{}` | Environment variables set for the task's process. |
+| `dir` | string | no | project root | Working directory, relative to the project root. |
+
+### Mixing forms
+
+You can mix short and full in the same file:
+
+```toml
+[tasks]
+build = "cargo build"
+fmt = "cargo fmt"
+
+[tasks.ci]
+cmd = "cargo test --workspace"
+description = "Full workspace test"
+deps = ["fmt", "build"]
+```
+
+## `[lanes]`
+
+Lanes chain tasks (and inline commands) into named pipelines. Run with `fledge lanes run <name>`.
+
+```toml
+[lanes.ci]
+description = "Full CI pipeline"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+  "build",
+]
+fail_fast = true
+```
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `description` | string | no | `"(no description)"` | Shown by `fledge lanes list`. |
+| `steps` | array | yes | — | Ordered steps. At least one is required. |
+| `fail_fast` | bool | no | `true` | If `false`, every step runs even after failures and a summary is reported at the end. |
+
+### Step types
+
+A step can be one of three shapes. Mix them freely.
+
+#### Task reference
+
+Just a string naming a task in `[tasks]`:
+
+```toml
+steps = ["lint", "test", "build"]
+```
+
+Task `deps` resolve automatically before the step runs.
+
+#### Inline command
+
+A one-off shell command without cluttering `[tasks]`:
+
+```toml
+steps = [
+  "test",
+  { run = "cargo build --release" },
+  { run = "tar -czf release.tar.gz -C target/release my-app" },
+]
+```
+
+#### Parallel group
+
+Items inside a `parallel` array run concurrently. The lane waits for all of them before the next step:
+
+```toml
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+]
+```
+
+Items in a parallel group can be task references or inline commands:
+
+```toml
+steps = [
+  { parallel = [
+      "lint",
+      { run = "cargo audit" },
+      "fmt",
+  ] },
+  "test",
+]
+```
+
+Parallel groups cannot be nested.
+
+### `fail_fast`
+
+```toml
+[lanes.audit]
+description = "Run everything, report all failures"
+fail_fast = false
+steps = ["lint", "test", "audit"]
+```
+
+| Value | Behavior |
+|-------|----------|
+| `true` (default) | Stop at the first failed step. |
+| `false` | Run every step; print a final report listing every failure. |
+
+Use `fail_fast = false` for "give me the full picture" lanes (audit, broad checks). Keep `true` for CI gates where there's no point continuing after a break.
+
+## `[release]`
+
+Controls additional files that `fledge release` bumps alongside the language's standard manifest (`Cargo.toml`, `package.json`, `pyproject.toml`, `pom.xml`, `build.gradle`, `setup.cfg`, or `plugin.toml`).
+
+```toml
+[release]
+files = ["flake.nix", "docs/install.md"]
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `files` | array of strings | `[]` | Extra files whose `version "X.Y.Z"` line should be rewritten on release. Paths are relative to the project root and may not escape it. |
+
+The bumper looks for the regex `version\s*[=:]\s*["']?(\d+\.\d+\.\d+)` and rewrites the matched version. Files without a matching line are silently skipped.
+
+`fledge release --dry-run` reports the same set of files the real run would bump, including these extras.
+
+> **Heads-up for plugin authors:** Don't list `Formula/*.rb` (Homebrew formulae) here. Formulae need a fresh `sha256` per release that doesn't exist until release artifacts are uploaded; bump them in a follow-up workflow instead.
+
+## `schema_version`
+
+```toml
+schema_version = 1
+```
+
+Currently parsed but unused. Reserved for future breaking-change migrations. Safe to omit.
+
+## Imported lanes (`.fledge/lanes/*.toml`)
+
+`fledge lanes import <source>` writes imported lane definitions to `.fledge/lanes/<source>.toml`. These files are auto-loaded by `fledge lanes run` after your top-level `fledge.toml`. Your local definitions win on name collisions.
+
+Each imported file has the same shape as `fledge.toml` but typically contains only `[tasks]` and `[lanes]` from the upstream source:
+
+```toml
+# Imported from CorvidLabs/fledge-lanes/rust@v1.0.0
+
+[tasks]
+fmt-check = "cargo fmt --check"
+
+[lanes.rust-ci]
+description = "Rust CI from CorvidLabs/fledge-lanes"
+steps = ["fmt-check", "lint", "test", "build"]
+```
+
+The leading `# Imported from <source>` comment is parsed and used to display the lane's trust tier in `fledge lanes list`.
+
+## Full worked example
+
+A real-world Rust project mixing every section:
+
+```toml
+# fledge.toml — example project
+
+schema_version = 1
+
+[tasks]
+build       = "cargo build"
+test        = "cargo test"
+lint        = "cargo clippy --all-targets -- -D warnings"
+fmt         = "cargo fmt --check"
+fmt-fix     = "cargo fmt"
+audit       = "cargo audit"
+
+[tasks.docs-serve]
+cmd = "mdbook serve docs --open"
+description = "Serve docs locally with live reload"
+
+[tasks.deploy]
+cmd = "scripts/deploy.sh"
+description = "Deploy the API"
+deps = ["test", "build"]
+env = { DEPLOY_TARGET = "staging" }
+dir = "."
+
+[lanes.check]
+description = "Quick pre-commit check"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+]
+
+[lanes.ci]
+description = "Full CI pipeline"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  "test",
+  "build",
+]
+
+[lanes.audit]
+description = "Every quality check, report all failures"
+fail_fast = false
+steps = ["fmt", "lint", "test", "audit"]
+
+[lanes.release]
+description = "Pre-release validation"
+steps = ["fmt", "lint", "test", "build", "audit"]
+
+[release]
+files = ["flake.nix"]
+```
+
+## Validating
+
+| Command | What it checks |
+|---------|---------------|
+| `fledge lanes validate` | Lane references resolve, no dependency cycles, lane structure is well-formed. |
+| `fledge lanes validate --strict` | Treats warnings as errors. Useful in CI. |
+| `fledge lanes validate --json` | Machine-readable report. |
+| `fledge run --list` | Parses `[tasks]` and shows everything fledge can see. |
+| `fledge lanes list` | Parses `[lanes]` and shows every lane plus its source (local vs. imported). |
+
+A parse failure on any section bails with a context-rich error pointing at the offending TOML.
+
+## Behavior reference
+
+A few subtle but documented behaviors worth knowing:
+
+- **Project precedence.** If `fledge.toml` exists, auto-detection is fully disabled — fledge uses only what's in the file.
+- **Empty `[tasks]` is an error.** `fledge run` bails with a "no tasks defined" message rather than silently running nothing.
+- **Empty `[lanes]` is an error for `fledge lanes run`.** The error tells you to add lanes, import them, or run `fledge lanes init`.
+- **Unknown fields are ignored.** TOML keys not in the schema are silently accepted (forward-compatible) but have no effect.
+- **`description` is optional everywhere.** Tasks fall back to showing `cmd`, lanes fall back to `(no description)`.
+- **Working directories cannot escape the project.** Both `dir` (in tasks) and `[release].files` paths are canonicalized and rejected if they resolve outside the project root.
+
+## Related
+
+- [Run: Tasks and Lanes](./lanes.md) — workflow walkthrough, auto-detection, watch mode
+- [Configuration](./configuration.md) — global `~/.config/fledge/config.toml`
+- [Extend: Plugins](./plugins.md) — `plugin.toml` reference and ecosystem
+- [Plugin Protocol Spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md) — `fledge-v1` JSON wire protocol
+- [CLI Reference](./cli-reference.md) — every subcommand and flag

--- a/docs/src/fledge-toml.md
+++ b/docs/src/fledge-toml.md
@@ -215,7 +215,7 @@ Currently parsed but unused. Reserved for future breaking-change migrations. Saf
 
 ## Imported lanes (`.fledge/lanes/*.toml`)
 
-`fledge lanes import <source>` writes imported lane definitions to `.fledge/lanes/<source>.toml`. These files are auto-loaded by `fledge lanes run` after your top-level `fledge.toml`. Your local definitions win on name collisions.
+`fledge lanes import <source>` writes imported lane definitions to a generated file under `.fledge/lanes/`. The filename is derived from the source ref as `<owner>-<repo>[-<subpath>].toml` (lowercased, with `/` in subpaths replaced by `-`) — for example, `fledge lanes import CorvidLabs/fledge-lanes/rust` writes to `.fledge/lanes/corvidlabs-fledge-lanes-rust.toml`. These files are auto-loaded by `fledge lanes run` after your top-level `fledge.toml`. Your local definitions win on name collisions.
 
 Each imported file has the same shape as `fledge.toml` but typically contains only `[tasks]` and `[lanes]` from the upstream source:
 
@@ -309,7 +309,7 @@ A few subtle but documented behaviors worth knowing:
 - **Empty `[lanes]` is an error for `fledge lanes run`.** The error tells you to add lanes, import them, or run `fledge lanes init`.
 - **Unknown fields are ignored.** TOML keys not in the schema are silently accepted (forward-compatible) but have no effect.
 - **`description` is optional everywhere.** Tasks fall back to showing `cmd`, lanes fall back to `(no description)`.
-- **Working directories cannot escape the project.** Both `dir` (in tasks) and `[release].files` paths are canonicalized and rejected if they resolve outside the project root.
+- **Path handling differs by field.** Task `dir` is joined to the project root as configured and is *not* currently canonicalized — values like `"../sibling"` are accepted and will resolve outside the project. `[release].files` paths *are* canonicalized and rejected if they escape the project root.
 
 ## Related
 

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -339,6 +339,7 @@ fledge lanes import CorvidLabs/fledge-lanes@v1.0.0
 
 ### Related
 
+- [`fledge.toml` Reference](./fledge-toml.md) — full schema for tasks, lanes, release, and imported lanes
 - [Configuration](./configuration.md) — global config, GitHub tokens
 - [Extend: Plugins](./plugins.md) — community commands, use plugins in lanes
 - [CLI Reference](./cli-reference.md) — full `fledge lanes` subcommand reference

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -175,8 +175,9 @@ fledge plugins install yourname/fledge-deploy
 |-------|------|----------|-|
 | `name` | string | Yes | Plugin name |
 | `version` | string | Yes | Semver |
-| `description` | string | No | Short description |
+| `description` | string | No | Short description (warned about if missing on `validate`) |
 | `author` | string | No | Who made it |
+| `protocol` | string | No | Set to `"fledge-v1"` to opt into the [structured plugin protocol](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md). Without it, the plugin runs with inherited stdio. |
 
 ### [[commands]]
 
@@ -257,21 +258,29 @@ See [Run: Tasks and Lanes](./lanes.md) for full step type documentation.
 
 ## Plugin Protocol (fledge-v1)
 
-Plugins that declare capabilities communicate with fledge via a JSON-over-stdin/stdout protocol. When a plugin starts, fledge sends an `init` message with the plugin's granted capabilities, then the plugin sends requests and fledge responds.
+Plugins that opt into the protocol (`protocol = "fledge-v1"` in `[plugin]`) communicate with fledge via newline-delimited JSON over stdin/stdout. When a plugin starts, fledge sends an `init` message with project context and granted capabilities, then the plugin sends outbound messages and fledge replies to anything that includes an `id`.
 
-### Message Types
+### Message types at a glance
 
-| Plugin sends | Fledge responds with | Requires |
-|-------------|---------------------|----------|
-| `exec` | `exec_result` (stdout, stderr, exit code) | `exec` capability |
-| `store` | `store_ack` | `store` capability |
-| `load` | `load_result` (value or null) | `store` capability |
-| `metadata` | `metadata_result` (project info) | `metadata` capability |
-| `log` | *(no response)* | *(always allowed)* |
-| `progress` | *(no response)* | *(always allowed)* |
-| `output` | *(terminates plugin)* | *(always allowed)* |
+Outbound (plugin → fledge):
 
-See the [plugin protocol spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md) for full details.
+| Type | Reply | Requires |
+|------|-------|----------|
+| `prompt` | `response` with string | — |
+| `confirm` | `response` with boolean | — |
+| `select` | `response` with selected string | — |
+| `multi_select` | `response` with array of strings | — |
+| `exec` | `response` with `{code, stdout, stderr}` | `exec` |
+| `store` | *(fire-and-forget)* | `store` |
+| `load` | `response` with string or `null` | `store` |
+| `metadata` | `response` with object of requested keys | `metadata` |
+| `progress` | *(fire-and-forget)* | — |
+| `log` | *(fire-and-forget; level: debug/info/warn/error)* | — |
+| `output` | *(fire-and-forget; printed verbatim to stdout)* | — |
+
+Reply messages always have shape `{"type": "response", "id": "<echoed>", "value": <type-specific>}`. There is no `exec_result` / `store_ack` / `load_result` envelope — every reply uses the generic `response` type.
+
+See the [plugin protocol spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md) for full schemas, lifecycle, security model, and worked examples.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
The full schema for `fledge.toml` was scattered: a brief mention in `configuration.md`, tasks/lanes in `lanes.md`, and the `[release].files` key wasn't documented anywhere. This PR adds a single canonical reference and corrects some drift in `plugins.md`.

- **New** `docs/src/fledge-toml.md` — every section (`[tasks]`, `[lanes]`, `[release]`, `schema_version`, imported `.fledge/lanes/*.toml`), every key with type/default/notes, behavior reference, full worked example, and validation commands.
- `SUMMARY.md` — wire the new page into the TOC under "Run: Tasks and Lanes".
- `configuration.md` — replace the thin "see lanes.md and plugins.md" stub with a link to the new ref.
- `lanes.md` — cross-link in the Related section.
- `plugins.md` — two corrections grounded in `src/plugin/mod.rs` and `src/protocol/mod.rs`:
  - Document the previously-missing `protocol` field on `[plugin]` (the `"fledge-v1"` opt-in).
  - Replace the inaccurate "Message Types" table. The old table claimed `exec_result` / `store_ack` / `load_result` / `metadata_result` envelopes that don't exist in the source — the protocol uses a generic `response` with an echoed `id` for everything. It also said `output` "terminates plugin", but `output` is fire-and-forget and just prints the text. The new table matches `OutboundMessage` and the dispatch in `run_message_loop`.

## Why
- Authors writing `fledge.toml` had to read three pages and a source struct to learn the schema.
- The `[release].files` key was undocumented but is real — `fledge release` reads it, and `release --dry-run` reports against it.
- Plugin authors looking at the message-types table got incorrect reply shapes, which would not match the actual wire protocol.

## Notes
- Audit-grounded: I read `src/run.rs` (`TaskConfig`), `src/lanes/mod.rs` (`LaneDef`, `Step`, `ParallelItem`), `src/release/bump.rs` (`[release]` parsing and the canonicalization invariant), `src/plugin/mod.rs` (`PluginManifest`), and `src/protocol/mod.rs` (`OutboundMessage`).
- Links to the existing canonical `specs/plugin/plugin-protocol.spec.md` for protocol details rather than introducing a new `plugin-protocol.md` page.
- Imported-lanes section documents `.fledge/lanes/*.toml` auto-load behavior I found in `src/lanes/mod.rs::load_lane_config`.

## Test plan
- [ ] `mdbook build docs` succeeds (couldn't run locally — `mdbook` not installed in my sandbox)
- [ ] mdbook navigation shows the new page under "Run: Tasks and Lanes"
- [ ] Confirm cross-links from `configuration.md`, `lanes.md`, and the new page all resolve
- [ ] Spot-check the worked example parses with `cargo run -- lanes validate` against a fixture project

🤖 Generated with [Claude Code](https://claude.com/claude-code)