### PR TITLE
fix(lint): silence clippy::const_is_empty on DEFAULT_PLUGINS

### DIFF
--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -119,9 +119,13 @@ fn resolve_plugin_source_dir_handles_non_symlink_path() {
     assert_eq!(resolved, expected);
 }
 
+const _: () = assert!(
+    !DEFAULT_PLUGINS.is_empty(),
+    "DEFAULT_PLUGINS must not be empty"
+);
+
 #[test]
 fn default_plugins_are_well_formed() {
-    assert!(!DEFAULT_PLUGINS.is_empty());
     for src in DEFAULT_PLUGINS {
         let (owner_repo, git_ref) = parse_source_ref(src);
         assert!(


### PR DESCRIPTION
## Summary

Rust 1.91 added the `clippy::const_is_empty` lint which flagged `assert!(!DEFAULT_PLUGINS.is_empty())` in `src/plugin/tests.rs` because the slice's emptiness is known at compile time. With `-D warnings` in CI, this blocks the lint step.

Replaced the runtime assertion with a compile-time `const _: () = assert!(...)` outside the test fn. Same invariant, no clippy noise, fails the build at compile time instead of at test time if someone empties the const.

Blocks 1.1.1 release, lint is currently red on main.

## Test plan

- [x] `fledge lanes run pre-commit` (fmt + lint + test + spec-check, all green)
- [x] `cargo clippy --tests -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)