### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2026-05-03
+
+### Features
+
+- **Plugin discoverability** — topic filter, interactive search, and recommend command (#357) (1cf52d9)
+  - `fledge plugins search --topic ci` filters results by GitHub topic
+  - `fledge plugins search --interactive` opens a fuzzy-select picker
+  - `fledge plugins recommend` suggests plugins based on project context
+- **Configurable trust tiers** — override trust classification via config.toml (#356) (74af2fd)
+  - `fledge config add trust.users corvid-agent` to trust a user
+  - `fledge config add trust.orgs myorg` to trust an org
+  - Overrides apply before GitHub API checks
+
+### Chores
+
+- bump default plugin pins (deps v0.2.0, metrics v0.2.1) (#355) (4513195)
+- update Homebrew formula to v1.1.1 (#354) (504d6fc)
+
 ## [v1.1.1] - 2026-05-03
 
 ### Chores

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.1.1";
+          version = "1.2.0";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary

Prep for v1.2.0 — the "Discoverability" release.

- Bumps version to 1.2.0 in `Cargo.toml` and `flake.nix`
- Adds changelog entry covering all changes since v1.1.1

### What's in 1.2.0

**Features:**
- **Plugin discoverability** — `--topic` filter, `--interactive` fuzzy picker, `plugins recommend` (#357)
- **Configurable trust tiers** — override trust via `config.toml` (#356)

**Chores:**
- Default plugin pin bumps (#355)
- Homebrew formula update (#354)

## Test plan

- [x] 971 tests pass
- [x] clippy clean
- [x] fmt clean  
- [x] spec-check clean (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)