### PR TITLE
fix(protocol): handle store errors gracefully

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -308,7 +308,14 @@ fn run_message_loop(
                 if !capabilities.store {
                     continue;
                 }
-                store::handle_store(plugin_dir, &key, &value)?;
+                if let Err(e) = store::handle_store(plugin_dir, &key, &value) {
+                    eprintln!(
+                        "  {} [{}] store rejected: {}",
+                        console::style("⚠️").yellow(),
+                        plugin_name,
+                        e
+                    );
+                }
             }
             OutboundMessage::Load { id, key } => {
                 if !capabilities.store {


### PR DESCRIPTION
## Summary
- Store validation errors (oversized keys/values, key count limits) were terminating the entire protocol session via `?` propagation
- This made it impossible for plugins to test or gracefully handle store boundary rejections
- Now logs a warning and continues the session, letting the plugin complete its run

Found while debugging why `fledge-plugin-canary`'s store boundary tests appeared broken — the fix in the canary plugin was correct but fledge was killing the session before it could run.

## Test plan
- [x] `cargo test` — all 80 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `fledge plugins update canary && fledge canary` should complete store boundary tests without raw errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)