### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.2] - 2026-05-02
+
+### Chores
+
+- update Homebrew formula to v1.0.1 (#338) (a607810)
+
+### Documentation
+
+- add consolidated fledge.toml reference page (#340) (45663ba)
+
+### Fixes
+
+- handle store errors gracefully instead of terminating session (#341) (2100d50)
+
+### Other
+
+- Update README.md (#339) (351b163)
+
 ## [v1.0.1] - 2026-05-01
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- skip gitignored files when staging release commit (#342) (7c8eadf)
 - handle store errors gracefully instead of terminating session (#341) (2100d50)
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.0.1";
+          version = "1.0.2";
           src = self;
 
           cargoLock = {

--- a/src/release/git.rs
+++ b/src/release/git.rs
@@ -17,6 +17,22 @@ pub(super) fn create_release_commit(
         files_to_add.push("CHANGELOG.md".to_string());
     }
 
+    // Filter out gitignored files to avoid staging failures (e.g. Cargo.lock)
+    let ignored = Command::new("git")
+        .arg("check-ignore")
+        .args(&files_to_add)
+        .current_dir(dir)
+        .output()
+        .ok()
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    files_to_add.retain(|f| !ignored.contains(f));
+
     if !files_to_add.is_empty() {
         let mut cmd = Command::new("git");
         cmd.arg("add").current_dir(dir);


### PR DESCRIPTION
## Summary
- Bump version to 1.0.2 (Cargo.toml, flake.nix)
- Update CHANGELOG.md

Patch release for the protocol store error handling fix (#341).