### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.1] - 2026-05-03
+
+### Chores
+
+- update Homebrew formula to v1.1.0 (#348) (3762b41)
+
+### Documentation
+
+- strip em-dashes and tighten voice across docs (#349) (519af50)
+
+### Fixes
+
+- silence clippy::const_is_empty on DEFAULT_PLUGINS check (#352) (1e61f87)
+- enforce trust tiers, fix TOCTOU cache, use typed traps (#350) (7f37822)
+
 ## [v1.1.0] - 2026-05-02
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.1.0";
+          version = "1.1.1";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary

Patch release shipping the post-1.1.0 security review fixes to crates.io and Homebrew users.

- **Headline fix:** `enforce trust tiers, fix TOCTOU cache, use typed traps (#350)`. HIGH/MEDIUM findings from Team Alpha's v1.1.0 review.
- Lint unblock: `silence clippy::const_is_empty on DEFAULT_PLUGINS check (#352)`. Rust 1.91 regression.
- Doc voice cleanup: `strip em-dashes and tighten voice across docs (#349)`.
- Homebrew formula bump for 1.1.0 captured in CHANGELOG (#348).

Bumps `Cargo.toml`, `Cargo.lock`, `flake.nix`, regenerates `CHANGELOG.md`. `Formula/fledge.rb` bumps separately via the post-release-formula workflow once binaries land.

## Test plan

- [x] `fledge release patch --dry-run` clean
- [x] `fledge lanes run pre-commit` (fmt + lint + test + spec-check, all green) on the pre-release main
- [ ] Tag `v1.1.1` on the merged commit and push to fire `release.yml`
- [ ] Verify crates.io + GitHub Release publish succeeds
- [ ] Verify post-release-formula PR opens for Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)