### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0] - 2026-05-02
+
+### Features
+
+- **WASM plugin runtime** — sandboxed plugins compiled to WebAssembly (#345)
+  - Capability-scoped permissions (network, filesystem, store)
+  - Fuel-bounded execution with configurable limits
+  - Cross-platform (any language that targets wasm32-wasip1)
+  - Precompiled module caching for fast startup
+  - Full fledge-v1 protocol support (output, log, progress, store)
+
+### Documentation
+
+- Add WASM plugin documentation to README and GitHub Pages (#346)
+- Fix plugin security model, storage paths, and spec accuracy (#344)
+
+### Chores
+
+- Update Homebrew formula to v1.0.2 (#343)
+
 ## [v1.0.2] - 2026-05-02
 
 ### Chores

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.0.2";
+          version = "1.1.0";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary

- Bump version to **1.1.0** across `Cargo.toml` and `flake.nix`
- Add CHANGELOG.md entry for v1.1.0

## What's in this release

**WASM plugin runtime** (#345) — the headline feature:
- Sandboxed plugin execution via WebAssembly
- Capability-scoped permissions (network, filesystem, store)
- Fuel-bounded execution with configurable limits
- Cross-platform (any language targeting wasm32-wasip1)
- Precompiled module caching
- Full fledge-v1 protocol support

**Documentation** (#344, #346):
- WASM plugin authoring guide on docs site
- README updated with plugin section
- Security model and storage path fixes

## Verification

| Check | Result |
|-------|--------|
| `cargo fmt --check` | Clean |
| `cargo clippy -- -D warnings` | Clean |
| `cargo test` | **945 pass**, 0 fail |
| `fledge spec check` | 30 specs, 0 errors |

## Post-merge

After merging this PR:
1. Tag `v1.1.0` and push tag
2. CI builds release binaries
3. Post-release workflow updates Homebrew formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)