### PR TITLE
chore: bump default plugin pins (deps v0.2.0, metrics v0.2.1)

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -52,7 +52,7 @@ use run_plugin::{apply_protocol, resolve_plugin_source_dir, which_fledge_plugin}
 pub const DEFAULT_PLUGINS: &[&str] = &[
     "CorvidLabs/fledge-plugin-github@v0.4.0",
     "CorvidLabs/fledge-plugin-deps@v0.2.0",
-    "CorvidLabs/fledge-plugin-metrics@v0.2.0",
+    "CorvidLabs/fledge-plugin-metrics@v0.2.1",
 ];
 
 /// Per-command JSON schema versions. Each constant tracks the wire shape of one

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -51,7 +51,7 @@ use run_plugin::{apply_protocol, resolve_plugin_source_dir, which_fledge_plugin}
 /// Bump the tag here when adopting a new plugin release.
 pub const DEFAULT_PLUGINS: &[&str] = &[
     "CorvidLabs/fledge-plugin-github@v0.4.0",
-    "CorvidLabs/fledge-plugin-deps@v0.1.0",
+    "CorvidLabs/fledge-plugin-deps@v0.2.0",
     "CorvidLabs/fledge-plugin-metrics@v0.2.0",
 ];
 


### PR DESCRIPTION
## Summary
- Bumps `DEFAULT_PLUGINS` pin for `fledge-plugin-deps` from `v0.1.0` → `v0.2.0`
  - v0.2.0 contains: stable JSON envelope, Python audit, fail-fast licenses, bun fallback, bun.lock detection
- Bumps `DEFAULT_PLUGINS` pin for `fledge-plugin-metrics` from `v0.2.0` → `v0.2.1`
  - v0.2.1 is the first release with prebuilt binaries attached
- Mirrors #335 (which bumped `fledge-plugin-github`)

## Ordering
Merge **after** `fledge-plugin-metrics` v0.2.1 is tagged so the pin resolves.

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [ ] Spot-check `fledge plugins install --defaults` resolves both pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)