### PR TITLE
fix(wasm): enforce trust tiers, fix TOCTOU cache, use typed traps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ shell-words = "1.1.1"
 wasmtime = "43"
 wasmtime-wasi = "43"
 
+[build-dependencies]
+toml = "0.8"
+
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["json"] }
 tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let cargo_toml = std::fs::read_to_string("Cargo.toml").expect("reading Cargo.toml");
+    let parsed: toml::Value = cargo_toml.parse().expect("parsing Cargo.toml");
+    let version = parsed["dependencies"]["wasmtime"]
+        .as_str()
+        .expect("wasmtime dependency should be a plain version string");
+    println!("cargo:rustc-env=WASMTIME_DEP_VERSION={version}");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
 fn main() {
     let cargo_toml = std::fs::read_to_string("Cargo.toml").expect("reading Cargo.toml");
     let parsed: toml::Value = cargo_toml.parse().expect("parsing Cargo.toml");
-    let version = parsed["dependencies"]["wasmtime"]
+    let wt = &parsed["dependencies"]["wasmtime"];
+    let version = wt
         .as_str()
-        .expect("wasmtime dependency should be a plain version string");
+        .or_else(|| wt.get("version").and_then(|v| v.as_str()))
+        .expect("wasmtime dependency should have a version (string or table with `version` key)");
     println!("cargo:rustc-env=WASMTIME_DEP_VERSION={version}");
     println!("cargo:rerun-if-changed=Cargo.toml");
 }

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 21
+version: 22
 status: active
 files:
   - src/plugin/mod.rs
@@ -151,7 +151,7 @@ Plugins are classified by their source into trust tiers:
 | Team | Source owner is a human member of the CorvidLabs org (`TEAM_MEMBERS` allowlist in `src/trust.rs`) | Cyan `[team]` |
 | Unverified | All other sources | Yellow `[unverified]` |
 
-Trust tiers are shown in `plugin list`, `plugin audit`, and during `plugin install`. Unverified plugins with elevated capabilities (exec, metadata) get an extra warning in `plugin audit`.
+Trust tiers are shown in `plugin list`, `plugin audit`, and during `plugin install`. Unverified plugins requesting `exec` or `network` capabilities are **blocked at install time** — the install is aborted, the partially-cloned directory is cleaned up, and the user is told to fork the plugin under a trusted source. Official and team-tier plugins are unaffected.
 
 ### Plugin Discovery
 
@@ -215,6 +215,7 @@ pinned_ref = "v0.2.0"
 14. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
 15. Protocol plugins without `exec` capability cannot run lifecycle hooks — `run_lifecycle_hook` skips them silently. Non-protocol plugins (no capability entry in the registry) are unaffected
 16. `plugin install` displays lifecycle hooks (with their shell commands) in the approval prompt alongside capabilities. Hooks-only plugins (no protocol capabilities) still require user approval before install completes
+17. `plugin install` rejects unverified plugins that request `exec` or `network` capabilities — the install is aborted before the approval prompt. Only official-tier and team-tier plugins may use these capabilities
 
 ## Behavioral Examples
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -279,6 +279,26 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
         has_caps && (manifest.plugin.protocol.is_some() || manifest.plugin.is_wasm());
     let has_hooks = manifest.hooks.has_any();
 
