### PR TITLE
docs: strip em-dashes and tighten voice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 
 | Command | What you get | Use when |
 |---------|-------------|----------|
-| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args: [...], subcommands: [...]}`. Each subcommand recursively has the same shape; each arg has `name, long?, short?, aliases, help, required, takes_value, value_name, global?`. Each node's `args` is the **complete set of flags accepted at that level**, including inherited globals from ancestors (marked `global: true`) — no need to walk up the parent chain | First contact with fledge |
+| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args: [...], subcommands: [...]}`. Each subcommand recursively has the same shape; each arg has `name, long?, short?, aliases, help, required, takes_value, value_name, global?`. Each node's `args` is the **complete set of flags accepted at that level**, including inherited globals from ancestors (marked `global: true`). No need to walk up the parent chain | First contact with fledge |
 | `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [{name, version, status, sections, companions, ...}]}` | Orienting to a new codebase |
 | `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {name, version, status, sections, companions, ...}}` | Need structured view of one module |
 | `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs: [...], totals, strict}` | Spec-sync validation as data |
@@ -113,9 +113,9 @@ Commands **without** `--json` (pretty output only): `spec init`, `spec new`, `wa
 - Pillar list/query commands (`plugins list`, `lanes list/run/search`, `templates list/search`) use `{schema_version: 1, <resource>: [...]}`. The resource key (`plugins`, `lanes`, `results`, `templates`) acts as the discriminator.
 - Cross-cutting commands (`doctor`, `run`, `ai`, `ask`, `changelog`, `work`, `spec`, `review`) use `{schema_version: 1, action: "<verb>", ...}`. The `action` string discriminates between commands sharing similar shapes.
 
-Top-level `schema_version` is the version contract, **scoped per command**. Each `--json`-emitting command has its own version that bumps only when *that command's* shape changes incompatibly. Two commands both emitting `schema_version: 1` does not mean their shapes are linked — they're tracked independently. New fields are additive within a given command's version; field removal/retyping bumps that command's version. **Always read `<resource>` (or `action` + named keys). Never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work. Pinning to fledge ≥ 1.0 means you can rely on the envelope.
+Top-level `schema_version` is the version contract, **scoped per command**. Each `--json`-emitting command has its own version that bumps only when *that command's* shape changes incompatibly. Two commands both emitting `schema_version: 1` does not mean their shapes are linked. They're tracked independently. New fields are additive within a given command's version; field removal/retyping bumps that command's version. **Always read `<resource>` (or `action` + named keys). Never assume the top level is an array.** Pre-1.0 outputs that returned bare arrays were wrapped in tier C/D of the 1.0 readiness work. Pinning to fledge ≥ 1.0 means you can rely on the envelope.
 
-**Error output.** Errors always go to stderr as plain text, even when `--json` is active. Check the exit code first — non-zero means failure and stderr carries the human-readable error. Do not parse stderr as JSON. Stdout may still contain a partial or final envelope before some failures (e.g. `lanes run --json` emits the lane envelope with `success: false` then bails), so don't treat "stdout has JSON" as a success signal — the exit code is the contract.
+**Error output.** Errors always go to stderr as plain text, even when `--json` is active. Check the exit code first. Non-zero means failure and stderr carries the human-readable error. Do not parse stderr as JSON. Stdout may still contain a partial or final envelope before some failures (e.g. `lanes run --json` emits the lane envelope with `success: false` then bails), so don't treat "stdout has JSON" as a success signal. The exit code is the contract.
 
 ## Non-interactive mode
 
@@ -131,7 +131,7 @@ When non-interactive mode is active, every command that would otherwise prompt b
 
 | Command | Effect |
 |---------|--------|
-| `fledge templates init` | Skip template-variable prompts (uses detected defaults). For **local** templates this also auto-confirms `post_create` hooks. For **remote** templates it does **not** — pass `--trust-hooks` (or set `FLEDGE_TRUST_HOOKS=1`) to authorize hooks from a third-party source. Without it, hooks are skipped in non-interactive mode and the rest of init still succeeds (`hooks_run: false` in the JSON envelope) |
+| `fledge templates init` | Skip template-variable prompts (uses detected defaults). For **local** templates this also auto-confirms `post_create` hooks. For **remote** templates it does **not**. Pass `--trust-hooks` (or set `FLEDGE_TRUST_HOOKS=1`) to authorize hooks from a third-party source. Without it, hooks are skipped in non-interactive mode and the rest of init still succeeds (`hooks_run: false` in the JSON envelope) |
 | `fledge templates create` | Skip name/description/type prompts |
 | `fledge ai use` | Errors with a clear "pass provider+model" message. No hang |
 | `fledge work commit` | Skip the interactive message prompt (requires `-m` or `--ai`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to fledge
 
-Thanks for your interest in contributing to fledge! Whether it's a bug fix, new feature, documentation improvement, or template — contributions are welcome.
+Thanks for your interest in contributing to fledge! Bug fix, new feature, documentation improvement, or template, contributions are welcome.
 
 ## Getting Started
 
@@ -120,9 +120,9 @@ fledge run docs-serve
 - `src/cli.rs` defines the clap derive types for every command and flag
 - `src/main.rs` dispatches parsed args to the appropriate handler
 - Folder modules (`mod.rs`) cover the bigger surfaces: `src/plugin/`, `src/lanes/`, `src/protocol/`, `src/spec/`, `src/release/`
-- Single-file modules cover smaller commands and command-support code. Examples: `src/init.rs`, `src/run.rs`, `src/watch.rs`, `src/work.rs`, `src/changelog.rs`, `src/review.rs`, `src/ask.rs`, `src/ai.rs`, `src/doctor.rs`, `src/introspect.rs`, `src/templates.rs`, `src/template_cmds.rs`, `src/config_cmds.rs`, `src/search.rs`, `src/publish.rs`, `src/validate.rs` — non-exhaustive; `src/` is the source of truth for where any given handler lives
+- Single-file modules cover smaller commands and command-support code. Examples: `src/init.rs`, `src/run.rs`, `src/watch.rs`, `src/work.rs`, `src/changelog.rs`, `src/review.rs`, `src/ask.rs`, `src/ai.rs`, `src/doctor.rs`, `src/introspect.rs`, `src/templates.rs`, `src/template_cmds.rs`, `src/config_cmds.rs`, `src/search.rs`, `src/publish.rs`, `src/validate.rs` (non-exhaustive). `src/` is the source of truth for where any given handler lives
 - Shared infra: `src/trust.rs`, `src/config.rs`, `src/prompts.rs`, `src/spinner.rs`, `src/llm.rs`, `src/github.rs`, `src/versioning.rs`, `src/meta.rs`, `src/utils.rs`
-- Specs in `specs/<module>/` define how each module should work — read them before modifying code. The `files:` frontmatter list ties each spec to its source files
+- Specs in `specs/<module>/` define how each module should work. Read them before modifying code. The `files:` frontmatter list ties each spec to its source files
 
 ### Error Handling
 
@@ -175,7 +175,7 @@ fledge release --dry-run patch     # or minor / major / 1.2.3
 fledge release patch               # or minor / major / 1.2.3
 ```
 
