### PR TITLE
docs: add WASM plugin documentation to README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,18 @@ fledge ai status                               # show active provider/model and 
 
 That is the whole core. Anything else is a plugin.
 
-## Default plugins
+## Plugins
 
-Three plugins extend fledge with commands that don't belong in every install. One line installs them all:
+Plugins extend fledge with community-built commands. Native plugins run as regular executables; **WASM plugins** run in a sandboxed Wasmtime runtime with no host access by default.
 
 ```bash
-fledge plugins install --defaults
+fledge plugins install --defaults          # curated native plugin set
+fledge plugins create my-lint --wasm       # scaffold a sandboxed WASM plugin
 ```
+
+### Default plugins
+
+Three native plugins ship as the default set:
 
 | Plugin | Adds |
 |--------|------|
@@ -91,7 +96,17 @@ fledge plugins install --defaults
 | [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) | `deps` — polyglot lockfile audits |
 | [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics` — LOC, churn, test/source ratio (via `tokei` + `git`) |
 
-Not every fledge user is on GitHub or runs a polyglot project. The core stays tight, you opt in to what you need.
+### WASM plugins
+
+WASM plugins are ideal for pure-computation tasks (linting, formatting, analysis) where you want strong isolation without trusting arbitrary binaries:
+
+- Sandboxed by default — no filesystem, no network
+- Opt-in capabilities prompted at install time
+- Fuel-bounded execution (no infinite loops)
+- 256 MB memory cap
+- Cross-platform single `.wasm` binary
+
+See the [WASM plugin guide](https://corvidlabs.github.io/fledge/wasm-plugins.html) for authoring details.
 
 ## Built-in templates
 
@@ -111,6 +126,7 @@ Browse community templates: `fledge templates search <keyword>`
 - [Template authoring](https://corvidlabs.github.io/fledge/template-authoring.html). How to create and publish your own templates
 - [Lanes guide](https://corvidlabs.github.io/fledge/lanes.html). Task pipelines and workflow automation
 - [Plugins guide](https://corvidlabs.github.io/fledge/plugins.html). Extend fledge with community tools
+- [WASM plugins](https://corvidlabs.github.io/fledge/wasm-plugins.html). Build sandboxed plugins with Wasmtime
 
 ## Contributing
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Ship: Branch, PR, Release](./ship.md)
   - [GitHub Integration (plugin)](./github-integration.md)
 - [Extend: Plugins, Config, Tools](./plugins.md)
+  - [WASM Plugins](./wasm-plugins.md)
   - [Configuration](./configuration.md)
   - [Doctor: Environment Diagnostics](./doctor.md)
 - [Reference](./reference.md)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -31,6 +31,8 @@ fledge plugins install --defaults
 
 That gets you `checks`/`issues`/`prs` (GitHub), `deps`, and `metrics`. See [Extend: Plugins](./plugins.md) for the full list and how to build your own.
 
+Plugins can also be **WASM modules** — sandboxed, cross-platform, and secure by default. WASM plugins run in a Wasmtime runtime with no host access unless explicitly granted. Great for community plugins where you don't want to trust arbitrary native code. See [WASM Plugins](./wasm-plugins.md) for the authoring guide.
+
 ## Zero-config
 
 It auto-detects your project type (Rust, Node, Go, Python, Ruby, Java, Swift) and generates sensible defaults. You don't need `fledge templates init` to get started, just `cd` into any existing project and run `fledge run test`. It works with zero config. When you want more control, `fledge run --init` generates a `fledge.toml` tailored to your stack.

--- a/docs/src/wasm-plugins.md
+++ b/docs/src/wasm-plugins.md
@@ -1,0 +1,157 @@
+# WASM Plugins
+
+WASM plugins run in a sandboxed [Wasmtime](https://wasmtime.dev/) runtime with no host access by default. They're ideal for pure-computation tasks — linting, formatting, analysis, code generation — where you want strong isolation without trusting arbitrary native binaries.
+
+## Quick start
+
+```bash
+fledge plugins create fledge-my-lint --wasm
+cd fledge-my-lint
+cargo build --target wasm32-wasip1 --release
+fledge plugins validate
+```
+
+## How it works
+
+When fledge runs a WASM plugin:
+
+1. The `.wasm` binary is compiled to native code and cached as `.cwasm` (version-stamped, invalidated on Wasmtime upgrades)
+2. A Wasmtime instance is created with the declared capabilities
+3. The plugin communicates via the same [fledge-v1 protocol](./plugins.md#plugin-protocol-fledge-v1) as native plugins — JSON messages over host-provided `send`/`recv` functions
+4. Execution is bounded by fuel (CPU) and a 60-second wall-clock timeout
+5. Memory is capped at 256 MB
+
+## Capabilities
+
+WASM plugins declare capabilities in `plugin.toml`. All default to denied.
+
+| Capability | Values | Effect |
+|------------|--------|--------|
+| `exec` | `true`/`false` | Execute shell commands on the host |
+| `store` | `true`/`false` | Persist key-value data between runs |
+| `metadata` | `true`/`false` | Read project metadata (language, name, git info) |
+| `filesystem` | `"none"`, `"project"`, `"plugin"` | `"project"` mounts project root read-only. `"plugin"` adds a read-write plugin directory. |
+| `network` | `true`/`false` | Inherit the host network stack |
+
+Users are prompted to approve capabilities at install time. Denied capabilities fail gracefully at runtime — no crashes.
+
+## plugin.toml for WASM
+
+```toml
+[plugin]
+name = "fledge-my-lint"
+version = "0.1.0"
+description = "Custom linting rules"
+protocol = "fledge-v1"
+runtime = "wasm"
+
+[[commands]]
+name = "my-lint"
+description = "Run custom lint rules"
+binary = "target/wasm32-wasip1/release/fledge-my-lint.wasm"
+
+[hooks]
+build = "cargo build --target wasm32-wasip1 --release"
+
+[capabilities]
+filesystem = "project"
+network = false
+```
+
+The key differences from native plugins:
+- `runtime = "wasm"` tells fledge to use the Wasmtime sandbox
+- `binary` points to a `.wasm` file instead of a native executable
+- `filesystem` and `network` are WASM-specific capability fields
+
+## Writing a WASM plugin in Rust
+
+The scaffold (`fledge plugins create --wasm`) generates a working starter. The core pattern:
+
+```rust
+#[link(wasm_import_module = "fledge")]
+extern "C" {
+    fn send(ptr: *const u8, len: u32) -> i32;
+    fn recv(ptr: *mut u8, len: u32) -> i32;
+}
+
+fn send_message(msg: &str) {
+    let bytes = msg.as_bytes();
+    unsafe { send(bytes.as_ptr(), bytes.len() as u32) };
+}
+
+fn recv_message(buf: &mut [u8]) -> Option<&str> {
+    let n = unsafe { recv(buf.as_mut_ptr(), buf.len() as u32) };
+    if n <= 0 { return None; }
+    std::str::from_utf8(&buf[..n as usize]).ok()
+}
+
+fn main() {
+    // Read init message
+    let mut buf = vec![0u8; 65536];
+    let init = recv_message(&mut buf);
+
+    // Do your work...
+
+    // Send output
+    send_message(r#"{"type":"output","data":"Lint passed!"}"#);
+}
+```
+
+## Building
+
+```bash
+# One-time setup
+rustup target add wasm32-wasip1
+
+# Build
+cargo build --target wasm32-wasip1 --release
+```
+
+The `[hooks] build` field in `plugin.toml` runs this automatically during `fledge plugins install`.
+
+## Testing locally
+
+```bash
+# Validate manifest and binary
+fledge plugins validate
+
+# Install from local directory (push to GitHub first, or copy manually)
+cp -r . ~/Library/Application\ Support/fledge/plugins/fledge-my-lint/
+
+# Run it
+fledge plugins run my-lint
+```
+
+## Resource limits
+
+| Resource | Limit | Behavior on exceed |
+|----------|-------|--------------------|
+| CPU | Fuel-bounded | Plugin traps, host continues |
+| Wall clock | 60 seconds | Plugin traps, host continues |
+| Memory | 256 MB | Allocation fails, plugin traps |
+| Stack | Wasmtime default | Plugin traps on overflow |
+
+All limits result in a clean trap — the host process never crashes or enters an invalid state.
+
+## When to use WASM vs native
+
+| Use WASM when... | Use native when... |
+|---|---|
+| Pure computation over project files | Need to shell out to external tools |
+| Untrusted or community plugins | Need unrestricted filesystem access |
+| Cross-platform distribution (single binary) | Need pipes, redirects, or shell features |
+| You want capability enforcement | Performance-critical host integrations |
+
+## Security model
+
+- **No ambient authority**: WASM plugins start with zero access. Every capability is opt-in and user-approved.
+- **Memory isolation**: Guest memory is separate from host memory. Out-of-bounds access traps the plugin.
+- **Deterministic execution**: Same inputs produce same outputs (no access to system clock, random, etc. unless granted).
+- **Cache integrity**: Compiled `.cwasm` files are SHA-256 verified and version-stamped. Corruption or Wasmtime version mismatch triggers recompilation.
+
+## Limitations
+
+- No interactive UI (prompt/confirm/select) — WASM plugins must use non-interactive output
+- No direct access to environment variables or the host filesystem beyond declared mounts
+- Build requires the `wasm32-wasip1` target (`rustup target add wasm32-wasip1`)
+- Currently Rust-only for the scaffold; any language that compiles to WASI works in practice


### PR DESCRIPTION
## Summary

- README now has a dedicated "Plugins" section highlighting both native and WASM plugins
- Added `docs/src/wasm-plugins.md` — a full authoring guide covering capabilities, resource limits, security model, and when to use WASM vs native
- Updated introduction.md to mention WASM plugins in the plugin layer section
- Added WASM Plugins page to docs SUMMARY.md navigation

Follows the WASM plugin runtime merge (#345). GitHub Pages will pick this up on next deploy.

## Test plan

- [x] `mdbook build docs/` succeeds
- [x] `cargo clippy -- -D warnings` clean
- [x] All internal links resolve (verified via mdbook build)
- [ ] Visual check on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)