+    if tier == TrustTier::Unverified {
+        let mut blocked = Vec::new();
+        if caps.exec {
+            blocked.push("exec");
+        }
+        if caps.network {
+            blocked.push("network");
+        }
+        if !blocked.is_empty() {
+            fs::remove_dir_all(&plugin_dir).ok();
+            bail!(
+                "Unverified plugin '{}' requests dangerous capabilities: {}\n  \
+                 Only official and team-tier plugins may use exec or network.\n  \
+                 If you trust this source, fork it into the CorvidLabs org or a team member's account.",
+                repo_name,
+                blocked.join(", ")
+            );
+        }
+    }
+
     if needs_cap_prompt || has_hooks {
         if !json {
             if needs_cap_prompt {
@@ -298,18 +318,33 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                         style("•").yellow()
                     );
                 }
-                if let Some(ref fs) = caps.filesystem {
-                    if fs != "none" {
-                        println!(
-                            "    {} filesystem ({}) — access host files",
-                            style("•").yellow(),
-                            fs
-                        );
+                if let Some(ref fs_cap) = caps.filesystem {
+                    match fs_cap.as_str() {
+                        "project" => {
+                            println!(
+                                "    {} filesystem (project) — read-only access to project directory",
+                                style("•").yellow()
+                            );
+                        }
+                        "plugin" => {
+                            println!(
+                                "    {} filesystem (plugin) — read-only project access + read-write plugin data",
+                                style("•").yellow()
+                            );
+                        }
+                        "none" => {}
+                        other => {
+                            println!(
+                                "    {} filesystem ({}) — access host files",
+                                style("•").yellow(),
+                                other
+                            );
+                        }
                     }
                 }
                 if caps.network {
                     println!(
-                        "    {} network — make outbound network requests",
+                        "    {} network — make outbound network requests (unrestricted)",
                         style("•").yellow()
                     );
                 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -301,11 +301,16 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     let has_hooks = manifest.hooks.has_any();
 
     if let Err(blocked) = check_tier_capabilities(tier, caps) {
-        fs::remove_dir_all(&plugin_dir).ok();
+        if let Err(e) = fs::remove_dir_all(&plugin_dir) {
+            eprintln!(
+                "Warning: failed to clean up partial install at {}: {e}",
+                plugin_dir.display()
+            );
+        }
         bail!(
             "Unverified plugin '{}' requests dangerous capabilities: {}\n  \
              Only official and team-tier plugins may use exec or network.\n  \
-             If you trust this source, fork it into the CorvidLabs org or a team member's account.",
+             If you trust this source, fork it under an account you control or an org in your team allowlist.",
             repo_name,
             blocked.join(", ")
         );

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -8,8 +8,29 @@ use crate::trust::{determine_trust_tier, parse_source_ref, TrustTier};
 use super::{
     apply_git_auth, extract_name_from_source, link_commands, load_registry, normalize_source,
     plugin_bin_dir, plugins_dir, run_build, run_hook, save_registry, validate_plugin_name,
-    PluginEntry, PluginManifest, PLUGINS_INSTALL_SCHEMA,
+    PluginCapabilities, PluginEntry, PluginManifest, PLUGINS_INSTALL_SCHEMA,
 };
+
+pub(super) fn check_tier_capabilities(
+    tier: TrustTier,
+    caps: &PluginCapabilities,
+) -> std::result::Result<(), Vec<&'static str>> {
+    if tier != TrustTier::Unverified {
+        return Ok(());
+    }
+    let mut blocked = Vec::new();
+    if caps.exec {
+        blocked.push("exec");
+    }
+    if caps.network {
+        blocked.push("network");
+    }
+    if blocked.is_empty() {
+        Ok(())
+    } else {
+        Err(blocked)
+    }
+}
 
 /// Top-level dispatcher for `fledge plugins install`. Splits the
 /// single-source path from the `--defaults` bulk-install path so each
@@ -279,24 +300,15 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
         has_caps && (manifest.plugin.protocol.is_some() || manifest.plugin.is_wasm());
     let has_hooks = manifest.hooks.has_any();
 
-    if tier == TrustTier::Unverified {
-        let mut blocked = Vec::new();
-        if caps.exec {
-            blocked.push("exec");
-        }
-        if caps.network {
-            blocked.push("network");
-        }
-        if !blocked.is_empty() {
-            fs::remove_dir_all(&plugin_dir).ok();
-            bail!(
-                "Unverified plugin '{}' requests dangerous capabilities: {}\n  \
-                 Only official and team-tier plugins may use exec or network.\n  \
-                 If you trust this source, fork it into the CorvidLabs org or a team member's account.",
-                repo_name,
-                blocked.join(", ")
-            );
-        }
+    if let Err(blocked) = check_tier_capabilities(tier, caps) {
+        fs::remove_dir_all(&plugin_dir).ok();
+        bail!(
+            "Unverified plugin '{}' requests dangerous capabilities: {}\n  \
+             Only official and team-tier plugins may use exec or network.\n  \
+             If you trust this source, fork it into the CorvidLabs org or a team member's account.",
+            repo_name,
+            blocked.join(", ")
+        );
     }
 
     if needs_cap_prompt || has_hooks {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -34,6 +34,8 @@ use update::update_plugins;
 use validate::validate_plugin;
 
 #[cfg(test)]
+use install::check_tier_capabilities;
+#[cfg(test)]
 use run_plugin::{apply_protocol, resolve_plugin_source_dir, which_fledge_plugin};
 
 // ─── Constants ───────────────────────────────────────────────────────────────

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -1325,7 +1325,9 @@ fn unverified_tier_blocks_exec_and_network() {
     };
     let result = check_tier_capabilities(TrustTier::Unverified, &caps);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), vec!["exec", "network"]);
+    let mut blocked = result.unwrap_err();
+    blocked.sort();
+    assert_eq!(blocked, vec!["exec", "network"]);
 }
 
 #[test]

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::trust::parse_source_ref;
+use crate::trust::{parse_source_ref, TrustTier};
 
 #[test]
 fn unsupported_protocol_version_returns_error() {
@@ -1290,4 +1290,71 @@ fn create_wasm_plugin_scaffolds_correct_files() {
         "WASM scaffold should use println!, not eprintln!"
     );
     assert!(main_rs.contains("println!"));
+}
+
+// --- Trust-tier capability enforcement ---
+
+#[test]
+fn unverified_tier_blocks_exec() {
+    let caps = PluginCapabilities {
+        exec: true,
+        ..Default::default()
+    };
+    let result = check_tier_capabilities(TrustTier::Unverified, &caps);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), vec!["exec"]);
+}
+
+#[test]
+fn unverified_tier_blocks_network() {
+    let caps = PluginCapabilities {
+        network: true,
+        ..Default::default()
+    };
+    let result = check_tier_capabilities(TrustTier::Unverified, &caps);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), vec!["network"]);
+}
+
+#[test]
+fn unverified_tier_blocks_exec_and_network() {
+    let caps = PluginCapabilities {
+        exec: true,
+        network: true,
+        ..Default::default()
+    };
+    let result = check_tier_capabilities(TrustTier::Unverified, &caps);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), vec!["exec", "network"]);
+}
+
+#[test]
+fn unverified_tier_allows_safe_capabilities() {
+    let caps = PluginCapabilities {
+        store: true,
+        metadata: true,
+        filesystem: Some("project".to_string()),
+        ..Default::default()
+    };
+    assert!(check_tier_capabilities(TrustTier::Unverified, &caps).is_ok());
+}
+
+#[test]
+fn official_tier_allows_exec() {
+    let caps = PluginCapabilities {
+        exec: true,
+        network: true,
+        ..Default::default()
+    };
+    assert!(check_tier_capabilities(TrustTier::Official, &caps).is_ok());
+}
+
+#[test]
+fn team_tier_allows_exec() {
+    let caps = PluginCapabilities {
+        exec: true,
+        network: true,
+        ..Default::default()
+    };
+    assert!(check_tier_capabilities(TrustTier::Team, &caps).is_ok());
 }

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -747,6 +747,7 @@ mod tests {
         assert!(result.is_ok(), "run_wasm_plugin should succeed: {result:?}");
     }
 