-`fledge release` does the version bump (`Cargo.toml` plus any extras listed in `[release].files` in `fledge.toml` — currently just `flake.nix`), regenerates `CHANGELOG.md` from git history, creates the bump commit, and tags `v<version>` locally. Pass `--push` to also push the commit and tag to `origin` in the same step; without it, the command prints the exact `git push` invocation to run when you're ready. The `release.yml` workflow (triggered by the pushed tag) then builds the multi-platform binaries and publishes to crates.io and GitHub Releases. `Formula/fledge.rb` is intentionally **not** in `[release].files` — Homebrew formulae need both a version and fresh `sha256`s that don't exist until release artifacts are uploaded. `post-release-formula.yml` opens a follow-up PR that bumps version + shas together once the artifacts and their `.sha256` sidecars exist.
+`fledge release` does the version bump (`Cargo.toml` plus any extras listed in `[release].files` in `fledge.toml`, currently just `flake.nix`), regenerates `CHANGELOG.md` from git history, creates the bump commit, and tags `v<version>` locally. Pass `--push` to also push the commit and tag to `origin` in the same step; without it, the command prints the exact `git push` invocation to run when you're ready. The `release.yml` workflow (triggered by the pushed tag) then builds the multi-platform binaries and publishes to crates.io and GitHub Releases. `Formula/fledge.rb` is intentionally **not** in `[release].files`. Homebrew formulae need both a version and fresh `sha256`s that don't exist until release artifacts are uploaded. `post-release-formula.yml` opens a follow-up PR that bumps version + shas together once the artifacts and their `.sha256` sidecars exist.
 
 For the JSON contract (e.g. for scripting), `fledge release --dry-run --json` and `fledge release --json` emit `{schema_version: 1, action: "release", ...}`.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ That is the whole core. Anything else is a plugin.
 
 ## Plugins
 
