### PR TITLE
fix(plugins): cap interactive search rows to prevent prompt ghosting

### DIFF
--- a/src/plugin/search.rs
+++ b/src/plugin/search.rs
@@ -150,6 +150,8 @@ fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
         .with_prompt("Select a plugin to install")
         .items(&items)
         .default(0)
+        .max_length(15)
+        .highlight_matches(true)
         .interact_opt()?;
 
     let Some(idx) = selection else {

--- a/src/plugin/search.rs
+++ b/src/plugin/search.rs
@@ -133,16 +133,24 @@ fn print_results(results: &[crate::search::SearchResult]) {
 fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
     crate::utils::require_interactive("--interactive")?;
 
+    let term_width = console::Term::stdout().size().1 as usize;
+    let max_item_width = term_width.saturating_sub(4);
+
     let items: Vec<String> = results
         .iter()
         .map(|r| {
             let tier = crate::trust::determine_trust_tier_from_owner(&r.owner);
-            format!(
+            let line = format!(
                 "{:<40} [{}]  {}",
                 r.full_name(),
                 tier.label(),
                 r.description
-            )
+            );
+            if line.len() > max_item_width {
+                format!("{}…", &line[..max_item_width - 1])
+            } else {
+                line
+            }
         })
         .collect();
 


### PR DESCRIPTION
## Summary
- `FuzzySelect` with no `max_length` renders all items at once — when 30+ plugin results exceed terminal height, ANSI cursor-up redraws can't clear scrolled lines, causing the "Select a plugin" prompt to ghost on every redraw cycle
- Adds `.max_length(15)` to cap visible rows and `.highlight_matches(true)` for better fuzzy search UX

## Test plan
- [ ] Run `fledge plugin search --interactive` and confirm the prompt appears only once
- [ ] Confirm fuzzy filtering highlights matching characters
- [ ] Verify selection installs the chosen plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)