+    // Verifies build.rs actually ran and emitted WASMTIME_DEP_VERSION.
     #[test]
     fn wasmtime_version_derived_from_cargo_toml() {
         let cargo_toml = include_str!("../../Cargo.toml");

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -43,38 +43,42 @@ fn create_engine() -> Result<Engine> {
 }
 
 pub(crate) fn load_module(engine: &Engine, wasm_path: &Path) -> Result<Module> {
+    let wasm_bytes = std::fs::read(wasm_path)?;
     let cwasm_path = wasm_path.with_extension("cwasm");
     if cwasm_path.exists() {
-        if let Some(module) = try_load_cached(engine, wasm_path, &cwasm_path)? {
+        if let Some(module) = try_load_cached(engine, &wasm_bytes, &cwasm_path)? {
             return Ok(module);
         }
     }
-    let wasm_bytes = std::fs::read(wasm_path)?;
     let module = Module::new(engine, &wasm_bytes)?;
     if let Ok(serialized) = module.serialize() {
         let tmp_cwasm = cwasm_path.with_extension("cwasm.tmp");
-        if std::fs::write(&tmp_cwasm, &serialized).is_ok() {
-            let _ = std::fs::rename(&tmp_cwasm, &cwasm_path);
-        }
-        let wasm_hash = compute_hash(&wasm_bytes);
-        let cwasm_hash = compute_hash(&serialized);
-        let stamp = format!("{}\n{}\n{}", wasm_hash, WASMTIME_VERSION, cwasm_hash);
-        let hash_path = cwasm_path.with_extension("cwasm.sha256");
-        let tmp_hash = hash_path.with_extension("sha256.tmp");
-        if std::fs::write(&tmp_hash, &stamp).is_ok() {
-            let _ = std::fs::rename(&tmp_hash, &hash_path);
+        if std::fs::write(&tmp_cwasm, &serialized).is_ok()
+            && std::fs::rename(&tmp_cwasm, &cwasm_path).is_ok()
+        {
+            let wasm_hash = compute_hash(&wasm_bytes);
+            let cwasm_hash = compute_hash(&serialized);
+            let stamp = format!("{}\n{}\n{}", wasm_hash, WASMTIME_VERSION, cwasm_hash);
+            let hash_path = cwasm_path.with_extension("cwasm.sha256");
+            let tmp_hash = hash_path.with_extension("sha256.tmp");
+            if std::fs::write(&tmp_hash, &stamp).is_ok() {
+                let _ = std::fs::rename(&tmp_hash, &hash_path);
+            }
         }
     }
     Ok(module)
 }
 
-fn try_load_cached(engine: &Engine, wasm_path: &Path, cwasm_path: &Path) -> Result<Option<Module>> {
-    let wasm_bytes = std::fs::read(wasm_path)?;
+fn try_load_cached(
+    engine: &Engine,
+    wasm_bytes: &[u8],
+    cwasm_path: &Path,
+) -> Result<Option<Module>> {
+    let expected_wasm_hash = compute_hash(wasm_bytes);
     let cwasm_bytes = match std::fs::read(cwasm_path) {
         Ok(b) => b,
         Err(_) => return Ok(None),
     };
-    let expected_wasm_hash = compute_hash(&wasm_bytes);
     let actual_cwasm_hash = compute_hash(&cwasm_bytes);
     let hash_path = cwasm_path.with_extension("cwasm.sha256");
     let stamp = match std::fs::read_to_string(&hash_path) {
@@ -658,7 +662,8 @@ mod tests {
         let cwasm_path = wasm_path.with_extension("cwasm");
         assert!(cwasm_path.exists());
         let engine = create_engine().unwrap();
-        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+        let wasm_bytes = std::fs::read(&wasm_path).unwrap();
+        assert!(try_load_cached(&engine, &wasm_bytes, &cwasm_path)
             .unwrap()
             .is_some());
     }
@@ -682,7 +687,8 @@ mod tests {
 
         let cwasm_path = wasm_path.with_extension("cwasm");
         let engine = create_engine().unwrap();
-        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+        let wasm_bytes = std::fs::read(&wasm_path).unwrap();
+        assert!(try_load_cached(&engine, &wasm_bytes, &cwasm_path)
             .unwrap()
             .is_none());
     }
@@ -695,11 +701,13 @@ mod tests {
 
         compile_and_cache(&wasm_path).unwrap();
 
-        std::fs::write(&wasm_path, format!("{}\n;; modified", EXIT_OK_WAT)).unwrap();
+        let modified = format!("{}\n;; modified", EXIT_OK_WAT);
+        std::fs::write(&wasm_path, &modified).unwrap();
 
         let cwasm_path = wasm_path.with_extension("cwasm");
         let engine = create_engine().unwrap();
-        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+        let wasm_bytes = modified.as_bytes();
+        assert!(try_load_cached(&engine, wasm_bytes, &cwasm_path)
             .unwrap()
             .is_none());
     }
@@ -743,9 +751,11 @@ mod tests {
     fn wasmtime_version_derived_from_cargo_toml() {
         let cargo_toml = include_str!("../../Cargo.toml");
         let parsed: toml::Value = cargo_toml.parse().unwrap();
-        let dep_version = parsed["dependencies"]["wasmtime"]
+        let wt = &parsed["dependencies"]["wasmtime"];
+        let dep_version = wt
             .as_str()
-            .expect("wasmtime dependency should be a string version");
+            .or_else(|| wt.get("version").and_then(|v| v.as_str()))
+            .expect("wasmtime dependency should have a version");
         assert_eq!(
             WASMTIME_VERSION, dep_version,
             "build.rs-derived WASMTIME_VERSION ({}) doesn't match Cargo.toml wasmtime = \"{}\"",
@@ -833,8 +843,9 @@ mod tests {
         std::fs::write(&cwasm_path, b"tampered data").unwrap();
 
         let engine = create_engine().unwrap();
+        let wasm_bytes = std::fs::read(&wasm_path).unwrap();
         assert!(
-            try_load_cached(&engine, &wasm_path, &cwasm_path)
+            try_load_cached(&engine, &wasm_bytes, &cwasm_path)
                 .unwrap()
                 .is_none(),
             "cache should be invalid after .cwasm tampering"
@@ -938,8 +949,9 @@ mod tests {
         std::fs::remove_file(&hash_path).unwrap();
 
         let engine = create_engine().unwrap();
+        let wasm_bytes = std::fs::read(&wasm_path).unwrap();
         assert!(
-            try_load_cached(&engine, &wasm_path, &cwasm_path)
+            try_load_cached(&engine, &wasm_bytes, &cwasm_path)
                 .unwrap()
                 .is_none(),
             "cache should be invalid when hash file is missing"
@@ -959,8 +971,9 @@ mod tests {
         std::fs::write(&hash_path, "somehash\n").unwrap();
 
         let engine = create_engine().unwrap();
+        let wasm_bytes = std::fs::read(&wasm_path).unwrap();
         assert!(
-            try_load_cached(&engine, &wasm_path, &cwasm_path)
+            try_load_cached(&engine, &wasm_bytes, &cwasm_path)
                 .unwrap()
                 .is_none(),
             "cache should be invalid with truncated hash file"

--- a/src/plugin/wasm.rs
+++ b/src/plugin/wasm.rs
@@ -13,8 +13,7 @@ use crate::plugin::PluginCapabilities;
 const FUEL_LIMIT: u64 = 10_000_000_000;
 const WALL_CLOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 const MAX_MEMORY_BYTES: usize = 256 * 1024 * 1024;
-// Must match the wasmtime version in Cargo.toml — .cwasm cache is invalidated on mismatch
-const WASMTIME_VERSION: &str = "43";
+const WASMTIME_VERSION: &str = env!("WASMTIME_DEP_VERSION");
 
 #[derive(Debug)]
 struct FledgeExitOk;
@@ -45,68 +44,62 @@ fn create_engine() -> Result<Engine> {
 
 pub(crate) fn load_module(engine: &Engine, wasm_path: &Path) -> Result<Module> {
     let cwasm_path = wasm_path.with_extension("cwasm");
-    if cwasm_path.exists() && is_cache_valid(wasm_path, &cwasm_path)? {
-        match unsafe { Module::deserialize_file(engine, &cwasm_path) } {
-            Ok(module) => return Ok(module),
-            Err(e) => {
-                eprintln!(
-                    "  {} cached module invalid (recompiling): {}",
-                    style("⚠").yellow(),
-                    e
-                );
-                let _ = std::fs::remove_file(&cwasm_path);
-                let _ = std::fs::remove_file(cwasm_path.with_extension("cwasm.sha256"));
-            }
+    if cwasm_path.exists() {
+        if let Some(module) = try_load_cached(engine, wasm_path, &cwasm_path)? {
+            return Ok(module);
         }
     }
-    let module = Module::from_file(engine, wasm_path)?;
-    match module.serialize() {
-        Ok(serialized) => {
-            let tmp_cwasm = cwasm_path.with_extension("cwasm.tmp");
-            if std::fs::write(&tmp_cwasm, &serialized).is_ok() {
-                let _ = std::fs::rename(&tmp_cwasm, &cwasm_path);
-            }
-            if let Ok(wasm_bytes) = std::fs::read(wasm_path) {
-                let wasm_hash = compute_hash(&wasm_bytes);
-                let cwasm_hash = compute_hash(&serialized);
-                let stamp = format!("{}\n{}\n{}", wasm_hash, WASMTIME_VERSION, cwasm_hash);
-                let hash_path = cwasm_path.with_extension("cwasm.sha256");
-                let tmp_hash = hash_path.with_extension("sha256.tmp");
-                if std::fs::write(&tmp_hash, &stamp).is_ok() {
-                    let _ = std::fs::rename(&tmp_hash, &hash_path);
-                }
-            }
+    let wasm_bytes = std::fs::read(wasm_path)?;
+    let module = Module::new(engine, &wasm_bytes)?;
+    if let Ok(serialized) = module.serialize() {
+        let tmp_cwasm = cwasm_path.with_extension("cwasm.tmp");
+        if std::fs::write(&tmp_cwasm, &serialized).is_ok() {
+            let _ = std::fs::rename(&tmp_cwasm, &cwasm_path);
         }
-        Err(e) => {
-            eprintln!(
-                "  {} module serialization failed (will recompile next run): {}",
-                style("⚠").yellow(),
-                e
-            );
+        let wasm_hash = compute_hash(&wasm_bytes);
+        let cwasm_hash = compute_hash(&serialized);
+        let stamp = format!("{}\n{}\n{}", wasm_hash, WASMTIME_VERSION, cwasm_hash);
+        let hash_path = cwasm_path.with_extension("cwasm.sha256");
+        let tmp_hash = hash_path.with_extension("sha256.tmp");
+        if std::fs::write(&tmp_hash, &stamp).is_ok() {
+            let _ = std::fs::rename(&tmp_hash, &hash_path);
         }
     }
     Ok(module)
 }
 
-fn is_cache_valid(wasm_path: &Path, cwasm_path: &Path) -> Result<bool> {
+fn try_load_cached(engine: &Engine, wasm_path: &Path, cwasm_path: &Path) -> Result<Option<Module>> {
     let wasm_bytes = std::fs::read(wasm_path)?;
+    let cwasm_bytes = match std::fs::read(cwasm_path) {
+        Ok(b) => b,
+        Err(_) => return Ok(None),
+    };
     let expected_wasm_hash = compute_hash(&wasm_bytes);
+    let actual_cwasm_hash = compute_hash(&cwasm_bytes);
     let hash_path = cwasm_path.with_extension("cwasm.sha256");
-    match std::fs::read_to_string(&hash_path) {
-        Ok(stored) => {
-            let mut lines = stored.lines();
-            let wasm_hash_ok = lines.next().is_some_and(|h| h.trim() == expected_wasm_hash);
-            let version_ok = lines.next().is_some_and(|v| v.trim() == WASMTIME_VERSION);
-            let cwasm_hash_ok = match lines.next() {
-                Some(stored_cwasm_hash) => match std::fs::read(cwasm_path) {
-                    Ok(cwasm_bytes) => compute_hash(&cwasm_bytes) == stored_cwasm_hash.trim(),
-                    Err(_) => false,
-                },
-                None => false,
-            };
-            Ok(wasm_hash_ok && version_ok && cwasm_hash_ok)
+    let stamp = match std::fs::read_to_string(&hash_path) {
+        Ok(s) => s,
+        Err(_) => return Ok(None),
+    };
+    let mut lines = stamp.lines();
+    let wasm_ok = lines.next().is_some_and(|h| h.trim() == expected_wasm_hash);
+    let version_ok = lines.next().is_some_and(|v| v.trim() == WASMTIME_VERSION);
+    let cwasm_ok = lines.next().is_some_and(|h| h.trim() == actual_cwasm_hash);
+    if !(wasm_ok && version_ok && cwasm_ok) {
+        return Ok(None);
+    }
+    match unsafe { Module::deserialize(engine, &cwasm_bytes) } {
+        Ok(module) => Ok(Some(module)),
+        Err(e) => {
+            eprintln!(
+                "  {} cached module invalid (recompiling): {}",
+                style("⚠").yellow(),
+                e
+            );
+            let _ = std::fs::remove_file(cwasm_path);
+            let _ = std::fs::remove_file(&hash_path);
+            Ok(None)
         }
-        Err(_) => Ok(false),
     }
 }
 
@@ -585,26 +578,25 @@ pub(crate) fn run_wasm_plugin(
         Ok(()) => Ok(()),
         Err(e) => {
             if e.downcast_ref::<FledgeExitOk>().is_some() {
-                Ok(())
-            } else {
-                let msg = e.to_string();
-                if msg.contains("all fuel consumed") || msg.contains("out of fuel") {
-                    bail!(
+                return Ok(());
+            }
+            if let Some(trap) = e.downcast_ref::<Trap>() {
+                match trap {
+                    Trap::OutOfFuel => bail!(
                         "Plugin '{}' exceeded its compute budget.\n  \
                          The plugin ran too many instructions. This is a safety limit, not a bug in fledge.\n  \
                          If the plugin is doing heavy work, it may need to be split into smaller steps.",
                         plugin_name
-                    )
-                } else if msg.contains("epoch") {
-                    bail!(
+                    ),
+                    Trap::Interrupt => bail!(
                         "Plugin '{}' exceeded time limit ({} seconds)",
                         plugin_name,
                         WALL_CLOCK_TIMEOUT.as_secs()
-                    )
-                } else {
-                    bail!("Plugin '{}' trapped: {}", plugin_name, e)
+                    ),
+                    _ => bail!("Plugin '{}' trapped: {}", plugin_name, trap),
                 }
             }
+            bail!("Plugin '{}' failed: {}", plugin_name, e)
         }
     }
 }
@@ -665,7 +657,10 @@ mod tests {
 
         let cwasm_path = wasm_path.with_extension("cwasm");
         assert!(cwasm_path.exists());
-        assert!(is_cache_valid(&wasm_path, &cwasm_path).unwrap());
+        let engine = create_engine().unwrap();
+        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -686,7 +681,10 @@ mod tests {
         std::fs::write(&hash_path, format!("{}\n999\n{}", hash_line, cwasm_hash)).unwrap();
 
         let cwasm_path = wasm_path.with_extension("cwasm");
-        assert!(!is_cache_valid(&wasm_path, &cwasm_path).unwrap());
+        let engine = create_engine().unwrap();
+        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -700,7 +698,10 @@ mod tests {
         std::fs::write(&wasm_path, format!("{}\n;; modified", EXIT_OK_WAT)).unwrap();
 
         let cwasm_path = wasm_path.with_extension("cwasm");
-        assert!(!is_cache_valid(&wasm_path, &cwasm_path).unwrap());
+        let engine = create_engine().unwrap();
+        assert!(try_load_cached(&engine, &wasm_path, &cwasm_path)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -739,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn wasmtime_version_const_matches_cargo_toml() {
+    fn wasmtime_version_derived_from_cargo_toml() {
         let cargo_toml = include_str!("../../Cargo.toml");
         let parsed: toml::Value = cargo_toml.parse().unwrap();
         let dep_version = parsed["dependencies"]["wasmtime"]
@@ -747,7 +748,7 @@ mod tests {
             .expect("wasmtime dependency should be a string version");
         assert_eq!(
             WASMTIME_VERSION, dep_version,
-            "WASMTIME_VERSION const ({}) does not match Cargo.toml wasmtime = \"{}\" — update the const",
+            "build.rs-derived WASMTIME_VERSION ({}) doesn't match Cargo.toml wasmtime = \"{}\"",
             WASMTIME_VERSION, dep_version
         );
     }
@@ -770,7 +771,7 @@ mod tests {
         assert!(result.is_err(), "infinite loop should be terminated");
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("fuel") || err.contains("time limit") || err.contains("trapped"),
+            err.contains("compute budget") || err.contains("time limit") || err.contains("trapped"),
             "expected resource-limit error, got: {err}"
         );
     }
@@ -815,7 +816,7 @@ mod tests {
         let result = run_wasm_plugin(&wasm_path, &[], "test-exit-bad", "0.0.1", dir.path(), &caps);
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("exited with code 1") || err.contains("trapped"),
+            err.contains("exited with code 1") || err.contains("trapped") || err.contains("failed"),
             "expected non-zero exit error, got: {err}"
         );
     }
@@ -829,11 +830,13 @@ mod tests {
         compile_and_cache(&wasm_path).unwrap();
 
         let cwasm_path = wasm_path.with_extension("cwasm");
-        // Tamper with the compiled module
         std::fs::write(&cwasm_path, b"tampered data").unwrap();
 
+        let engine = create_engine().unwrap();
         assert!(
-            !is_cache_valid(&wasm_path, &cwasm_path).unwrap(),
+            try_load_cached(&engine, &wasm_path, &cwasm_path)
+                .unwrap()
+                .is_none(),
             "cache should be invalid after .cwasm tampering"
         );
     }
@@ -934,8 +937,11 @@ mod tests {
         let hash_path = cwasm_path.with_extension("cwasm.sha256");
         std::fs::remove_file(&hash_path).unwrap();
 
+        let engine = create_engine().unwrap();
         assert!(
-            !is_cache_valid(&wasm_path, &cwasm_path).unwrap(),
+            try_load_cached(&engine, &wasm_path, &cwasm_path)
+                .unwrap()
+                .is_none(),
             "cache should be invalid when hash file is missing"
         );
     }
@@ -950,11 +956,13 @@ mod tests {
 
         let cwasm_path = wasm_path.with_extension("cwasm");
         let hash_path = cwasm_path.with_extension("cwasm.sha256");
-        // Write only 1 line instead of 3
         std::fs::write(&hash_path, "somehash\n").unwrap();
 
+        let engine = create_engine().unwrap();
         assert!(
-            !is_cache_valid(&wasm_path, &cwasm_path).unwrap(),
+            try_load_cached(&engine, &wasm_path, &cwasm_path)
+                .unwrap()
+                .is_none(),
             "cache should be invalid with truncated hash file"
         );
     }


### PR DESCRIPTION
## Summary

Addresses HIGH and MEDIUM findings from the Team Alpha v1.1.0 post-release review (Rook, Jackdaw, Magpie).

### HIGH
- **Trust tier enforcement** — Unverified plugins are now blocked from requesting `exec` or `network` capabilities at install time. Only Official and Team-tier plugins may use these dangerous capabilities.

### MEDIUM
- **TOCTOU fix in compiled module cache** — `load_module` now reads `.cwasm` bytes into memory before hash validation, then calls `Module::deserialize()` on the validated buffer instead of `deserialize_file()` which re-reads from disk (race window eliminated).
- **Filesystem capability disclosure** — Install prompts now explicitly state what each filesystem mode grants: `project` = read-only project access, `plugin` = read-only project + read-write plugin data.
- **Auto-derive WASMTIME_VERSION** — New `build.rs` extracts the wasmtime version from `Cargo.toml` at compile time via `env!("WASMTIME_DEP_VERSION")`, eliminating manual constant maintenance.

### LOW
- **Typed trap detection** — Replaced `msg.contains("all fuel consumed")` / `msg.contains("epoch")` string matching with `wasmtime::Trap` enum matching (`Trap::OutOfFuel`, `Trap::Interrupt`).

## Verification

- 945 tests pass, 0 failures
- clippy clean (`-D warnings`)
- fmt clean
- 30 specs, 0 errors

## Test plan

- [x] All existing tests pass with refactored cache and trap code
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `fledge spec check` — 30 specs, 0 errors
- [ ] Manual: attempt `fledge plugins install someuser/fledge-plugin-exec-test` with `exec = true` in manifest — should be blocked with trust tier error

🤖 Generated with [Claude Code](https://claude.com/claude-code)