-Plugins extend fledge with community-built commands. Native plugins run as regular executables; **WASM plugins** run in a sandboxed Wasmtime runtime with no host access by default.
+Plugins extend fledge with community-built commands. Native plugins run as regular executables. **WASM plugins** run in a sandboxed Wasmtime runtime with no host access by default.
 
 ```bash
 fledge plugins install --defaults          # curated native plugin set
@@ -92,15 +92,15 @@ Three native plugins ship as the default set:
 
 | Plugin | Adds |
 |--------|------|
-| [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) | `checks`, `issues`, `prs` — GitHub PR/issue/CI flow |
-| [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) | `deps` — polyglot lockfile audits |
-| [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics` — LOC, churn, test/source ratio (via `tokei` + `git`) |
+| [`fledge-plugin-github`](https://github.com/CorvidLabs/fledge-plugin-github) | `checks`, `issues`, `prs`. GitHub PR/issue/CI flow |
+| [`fledge-plugin-deps`](https://github.com/CorvidLabs/fledge-plugin-deps) | `deps`. Polyglot lockfile audits |
+| [`fledge-plugin-metrics`](https://github.com/CorvidLabs/fledge-plugin-metrics) | `metrics`. LOC, churn, test/source ratio (via `tokei` + `git`) |
 
 ### WASM plugins
 
 WASM plugins are ideal for pure-computation tasks (linting, formatting, analysis) where you want strong isolation without trusting arbitrary binaries:
 
-- Sandboxed by default — no filesystem, no network
+- Sandboxed by default. No filesystem, no network
 - Opt-in capabilities prompted at install time
 - Fuel-bounded execution (no infinite loops)
 - 256 MB memory cap

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,13 +29,13 @@ We aim to acknowledge reports within 48 hours and provide a fix or mitigation pl
 ### Template Rendering
 
 - Templates are rendered through Tera (Jinja2-style) in a sandboxed context
-- Path traversal is blocked — templates cannot write outside the project directory
+- Path traversal is blocked. Templates cannot write outside the project directory
 - **Local** templates (built-in or under a configured `extra_paths`) are
   presumed user-authored. `--yes` (or `FLEDGE_NON_INTERACTIVE=1`) auto-confirms
   their `post_create` hooks, on the same trust footing as the rest of the
   template content
 - **Remote** templates fetched from GitHub get a stricter consent rule.
-  `--yes` does **not** authorize their hooks — `--yes` skips routine prompts
+  `--yes` does **not** authorize their hooks. `--yes` skips routine prompts
   (template-variable defaults, etc.), but arbitrary shell execution from a
   third-party source needs explicit consent. Pass `--trust-hooks` (or set
   `FLEDGE_TRUST_HOOKS=1`) to authorize hook execution for the run; otherwise
@@ -58,18 +58,18 @@ We aim to acknowledge reports within 48 hours and provide a fix or mitigation pl
   [File Locations](#file-locations) below)
 - **Native plugins run as unsandboxed processes with the same permissions as
   the user.** A plugin binary can read any file the user can read, write to
-  any directory the user can write to, and make network requests — regardless
+  any directory the user can write to, and make network requests, regardless
   of its declared capabilities. Capabilities gate the fledge-v1 *protocol*
   (exec/store/metadata RPC messages), not the process itself. Treat
   installing a native plugin as equivalent to running arbitrary code
-- The `fledge-v1` plugin protocol exposes three opt-in capabilities — `exec`,
-  `store`, and `metadata` — that default to `false`. Each is presented for
+- The `fledge-v1` plugin protocol exposes three opt-in capabilities (`exec`,
+  `store`, and `metadata`) that default to `false`. Each is presented for
   explicit user approval at install time and persisted in `plugins.toml`
-- **`exec` grants full shell access — there is no sandbox.** A plugin with
+- **`exec` grants full shell access. There is no sandbox.** A plugin with
   `exec = true` can run any shell command via `sh -c <command>` (Unix) or
   `cmd /C <command>` (Windows). The optional `cwd` parameter is validated
   to stay within the project root or the plugin's own directory, but the
-  command string itself is unfiltered — `cat /etc/passwd`, `curl`, absolute
+  command string itself is unfiltered. `cat /etc/passwd`, `curl`, absolute
   paths, and `cd /` all work. Treat granting `exec` the same as granting
   the plugin full access to your system as your user
 - Stdout/stderr from `exec` are each capped at 10 MB; plugin state at 1 MB
@@ -85,9 +85,9 @@ sandbox with strict isolation:
   only compute and send output via the fledge protocol
 - **Filesystem access is opt-in and scoped.** The `filesystem` capability
   controls what the plugin can see:
-  - `"none"` (default) — no filesystem access
-  - `"project"` — read-only access to the project root (mounted at `/project`)
-  - `"plugin"` — read-only project root + read-write access to the plugin's
+  - `"none"` (default). No filesystem access
+  - `"project"`. Read-only access to the project root (mounted at `/project`)
+  - `"plugin"`. Read-only project root + read-write access to the plugin's
     own directory (mounted at `/plugin`)
 - **Network access is opt-in.** `network = true` inherits the host's network
   stack. Without it, the plugin cannot make any network requests
@@ -103,7 +103,7 @@ sandbox with strict isolation:
   approval
 - **Pre-compiled module caching.** WASM modules are compiled to native code
   and cached (`.cwasm`). The cache is keyed on SHA-256 hash of the `.wasm`
-  binary and the Wasmtime engine version — a Wasmtime upgrade automatically
+  binary and the Wasmtime engine version. A Wasmtime upgrade automatically
   invalidates stale caches
 
 ### File Locations
@@ -117,15 +117,15 @@ Plugin storage uses the platform config directory (`dirs::config_dir()`):
 | Windows  | `%APPDATA%\fledge\` |
 
 Under that base:
-- `plugins/` — installed plugin directories
-- `plugins/bin/` — symlinked binaries
-- `plugins.toml` — plugin registry
-- `config.toml` — global fledge config
+- `plugins/`. Installed plugin directories
+- `plugins/bin/`. Symlinked binaries
+- `plugins.toml`. Plugin registry
+- `config.toml`. Global fledge config
 
 ### Dependencies
 
 - `cargo audit` runs in CI to check for known vulnerabilities
-- Dependencies are kept up to date — run `fledge deps --audit` to check locally
+- Dependencies are kept up to date. Run `fledge deps --audit` to check locally
 
 ## Scope
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -2,7 +2,7 @@
 title = "fledge Documentation"
 authors = ["CorvidLabs"]
 language = "en"
-description = "Dev-lifecycle CLI — get your projects ready to fly. One Rust binary for the full loop from init to changelog."
+description = "Dev-lifecycle CLI. Get your projects ready to fly. One Rust binary for the full loop from init to changelog."
 
 [output.html]
 git-repository-url = "https://github.com/CorvidLabs/fledge"

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -35,7 +35,7 @@ Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 
 | Command | Payload shape |
 |---------|---------------|
-| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args, subcommands}` recursively. Each node's `args` is the **complete set of flags accepted at that level**, including inherited globals from ancestors (marked `global: true`) — no need to walk up the parent chain |
+| `fledge introspect --json` | `{schema_version: 1, name, about, aliases, args, subcommands}` recursively. Each node's `args` is the **complete set of flags accepted at that level**, including inherited globals from ancestors (marked `global: true`). No need to walk up the parent chain |
 | `fledge spec list --json` | `{schema_version: 1, action: "spec_list", specs: [...]}` |
 | `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {...}}` |
 | `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs, totals, strict}` |

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -417,7 +417,7 @@ fledge work <start|commit|push|status> [OPTIONS]
 - `start <name>`: Create a work branch (`--json` for JSON output)
 - `commit`: Stage and commit with conventional-commit formatting (`--json` for JSON output)
 - `push`: Push the current branch to origin (`--json` for JSON output)
-- `status`: Current branch status — ahead/behind counts and dirty file count (`--json` for JSON output)
+- `status`: Current branch status. Ahead/behind counts and dirty file count (`--json` for JSON output)
 
 **Options for `work start`:**
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -140,8 +140,8 @@ timeout_seconds = 600
 
 | Variable | What it does |
 |----------|-------------|
-| `FLEDGE_NON_INTERACTIVE` | Truthy (`1`, `true`, `yes`, `y`, `on`) silences prompts — same effect as passing `--non-interactive` (alias `--ni`) per invocation. Confirmation prompts behave as `--yes`; prompts with no default bail with a clear error instead of hanging. **Hook exception:** for **ad-hoc remote** templates passed to `templates init` (`--template owner/repo` not in config), `post_create` hooks are skipped unless trust is granted explicitly via `--trust-hooks` or `FLEDGE_TRUST_HOOKS`. Built-in templates, anything under `templates.paths`, and anything reachable through your configured `templates.repos` still follow the `--yes` consent path. |
-| `FLEDGE_TRUST_HOOKS` | Truthy authorizes `post_create` hook execution for **ad-hoc remote** templates passed to `fledge templates init` — same as passing `--trust-hooks`. Has no effect on templates reached through `templates.paths` or `templates.repos` (those already follow the `--yes` consent path). Hooks run arbitrary shell commands; only set this for sources you trust. |
+| `FLEDGE_NON_INTERACTIVE` | Truthy (`1`, `true`, `yes`, `y`, `on`) silences prompts. Same effect as passing `--non-interactive` (alias `--ni`) per invocation. Confirmation prompts behave as `--yes`; prompts with no default bail with a clear error instead of hanging. **Hook exception:** for **ad-hoc remote** templates passed to `templates init` (`--template owner/repo` not in config), `post_create` hooks are skipped unless trust is granted explicitly via `--trust-hooks` or `FLEDGE_TRUST_HOOKS`. Built-in templates, anything under `templates.paths`, and anything reachable through your configured `templates.repos` still follow the `--yes` consent path. |
+| `FLEDGE_TRUST_HOOKS` | Truthy authorizes `post_create` hook execution for **ad-hoc remote** templates passed to `fledge templates init`. Same as passing `--trust-hooks`. Has no effect on templates reached through `templates.paths` or `templates.repos` (those already follow the `--yes` consent path). Hooks run arbitrary shell commands; only set this for sources you trust. |
 | `FLEDGE_GITHUB_TOKEN` | GitHub token (highest priority) |
 | `GITHUB_TOKEN` | GitHub token (fallback after FLEDGE_GITHUB_TOKEN) |
 | `FLEDGE_AI_PROVIDER` | AI provider override (`claude` or `ollama`) |
@@ -159,8 +159,8 @@ Per-project settings live in `fledge.toml` in your project root. This file defin
 For the full schema (every section, every key, every default), see the [`fledge.toml` Reference](./fledge-toml.md).
 
 Topical guides:
-- [Run: Tasks and Lanes](./lanes.md) — defining tasks/lanes, step types, parallel groups, importing community lanes
-- [Extend: Plugins](./plugins.md) — `plugin.toml` and the plugin ecosystem
+- [Run: Tasks and Lanes](./lanes.md). Defining tasks/lanes, step types, parallel groups, importing community lanes
+- [Extend: Plugins](./plugins.md). `plugin.toml` and the plugin ecosystem
 
 ## Priority Order
 

--- a/docs/src/fledge-toml.md
+++ b/docs/src/fledge-toml.md
@@ -2,7 +2,7 @@
 
 `fledge.toml` lives in your project root and defines tasks, lanes, and release behavior. It's read by `fledge run`, `fledge lanes`, `fledge release`, and `fledge watch`. Plugins with the `metadata` capability can read it through the `fledge_config` metadata key.
 
-If no `fledge.toml` exists, `fledge run` falls back to language-aware auto-detection. As soon as the file exists, it takes full precedence — there is no merging with auto-detection.
+If no `fledge.toml` exists, `fledge run` falls back to language-aware auto-detection. As soon as the file exists, it takes full precedence. There is no merging with auto-detection.
 
 For plugin manifests (`plugin.toml`), see [Extend: Plugins](./plugins.md). For global user config (`~/.config/fledge/config.toml`), see [Configuration](./configuration.md).
 
@@ -76,7 +76,7 @@ dir = "crates/cli"
 
 | Field | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
-| `cmd` | string | yes | — | Shell command. Run via `sh -c` (Unix) or `cmd /C` (Windows). |
+| `cmd` | string | yes | n/a | Shell command. Run via `sh -c` (Unix) or `cmd /C` (Windows). |
 | `description` | string | no | (uses `cmd`) | Shown by `fledge run --list`. |
 | `deps` | array of strings | no | `[]` | Tasks to run first. Resolved recursively. Cycles are detected and rejected. |
 | `env` | table | no | `{}` | Environment variables set for the task's process. |
@@ -115,7 +115,7 @@ fail_fast = true
 | Field | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
 | `description` | string | no | `"(no description)"` | Shown by `fledge lanes list`. |
-| `steps` | array | yes | — | Ordered steps. At least one is required. |
+| `steps` | array | yes | n/a | Ordered steps. At least one is required. |
 | `fail_fast` | bool | no | `true` | If `false`, every step runs even after failures and a summary is reported at the end. |
 
 ### Step types
@@ -215,7 +215,7 @@ Currently parsed but unused. Reserved for future breaking-change migrations. Saf
 
 ## Imported lanes (`.fledge/lanes/*.toml`)
 
-`fledge lanes import <source>` writes imported lane definitions to a generated file under `.fledge/lanes/`. The filename is derived from the source ref as `<owner>-<repo>[-<subpath>].toml` (lowercased, with `/` in subpaths replaced by `-`) — for example, `fledge lanes import CorvidLabs/fledge-lanes/rust` writes to `.fledge/lanes/corvidlabs-fledge-lanes-rust.toml`. These files are auto-loaded by `fledge lanes run` after your top-level `fledge.toml`. Your local definitions win on name collisions.
+`fledge lanes import <source>` writes imported lane definitions to a generated file under `.fledge/lanes/`. The filename is derived from the source ref as `<owner>-<repo>[-<subpath>].toml` (lowercased, with `/` in subpaths replaced by `-`). For example, `fledge lanes import CorvidLabs/fledge-lanes/rust` writes to `.fledge/lanes/corvidlabs-fledge-lanes-rust.toml`. These files are auto-loaded by `fledge lanes run` after your top-level `fledge.toml`. Your local definitions win on name collisions.
 
 Each imported file has the same shape as `fledge.toml` but typically contains only `[tasks]` and `[lanes]` from the upstream source:
 
@@ -237,7 +237,7 @@ The leading `# Imported from <source>` comment is parsed and used to display the
 A real-world Rust project mixing every section:
 
 ```toml
-# fledge.toml — example project
+# fledge.toml. example project
 
 schema_version = 1
 
@@ -304,17 +304,17 @@ A parse failure on any section bails with a context-rich error pointing at the o
 
 A few subtle but documented behaviors worth knowing:
 
-- **Project precedence.** If `fledge.toml` exists, auto-detection is fully disabled — fledge uses only what's in the file.
+- **Project precedence.** If `fledge.toml` exists, auto-detection is fully disabled. Fledge uses only what's in the file.
 - **Empty `[tasks]` is an error.** `fledge run` bails with a "no tasks defined" message rather than silently running nothing.
 - **Empty `[lanes]` is an error for `fledge lanes run`.** The error tells you to add lanes, import them, or run `fledge lanes init`.
 - **Unknown fields are ignored.** TOML keys not in the schema are silently accepted (forward-compatible) but have no effect.
 - **`description` is optional everywhere.** Tasks fall back to showing `cmd`, lanes fall back to `(no description)`.
-- **Path handling differs by field.** Task `dir` is joined to the project root as configured and is *not* currently canonicalized — values like `"../sibling"` are accepted and will resolve outside the project. `[release].files` paths *are* canonicalized and rejected if they escape the project root.
+- **Path handling differs by field.** Task `dir` is joined to the project root as configured and is *not* currently canonicalized. Values like `"../sibling"` are accepted and will resolve outside the project. `[release].files` paths *are* canonicalized and rejected if they escape the project root.
 
 ## Related
 
-- [Run: Tasks and Lanes](./lanes.md) — workflow walkthrough, auto-detection, watch mode
-- [Configuration](./configuration.md) — global `~/.config/fledge/config.toml`
-- [Extend: Plugins](./plugins.md) — `plugin.toml` reference and ecosystem
-- [Plugin Protocol Spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md) — `fledge-v1` JSON wire protocol
-- [CLI Reference](./cli-reference.md) — every subcommand and flag
+- [Run: Tasks and Lanes](./lanes.md). Workflow walkthrough, auto-detection, watch mode
+- [Configuration](./configuration.md). Global `~/.config/fledge/config.toml`
+- [Extend: Plugins](./plugins.md). `plugin.toml` reference and ecosystem
+- [Plugin Protocol Spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md). `fledge-v1` JSON wire protocol
+- [CLI Reference](./cli-reference.md). Every subcommand and flag

--- a/docs/src/getting-started/existing-projects.md
+++ b/docs/src/getting-started/existing-projects.md
@@ -43,7 +43,7 @@ Once `fledge.toml` exists, it takes full precedence over auto-detection.
 
 ## Everything Else Works Too
 
-Every command in the [six pillars](../pillars.md) works in any git repo — AI review, work branches, changelog, doctor, plugins, and more. See the sidebar for the full list.
+Every command in the [six pillars](../pillars.md) works in any git repo. AI review, work branches, changelog, doctor, plugins, and more. See the sidebar for the full list.
 
 ## Turn Your Project into a Template
 
@@ -67,4 +67,4 @@ fledge templates publish ./my-stack
 
 ## What's Next
 
-Once you're running tasks, the rest of the dev loop is available immediately — see [Quick Start: What's Next](./quick-start.md#whats-next) for the full list.
+Once you're running tasks, the rest of the dev loop is available immediately. See [Quick Start: What's Next](./quick-start.md#whats-next) for the full list.

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -81,4 +81,4 @@ fledge doctor                        # anything broken in your env?
 fledge plugins install --defaults    # adds checks, issues, prs, deps, metrics
 ```
 
-Each of these has its own chapter — see the sidebar for details.
+Each of these has its own chapter. See the sidebar for details.

--- a/docs/src/github-integration.md
+++ b/docs/src/github-integration.md
@@ -10,7 +10,7 @@ fledge plugins install CorvidLabs/fledge-plugin-github
 
 ## Setup
 
-You need a GitHub token. The easiest option is to install `gh` and run `gh auth login` — fledge uses it as a fallback automatically. Otherwise, set `GITHUB_TOKEN` or configure it via `fledge config set github.token`. See [Configuration: GitHub](./configuration.md#github) for the full token resolution order and required scopes.
+You need a GitHub token. The easiest option is to install `gh` and run `gh auth login`. Fledge uses it as a fallback automatically. Otherwise, set `GITHUB_TOKEN` or configure it via `fledge config set github.token`. See [Configuration: GitHub](./configuration.md#github) for the full token resolution order and required scopes.
 
 ## GitHub commands (plugin)
 
@@ -52,5 +52,5 @@ fledge github checks --json
 
 ## Related
 
-- [Ship: Branch, Commit, Push, Release](./ship.md) — branch creation, commit, push, release workflow
-- [AI: Ask and Review](./review.md) — multi-model review panels, spec-awareness, output formats
+- [Ship: Branch, Commit, Push, Release](./ship.md). Branch creation, commit, push, release workflow
+- [AI: Ask and Review](./review.md). Multi-model review panels, spec-awareness, output formats

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-One CLI for the entire dev lifecycle — scaffold, run tasks, sync specs, AI review, ship PRs, and release. Works with any language, outputs JSON for automation, and extends through plugins.
+One CLI for the entire dev lifecycle. Scaffold, run tasks, sync specs, AI review, ship PRs, and release. Works with any language, outputs JSON for automation, and extends through plugins.
 
 ## Why I built this
 
@@ -31,7 +31,7 @@ fledge plugins install --defaults
 
 That gets you `checks`/`issues`/`prs` (GitHub), `deps`, and `metrics`. See [Extend: Plugins](./plugins.md) for the full list and how to build your own.
 
-Plugins can also be **WASM modules** — sandboxed, cross-platform, and secure by default. WASM plugins run in a Wasmtime runtime with no host access unless explicitly granted. Great for community plugins where you don't want to trust arbitrary native code. See [WASM Plugins](./wasm-plugins.md) for the authoring guide.
+Plugins can also be **WASM modules**. Sandboxed, cross-platform, and secure by default. WASM plugins run in a Wasmtime runtime with no host access unless explicitly granted. Great for community plugins where you don't want to trust arbitrary native code. See [WASM Plugins](./wasm-plugins.md) for the authoring guide.
 
 ## Zero-config
 

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -4,7 +4,7 @@ The Run pillar covers three commands: `fledge run` (task runner), `fledge watch`
 
 ## Running Tasks
 
-`fledge run` works immediately in any project — no config needed. It detects your stack from marker files and provides sensible defaults:
+`fledge run` works immediately in any project. No config needed. It detects your stack from marker files and provides sensible defaults:
 
 ```bash
 fledge run test     # auto-detects Rust/Node/Go/Python/Ruby/Java/Swift
@@ -36,7 +36,7 @@ When you want full control, generate a `fledge.toml`:
 fledge run --init
 ```
 
-This creates a config file pre-filled with detected tasks. Once `fledge.toml` exists, it takes full precedence — no mixing with auto-detection. You can also override the detected language with `--lang`:
+This creates a config file pre-filled with detected tasks. Once `fledge.toml` exists, it takes full precedence. No mixing with auto-detection. You can also override the detected language with `--lang`:
 
 ```bash
 fledge run test --lang swift
@@ -339,11 +339,11 @@ fledge lanes import CorvidLabs/fledge-lanes@v1.0.0
 
 ### Related
 
-- [`fledge.toml` Reference](./fledge-toml.md) — full schema for tasks, lanes, release, and imported lanes
-- [Configuration](./configuration.md) — global config, GitHub tokens
-- [Extend: Plugins](./plugins.md) — community commands, use plugins in lanes
-- [CLI Reference](./cli-reference.md) — full `fledge lanes` subcommand reference
-- [Example Lanes](https://github.com/CorvidLabs/fledge-lanes) — official community lane collection
+- [`fledge.toml` Reference](./fledge-toml.md). Full schema for tasks, lanes, release, and imported lanes
+- [Configuration](./configuration.md). Global config, GitHub tokens
+- [Extend: Plugins](./plugins.md). Community commands, use plugins in lanes
+- [CLI Reference](./cli-reference.md). Full `fledge lanes` subcommand reference
+- [Example Lanes](https://github.com/CorvidLabs/fledge-lanes). Official community lane collection
 
 ### Tips
 

--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -132,7 +132,7 @@ network = false
 
 ### Limitations
 
-- Interactive UI (prompt/confirm/select) is not supported — use non-interactive output
+- Interactive UI (prompt/confirm/select) is not supported. Use non-interactive output
 - Compute is bounded (fuel limit + 60s wall-clock timeout)
 - Memory is limited to 256 MB
 
@@ -339,19 +339,19 @@ Outbound (plugin → fledge):
 
 | Type | Reply | Requires |
 |------|-------|----------|
-| `prompt` | `response` with string | — |
-| `confirm` | `response` with boolean | — |
-| `select` | `response` with selected string | — |
-| `multi_select` | `response` with array of strings | — |
+| `prompt` | `response` with string | none |
+| `confirm` | `response` with boolean | none |
+| `select` | `response` with selected string | none |
+| `multi_select` | `response` with array of strings | none |
 | `exec` | `response` with `{code, stdout, stderr}` | `exec` |
 | `store` | *(fire-and-forget)* | `store` |
 | `load` | `response` with string or `null` | `store` |
 | `metadata` | `response` with object of requested keys | `metadata` |
-| `progress` | *(fire-and-forget)* | — |
-| `log` | *(fire-and-forget; level: debug/info/warn/error)* | — |
-| `output` | *(fire-and-forget; printed verbatim to stdout)* | — |
+| `progress` | *(fire-and-forget)* | none |
+| `log` | *(fire-and-forget; level: debug/info/warn/error)* | none |
+| `output` | *(fire-and-forget; printed verbatim to stdout)* | none |
 
-Reply messages always have shape `{"type": "response", "id": "<echoed>", "value": <type-specific>}`. There is no `exec_result` / `store_ack` / `load_result` envelope — every reply uses the generic `response` type.
+Reply messages always have shape `{"type": "response", "id": "<echoed>", "value": <type-specific>}`. There is no `exec_result` / `store_ack` / `load_result` envelope. Every reply uses the generic `response` type.
 
 See the [plugin protocol spec](https://github.com/CorvidLabs/fledge/blob/main/specs/plugin/plugin-protocol.spec.md) for full schemas, lifecycle, security model, and worked examples.
 
@@ -359,11 +359,11 @@ See the [plugin protocol spec](https://github.com/CorvidLabs/fledge/blob/main/sp
 
 Plugin install, update, and search operations use your GitHub token when available. This enables installing plugins from private repositories. See [Configuration: GitHub](./configuration.md#github) for the full token resolution order and required scopes.
 
-The easiest setup is `gh auth login` — fledge uses it automatically as a fallback. The token is injected via git's `http.extraheader` mechanism and is never embedded in remote URLs or persisted to disk.
+The easiest setup is `gh auth login`. Fledge uses it automatically as a fallback. The token is injected via git's `http.extraheader` mechanism and is never embedded in remote URLs or persisted to disk.
 
 ## Security Model
 
-> **Warning (native plugins):** Native plugins run as unsandboxed processes with your full user permissions. A plugin can read any file you can read, write to any directory you can write to, and make network requests — regardless of its declared capabilities. Capabilities gate the fledge-v1 *protocol* (exec/store/metadata RPC messages), not the process itself. Review plugin source before installing, especially from unknown authors.
+> **Warning (native plugins):** Native plugins run as unsandboxed processes with your full user permissions. A plugin can read any file you can read, write to any directory you can write to, and make network requests, regardless of its declared capabilities. Capabilities gate the fledge-v1 *protocol* (exec/store/metadata RPC messages), not the process itself. Review plugin source before installing, especially from unknown authors.
 >
 > **WASM plugins** run in a sandboxed Wasmtime runtime with no host access by default. Filesystem and network access are opt-in, scoped, and prompted at install time. See [WASM Plugins](#wasm-plugins) above.
 

--- a/docs/src/review.md
+++ b/docs/src/review.md
@@ -111,5 +111,5 @@ REVIEW=$(fledge review --json)
 
 ## Related
 
-- [Extend: Plugins](./plugins.md) — `fledge metrics` and `fledge deps` complement AI review (install with `fledge plugins install --defaults`)
-- [CLI Reference](./cli-reference.md#ai-ask-and-review) — full flag reference for `ai`, `ask`, and `review`
+- [Extend: Plugins](./plugins.md). `fledge metrics` and `fledge deps` complement AI review (install with `fledge plugins install --defaults`)
+- [CLI Reference](./cli-reference.md#ai-ask-and-review). Full flag reference for `ai`, `ask`, and `review`

--- a/docs/src/spec.md
+++ b/docs/src/spec.md
@@ -1,6 +1,6 @@
 # Spec: Spec-sync
 
-Keep your specs in sync with the code. Specs are the source of truth for module design — write the spec first, then write the code to match.
+Keep your specs in sync with the code. Specs are the source of truth for module design. Write the spec first, then write the code to match.
 
 ## Why spec-sync?
 

--- a/docs/src/template-authoring.md
+++ b/docs/src/template-authoring.md
@@ -79,12 +79,12 @@ repo_url = { message = "Repository URL", default = "https://github.com/{{ github
 Controls which files get rendered, copied, or skipped.
 
 - **`render`** - process through Tera
-- **`copy`** - copy as-is, even if a `render` glob would otherwise match (use this for binary assets, images, fonts — anything you don't want Tera to touch)
+- **`copy`** - copy as-is, even if a `render` glob would otherwise match (use this for binary assets, images, fonts, anything you don't want Tera to touch)
 - **`ignore`** - skip entirely (file is not written to the project)
 
 Files ending in `.tera` are *always* rendered (and the extension stripped) regardless of the globs. That is the explicit "render this" signal.
 
-Precedence — first rule that matches wins:
+Precedence. First rule that matches wins:
 
 1. `ignore` glob → skip
 2. `.tera` extension → render, strip extension
@@ -92,7 +92,7 @@ Precedence — first rule that matches wins:
 4. `render` glob → render through Tera
 5. Default (nothing matched) → copy bytes
 
-So a broad `render = ["**/*"]` is safe as long as binary assets are listed under `copy` — they bypass Tera even though the render glob would catch them.
+So a broad `render = ["**/*"]` is safe as long as binary assets are listed under `copy`. They bypass Tera even though the render glob would catch them.
 
 ```toml
 [files]

--- a/docs/src/templates.md
+++ b/docs/src/templates.md
@@ -101,7 +101,7 @@ Templates on GitHub use the `fledge-template` topic, that's what `templates sear
 
 ## Project Metadata
 
-`fledge templates init` writes `.fledge/meta.toml` to your project root: template source, variable values used during scaffolding, and per-file SHA hashes. This metadata is informational — a community plugin can ingest it if you want template-update tooling.
+`fledge templates init` writes `.fledge/meta.toml` to your project root: template source, variable values used during scaffolding, and per-file SHA hashes. This metadata is informational. A community plugin can ingest it if you want template-update tooling.
 
 ## Publishing Your Own
 
@@ -148,11 +148,11 @@ For the full format reference, see the [Template Authoring Guide](./template-aut
 
 When you run `fledge templates init --template <name>`, fledge resolves `<name>` as follows:
 
-1. **GitHub shorthand** — if `<name>` looks like `owner/repo` (or `owner/repo/subpath`, optionally with `@ref`), fledge fetches it directly from GitHub. This is the only path that treats the template as fully untrusted (see *Security* below).
-2. **Discovered name** — otherwise fledge looks up the bare name in the merged set of:
-   - **Built-in templates** — the 8 bundled ones (`go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`)
-   - **Configured repo templates** — anything under `templates.repos` in your config (these are fetched from GitHub but treated as user-curated since you added them to config)
-   - **Local-path templates** — anything under `templates.paths` in your config
+1. **GitHub shorthand.** If `<name>` looks like `owner/repo` (or `owner/repo/subpath`, optionally with `@ref`), fledge fetches it directly from GitHub. This is the only path that treats the template as fully untrusted (see *Security* below).
+2. **Discovered name.** Otherwise fledge looks up the bare name in the merged set of:
+   - **Built-in templates.** The 8 bundled ones (`go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`)
+   - **Configured repo templates.** Anything under `templates.repos` in your config (these are fetched from GitHub but treated as user-curated since you added them to config)
+   - **Local-path templates.** Anything under `templates.paths` in your config
 
 If `<name>` is omitted entirely and the run is interactive, fledge shows a picker over the same merged set.
 
@@ -162,9 +162,9 @@ If `<name>` is omitted entirely and the run is interactive, fledge shows a picke
 
 Hook consent is split by **how you reached the template**, not where its files physically live:
 
-- **Curated path** — built-in starters, anything under `templates.paths`, and templates discovered through `templates.repos` (which you opted into at config time). `--yes` (or `FLEDGE_NON_INTERACTIVE=1`) auto-confirms their `post_create` hooks. The trust decision happened when you added the source to your config.
-- **Ad-hoc remote** — `--template owner/repo` (or `owner/repo/subpath`, optionally `@ref`) passed directly on the command line, with no prior config entry. `--yes` does **not** authorize hooks here — pass `--trust-hooks` (or set `FLEDGE_TRUST_HOOKS=1`) to authorize execution for the run. Without it, the prompt fires interactively, or hooks are skipped in non-interactive mode with a hint pointing at the right flag (the rest of init still succeeds; `hooks_run: false` in the JSON envelope).
+- **Curated path.** Built-in starters, anything under `templates.paths`, and templates discovered through `templates.repos` (which you opted into at config time). `--yes` (or `FLEDGE_NON_INTERACTIVE=1`) auto-confirms their `post_create` hooks. The trust decision happened when you added the source to your config.
+- **Ad-hoc remote.** `--template owner/repo` (or `owner/repo/subpath`, optionally `@ref`) passed directly on the command line, with no prior config entry. `--yes` does **not** authorize hooks here. Pass `--trust-hooks` (or set `FLEDGE_TRUST_HOOKS=1`) to authorize execution for the run. Without it, the prompt fires interactively, or hooks are skipped in non-interactive mode with a hint pointing at the right flag (the rest of init still succeeds; `hooks_run: false` in the JSON envelope).
 
-If you find yourself reaching for `--trust-hooks` on the same source repeatedly, add it to `templates.repos` instead — that's the durable trust grant.
+If you find yourself reaching for `--trust-hooks` on the same source repeatedly, add it to `templates.repos` instead. That's the durable trust grant.
 
 The `--dry-run` path always lists the hooks that would run regardless of trust, so you can audit before consenting.

--- a/docs/src/use-cases.md
+++ b/docs/src/use-cases.md
@@ -6,7 +6,7 @@ fledge works for solo devs, teams, and AI agents. This page covers real workflow
 
 ### Zero-config task runner
 
-`fledge run test` works immediately in any project — it auto-detects your stack from marker files. No config file needed. See [Existing Projects](./getting-started/existing-projects.md) for details.
+`fledge run test` works immediately in any project. It auto-detects your stack from marker files. No config file needed. See [Existing Projects](./getting-started/existing-projects.md) for details.
 
 ```bash
 fledge run test    # always works, regardless of language

--- a/docs/src/wasm-plugins.md
+++ b/docs/src/wasm-plugins.md
@@ -1,6 +1,6 @@
 # WASM Plugins
 
-WASM plugins run in a sandboxed [Wasmtime](https://wasmtime.dev/) runtime with no host access by default. They're ideal for pure-computation tasks — linting, formatting, analysis, code generation — where you want strong isolation without trusting arbitrary native binaries.
+WASM plugins run in a sandboxed [Wasmtime](https://wasmtime.dev/) runtime with no host access by default. They're ideal for pure-computation tasks (linting, formatting, analysis, code generation) where you want strong isolation without trusting arbitrary native binaries.
 
 ## Quick start
 
@@ -17,7 +17,7 @@ When fledge runs a WASM plugin:
 
 1. The `.wasm` binary is compiled to native code and cached as `.cwasm` (version-stamped, invalidated on Wasmtime upgrades)
 2. A Wasmtime instance is created with the declared capabilities
-3. The plugin communicates via the same [fledge-v1 protocol](./plugins.md#plugin-protocol-fledge-v1) as native plugins — JSON messages over host-provided `send`/`recv` functions
+3. The plugin communicates via the same [fledge-v1 protocol](./plugins.md#plugin-protocol-fledge-v1) as native plugins. JSON messages over host-provided `send`/`recv` functions
 4. Execution is bounded by fuel (CPU) and a 60-second wall-clock timeout
 5. Memory is capped at 256 MB
 
@@ -33,7 +33,7 @@ WASM plugins declare capabilities in `plugin.toml`. All default to denied.
 | `filesystem` | `"none"`, `"project"`, `"plugin"` | `"project"` mounts project root read-only. `"plugin"` adds a read-write plugin directory. |
 | `network` | `true`/`false` | Inherit the host network stack |
 
-Users are prompted to approve capabilities at install time. Denied capabilities fail gracefully at runtime — no crashes.
+Users are prompted to approve capabilities at install time. Denied capabilities fail gracefully at runtime. No crashes.
 
 ## plugin.toml for WASM
 
@@ -131,7 +131,7 @@ fledge plugins run my-lint
 | Memory | 256 MB | Allocation fails, plugin traps |
 | Stack | Wasmtime default | Plugin traps on overflow |
 
-All limits result in a clean trap — the host process never crashes or enters an invalid state.
+All limits result in a clean trap. The host process never crashes or enters an invalid state.
 
 ## When to use WASM vs native
 
@@ -151,7 +151,7 @@ All limits result in a clean trap — the host process never crashes or enters a
 
 ## Limitations
 
-- No interactive UI (prompt/confirm/select) — WASM plugins must use non-interactive output
+- No interactive UI (prompt/confirm/select). WASM plugins must use non-interactive output
 - No direct access to environment variables or the host filesystem beyond declared mounts
 - Build requires the `wasm32-wasip1` target (`rustup target add wasm32-wasip1`)
 - Currently Rust-only for the scaffold; any language that compiles to WASI works in practice


### PR DESCRIPTION
## Summary

- Removed every em-dash from user-facing docs (README, AGENTS, CONTRIBUTING, SECURITY, docs/src/, docs/book.toml).
- Replaced with periods, parens, or commas so the prose matches my actual voice. Short, direct, no typographic flair.
- CHANGELOG.md left untouched since it's the historical release record.

## Test plan

- [x] `cargo run -- spec check` (30 specs, 0 errors, 0 warnings)
- [x] `cargo fmt --check` clean
- [x] `grep -rn '—' README.md AGENTS.md CONTRIBUTING.md SECURITY.md docs/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)