### PR TITLE
feat(lanes): retry_delay, Windows job kill, thread-safe when tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,4 @@ libc = "0.2.185"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_System_JobObjects",
-    "Win32_System_Threading",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,10 @@ tempfile = "3"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.185"
+
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }

--- a/specs/lanes/lanes.spec.md
+++ b/specs/lanes/lanes.spec.md
@@ -1,6 +1,6 @@
 ---
 module: lanes
-version: 23
+version: 24
 status: active
 files:
   - src/lanes/mod.rs
@@ -141,7 +141,8 @@ steps = ["deps-audit", "license-check", "security-scan"]
 |--------|------|-------------|
 | `when` | `string` | Condition: skip step if not met. Supports `VAR` (set & non-empty), `VAR=value` (equals), `!VAR` (not set/empty), `!VAR=value` (not equals). Multiple comma-separated conditions are AND'd |
 | `timeout` | `integer` | Per-attempt timeout in seconds. Each retry attempt gets a fresh deadline. The deadline covers the entire step including task deps. Process is killed on timeout |
-| `retries` | `integer` | Number of retry attempts after failure (0 = no retries, default). Total attempts = retries + 1. A 1-second delay is inserted between attempts |
+| `retries` | `integer` | Number of retry attempts after failure (0 = no retries, default). Total attempts = retries + 1. The delay between attempts is configurable via `retry_delay` (defaults to 1 second) |
+| `retry_delay` | `integer` | Seconds to sleep between retry attempts. Defaults to 1. Set to 0 for immediate retry. Only meaningful when `retries > 0` |
 
 ```toml
 # Examples of step options
@@ -166,8 +167,8 @@ steps = [
 10. Each step prints its elapsed time on completion; the lane summary includes total elapsed time
 11. `--from <step>` skips all steps before the target (by 1-based index or step name). Stateless — no run history is persisted. Skipped steps show in both human-readable and JSON output
 12. `when` conditions are evaluated against environment variables before each step executes. Steps with unmet conditions are silently skipped (shown as skipped in output). Evaluation is AND-logic for comma-separated conditions
-13. `timeout` sets a per-attempt deadline in seconds. Each retry attempt gets a fresh deadline. The deadline covers the entire step execution including task dependency resolution. On Unix, the spawned command runs in its own process group and the entire group is killed via `killpg(SIGKILL)` when the deadline passes — multi-statement shell commands (`sh -c "a && b"`) do not leak grandchild processes. On Windows only the direct child is killed; grandchildren may orphan
-14. `retries` specifies the number of retry attempts after failure. Total attempts = retries + 1. Retry is per-step (the full step re-executes, not individual commands within it). A 1-second delay is inserted between retry attempts to avoid hammering failing resources
+13. `timeout` sets a per-attempt deadline in seconds. Each retry attempt gets a fresh deadline. The deadline covers the entire step execution including task dependency resolution. The spawned command's full process tree is reaped on timeout: on Unix via process group + `killpg(SIGKILL)`; on Windows via Job Object + `TerminateJobObject`. Multi-statement shell commands (`sh -c "a && b"`, `cmd /c "a & b"`) do not leak grandchild processes
+14. `retries` specifies the number of retry attempts after failure. Total attempts = retries + 1. Retry is per-step (the full step re-executes, not individual commands within it). `retry_delay` controls the sleep between attempts in seconds (default 1, set to 0 for immediate retry)
 
 ## Behavioral Examples
 
@@ -332,6 +333,7 @@ files continue to load against v1 semantics indefinitely.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 24 | 2026-05-04 | Follow-up polish: (a) New `retry_delay` step option (seconds, default 1) — overrides the inter-attempt sleep, supports immediate retry with `retry_delay = 0`. (b) Windows process tree reaping via Job Object + `TerminateJobObject` — mirrors the Unix `process_group` + `killpg` fix from v23 so timeout no longer leaks grandchildren on Windows either. (c) `evaluate_when` now exposes a closure-injected `evaluate_when_with` so tests can supply a `HashMap` instead of mutating process-global env vars (edition-2024 prep) |
 | 23 | 2026-05-04 | Follow-up review fixes: (a) Process group kill on Unix — `timeout` now reaps the entire process tree via `killpg(SIGKILL)`, no more orphaned grandchildren from `sh -c "a && b"`. (b) Skipped step JSON entries normalized to include `success: null, duration_ms: null, error: null` so the per-step shape is consistent across completed and skipped rows; `LANES_RUN_SCHEMA` and `LANES_DRY_RUN_SCHEMA` reverted to 1 (additive only). (c) `--from <name>` on a parallel step now emits a specific error pointing at index targeting instead of the generic "no match" |
 | 22 | 2026-05-04 | Review fixes: (a) 1-second retry delay between attempts. (b) Timeout is per-attempt — each retry gets a fresh deadline. (c) Bump `LANES_RUN_SCHEMA` and `LANES_DRY_RUN_SCHEMA` from 1 → 2 for new fields (later reverted in v23). (d) Fix spec: remove private fns from Exported Functions, document process tree limitation on timeout |
 | 21 | 2026-05-04 | Add `when` (conditional steps), `timeout` (per-step deadlines), `retries`, and `--from` (resume from step). New `Step` options on table-form steps. New exports: `resolve_from`, `evaluate_when`. Invariants 11-14 |

--- a/src/lanes/execute.rs
+++ b/src/lanes/execute.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use super::{
     evaluate_when, format_duration, step_description, LaneDef, ParallelItem, Step, TaskDef,
-    LANES_RUN_SCHEMA,
+    DEFAULT_RETRY_DELAY_SECS, LANES_RUN_SCHEMA,
 };
 
 pub(crate) fn execute_lane(
@@ -67,12 +67,13 @@ pub(crate) fn execute_lane(
 
         let retries = step.retries().unwrap_or(0);
         let timeout = step.timeout();
+        let retry_delay = step.retry_delay().unwrap_or(DEFAULT_RETRY_DELAY_SECS);
         let step_start = Instant::now();
 
         let mut last_err = None;
         for attempt in 0..=retries {
             if attempt > 0 {
-                std::thread::sleep(Duration::from_secs(1));
+                std::thread::sleep(Duration::from_secs(retry_delay));
                 println!(
                     "  {} Retry {}/{} for step {}",
                     style("⟳").yellow(),
@@ -195,13 +196,14 @@ fn execute_lane_json(
 
         let retries = step.retries().unwrap_or(0);
         let timeout = step.timeout();
+        let retry_delay = step.retry_delay().unwrap_or(DEFAULT_RETRY_DELAY_SECS);
         let step_start = Instant::now();
 
         let mut attempts = 0u32;
         let mut last_err = None;
         for attempt in 0..=retries {
             if attempt > 0 {
-                std::thread::sleep(Duration::from_secs(1));
+                std::thread::sleep(Duration::from_secs(retry_delay));
             }
             attempts = attempt + 1;
             let deadline = timeout.map(|t| Instant::now() + Duration::from_secs(t));
@@ -297,11 +299,12 @@ pub(crate) fn execute_lane_silent(
 
         let retries = step.retries().unwrap_or(0);
         let timeout = step.timeout();
+        let retry_delay = step.retry_delay().unwrap_or(DEFAULT_RETRY_DELAY_SECS);
 
         let mut last_err = None;
         for attempt in 0..=retries {
             if attempt > 0 {
-                std::thread::sleep(Duration::from_secs(1));
+                std::thread::sleep(Duration::from_secs(retry_delay));
             }
             let deadline = timeout.map(|t| Instant::now() + Duration::from_secs(t));
             let result = execute_step_core(step, tasks, project_dir, true, deadline);
@@ -567,29 +570,59 @@ fn run_command_with_deadline(
             if Instant::now() >= d {
                 bail!("step timed out");
             }
-            // On Unix, place the child in its own process group so we can
-            // signal the entire tree on timeout. Without this, killing a
-            // shell-launched child (e.g. `sh -c "echo a && sleep 30"`)
-            // leaves grandchildren orphaned and adopted by init.
+
+            // Reap entire process tree on timeout. Without this, a shell
+            // command like `sh -c "echo a && sleep 30"` would leave
+            // grandchildren running after the direct child is killed.
+            //
+            // - Unix: spawn in a fresh process group, signal it with
+            //   `killpg(SIGKILL)` on timeout.
+            // - Windows: assign the child to a Job Object configured
+            //   with KILL_ON_JOB_CLOSE; on timeout, `TerminateJobObject`
+            //   kills every process in the job tree.
             #[cfg(unix)]
             command.process_group(0);
             let mut child = command.spawn().context("spawning command")?;
             #[cfg(unix)]
             let pgid = child.id() as libc::pid_t;
+            #[cfg(windows)]
+            let job = setup_windows_job(&child);
+
             loop {
                 match child.try_wait().context("waiting for command")? {
-                    Some(status) => return Ok(status),
+                    Some(status) => {
+                        #[cfg(windows)]
+                        if let Some(h) = job {
+                            // SAFETY: handle returned by CreateJobObjectW; closing it
+                            // after the child has exited cannot affect a living tree.
+                            unsafe {
+                                windows_sys::Win32::Foundation::CloseHandle(h);
+                            }
+                        }
+                        return Ok(status);
+                    }
                     None => {
                         if Instant::now() >= d {
                             #[cfg(unix)]
-                            // SAFETY: killpg(pgid, SIGKILL) is safe — pgid is the
-                            // child's own pgid (set via process_group(0) above) and
-                            // SIGKILL has no signal handler to invoke.
+                            // SAFETY: killpg(pgid, SIGKILL) — pgid is the child's own
+                            // pgid (set via process_group(0) above) and SIGKILL has no
+                            // signal handler to invoke.
                             unsafe {
                                 libc::killpg(pgid, libc::SIGKILL);
                             }
-                            #[cfg(not(unix))]
-                            let _ = child.kill();
+                            #[cfg(windows)]
+                            if let Some(h) = job {
+                                // SAFETY: TerminateJobObject + CloseHandle on a job we
+                                // own. Exit code 1 stands for the synthetic kill.
+                                unsafe {
+                                    windows_sys::Win32::System::JobObjects::TerminateJobObject(
+                                        h, 1,
+                                    );
+                                    windows_sys::Win32::Foundation::CloseHandle(h);
+                                }
+                            } else {
+                                let _ = child.kill();
+                            }
                             let _ = child.wait();
                             bail!("step timed out");
                         }
@@ -600,4 +633,58 @@ fn run_command_with_deadline(
         }
         None => Ok(command.status()?),
     }
+}
+
+/// Wrap the spawned child in a Job Object so that `TerminateJobObject`
+/// reaps the entire process tree on timeout. The race window between
+/// `spawn` and `AssignProcessToJobObject` is small for typical shell
+/// invocations — a child rarely spawns grandchildren before the assign
+/// call lands a few microseconds later. If setup fails (rare; would
+/// require resource exhaustion), returns `None` and the timeout path
+/// falls back to `child.kill()` which only signals the direct child.
+#[cfg(windows)]
+fn setup_windows_job(
+    child: &std::process::Child,
+) -> Option<windows_sys::Win32::Foundation::HANDLE> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    // SAFETY: CreateJobObjectW with null name returns a fresh unnamed job
+    // handle or null on failure.
+    let job: HANDLE = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return None;
+    }
+
+    // SAFETY: zero-initialized struct is valid for JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+    // we only set LimitFlags. Pointer is to a stack value valid for the call duration.
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    let ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    };
+    if ok == 0 {
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+        return None;
+    }
+
+    // SAFETY: child's raw handle is valid for the duration of the Child borrow;
+    // AssignProcessToJobObject does not retain the handle past the call.
+    let assigned = unsafe { AssignProcessToJobObject(job, child.as_raw_handle() as HANDLE) };
+    if assigned == 0 {
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+        return None;
+    }
+
+    Some(job)
 }

--- a/src/lanes/execute.rs
+++ b/src/lanes/execute.rs
@@ -577,9 +577,11 @@ fn run_command_with_deadline(
             //
             // - Unix: spawn in a fresh process group, signal it with
             //   `killpg(SIGKILL)` on timeout.
-            // - Windows: assign the child to a Job Object configured
-            //   with KILL_ON_JOB_CLOSE; on timeout, `TerminateJobObject`
-            //   kills every process in the job tree.
+            // - Windows: assign the child to a Job Object; on timeout,
+            //   `TerminateJobObject` kills every process in the job tree.
+            //   The job is configured with NO limit flags — children that
+            //   outlive the parent on a successful exit are NOT reaped
+            //   when the job handle drops, matching the Unix semantic.
             #[cfg(unix)]
             command.process_group(0);
             let mut child = command.spawn().context("spawning command")?;
@@ -589,18 +591,11 @@ fn run_command_with_deadline(
             let job = setup_windows_job(&child);
 
             loop {
+                // RAII (`#[cfg(windows)] _job: Some(JobHandle)`) closes the
+                // job handle on every exit path including the `?` propagation
+                // from `try_wait`, preventing a Windows handle leak.
                 match child.try_wait().context("waiting for command")? {
-                    Some(status) => {
-                        #[cfg(windows)]
-                        if let Some(h) = job {
-                            // SAFETY: handle returned by CreateJobObjectW; closing it
-                            // after the child has exited cannot affect a living tree.
-                            unsafe {
-                                windows_sys::Win32::Foundation::CloseHandle(h);
-                            }
-                        }
-                        return Ok(status);
-                    }
+                    Some(status) => return Ok(status),
                     None => {
                         if Instant::now() >= d {
                             #[cfg(unix)]
@@ -611,17 +606,11 @@ fn run_command_with_deadline(
                                 libc::killpg(pgid, libc::SIGKILL);
                             }
                             #[cfg(windows)]
-                            if let Some(h) = job {
-                                // SAFETY: TerminateJobObject + CloseHandle on a job we
-                                // own. Exit code 1 stands for the synthetic kill.
-                                unsafe {
-                                    windows_sys::Win32::System::JobObjects::TerminateJobObject(
-                                        h, 1,
-                                    );
-                                    windows_sys::Win32::Foundation::CloseHandle(h);
+                            match &job {
+                                Some(j) => j.terminate(),
+                                None => {
+                                    let _ = child.kill();
                                 }
-                            } else {
-                                let _ = child.kill();
                             }
                             let _ = child.wait();
                             bail!("step timed out");
@@ -635,6 +624,40 @@ fn run_command_with_deadline(
     }
 }
 
+/// RAII wrapper for a Win32 Job Object handle. Drop closes the handle.
+/// The job is configured with no limit flags — closing the handle does
+/// not kill members; only an explicit `terminate()` does. This keeps the
+/// Windows path's behavior aligned with Unix: tree reaping fires on
+/// timeout, never on successful exit (so a step that intentionally
+/// backgrounds a daemon does not get its daemon killed).
+#[cfg(windows)]
+struct JobHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl JobHandle {
+    fn terminate(&self) {
+        // SAFETY: self.0 is a valid job handle owned by this guard for the
+        // lifetime of the borrow; TerminateJobObject is documented to be
+        // safe to call on a valid handle. Exit code 1 stands for the
+        // synthetic kill.
+        unsafe {
+            windows_sys::Win32::System::JobObjects::TerminateJobObject(self.0, 1);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for JobHandle {
+    fn drop(&mut self) {
+        // SAFETY: self.0 is a valid handle returned by CreateJobObjectW
+        // and never closed elsewhere — Drop is the single owner of the
+        // close call.
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
 /// Wrap the spawned child in a Job Object so that `TerminateJobObject`
 /// reaps the entire process tree on timeout. The race window between
 /// `spawn` and `AssignProcessToJobObject` is small for typical shell
@@ -643,16 +666,10 @@ fn run_command_with_deadline(
 /// require resource exhaustion), returns `None` and the timeout path
 /// falls back to `child.kill()` which only signals the direct child.
 #[cfg(windows)]
-fn setup_windows_job(
-    child: &std::process::Child,
-) -> Option<windows_sys::Win32::Foundation::HANDLE> {
+fn setup_windows_job(child: &std::process::Child) -> Option<JobHandle> {
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Foundation::HANDLE;
-    use windows_sys::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
-        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-    };
+    use windows_sys::Win32::System::JobObjects::{AssignProcessToJobObject, CreateJobObjectW};
 
     // SAFETY: CreateJobObjectW with null name returns a fresh unnamed job
     // handle or null on failure.
@@ -660,31 +677,15 @@ fn setup_windows_job(
     if job.is_null() {
         return None;
     }
-
-    // SAFETY: zero-initialized struct is valid for JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
-    // we only set LimitFlags. Pointer is to a stack value valid for the call duration.
-    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
-    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    let ok = unsafe {
-        SetInformationJobObject(
-            job,
-            JobObjectExtendedLimitInformation,
-            &info as *const _ as *const _,
-            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-        )
-    };
-    if ok == 0 {
-        unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
-        return None;
-    }
+    let guard = JobHandle(job);
 
     // SAFETY: child's raw handle is valid for the duration of the Child borrow;
     // AssignProcessToJobObject does not retain the handle past the call.
     let assigned = unsafe { AssignProcessToJobObject(job, child.as_raw_handle() as HANDLE) };
     if assigned == 0 {
-        unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+        // guard's Drop closes the job handle on this path
         return None;
     }
 
-    Some(job)
+    Some(guard)
 }

--- a/src/lanes/mod.rs
+++ b/src/lanes/mod.rs
@@ -125,6 +125,8 @@ pub(super) enum Step {
         timeout: Option<u64>,
         #[serde(default)]
         retries: Option<u32>,
+        #[serde(default)]
+        retry_delay: Option<u64>,
     },
     TaskRefFull {
         task: String,
@@ -134,6 +136,8 @@ pub(super) enum Step {
         timeout: Option<u64>,
         #[serde(default)]
         retries: Option<u32>,
+        #[serde(default)]
+        retry_delay: Option<u64>,
     },
     Parallel {
         parallel: Vec<ParallelItem>,
@@ -143,6 +147,8 @@ pub(super) enum Step {
         timeout: Option<u64>,
         #[serde(default)]
         retries: Option<u32>,
+        #[serde(default)]
+        retry_delay: Option<u64>,
     },
 }
 
@@ -173,7 +179,19 @@ impl Step {
             Step::Parallel { retries, .. } => *retries,
         }
     }
+
+    pub(super) fn retry_delay(&self) -> Option<u64> {
+        match self {
+            Step::TaskRef(_) => None,
+            Step::Inline { retry_delay, .. } => *retry_delay,
+            Step::TaskRefFull { retry_delay, .. } => *retry_delay,
+            Step::Parallel { retry_delay, .. } => *retry_delay,
+        }
+    }
 }
+
+/// Default delay between retry attempts when `retry_delay` is not specified.
+pub(super) const DEFAULT_RETRY_DELAY_SECS: u64 = 1;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -568,6 +586,9 @@ pub(super) fn dry_run_lane(
                 if let Some(retries) = step.retries() {
                     entry["retries"] = serde_json::json!(retries);
                 }
+                if let Some(retry_delay) = step.retry_delay() {
+                    entry["retry_delay"] = serde_json::json!(retry_delay);
+                }
                 entry
             })
             .collect();
@@ -698,6 +719,9 @@ fn step_annotations(step: &Step) -> String {
     if let Some(retries) = step.retries() {
         parts.push(format!("retries={retries}"));
     }
+    if let Some(retry_delay) = step.retry_delay() {
+        parts.push(format!("retry_delay={retry_delay}s"));
+    }
     if parts.is_empty() {
         String::new()
     } else {
@@ -753,6 +777,15 @@ pub(super) fn resolve_from(steps: &[Step], from: &str) -> Result<usize> {
 }
 
 pub(super) fn evaluate_when(condition: &str) -> bool {
+    evaluate_when_with(condition, |var| std::env::var(var).ok())
+}
+
+/// Like `evaluate_when` but with the env lookup injected. Used by tests so
+/// they can pass a `HashMap` instead of mutating process-global env vars.
+pub(super) fn evaluate_when_with<F>(condition: &str, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
     for part in condition.split(',') {
         let part = part.trim();
         if part.is_empty() {
@@ -761,26 +794,18 @@ pub(super) fn evaluate_when(condition: &str) -> bool {
 
         if let Some(rest) = part.strip_prefix('!') {
             if let Some((var, val)) = rest.split_once('=') {
-                match std::env::var(var) {
-                    Ok(v) if v == val => return false,
-                    _ => {}
+                if matches!(lookup(var), Some(v) if v == val) {
+                    return false;
                 }
-            } else {
-                match std::env::var(rest) {
-                    Ok(v) if !v.is_empty() => return false,
-                    _ => {}
-                }
+            } else if matches!(lookup(rest), Some(v) if !v.is_empty()) {
+                return false;
             }
         } else if let Some((var, val)) = part.split_once('=') {
-            match std::env::var(var) {
-                Ok(v) if v == val => {}
-                _ => return false,
+            if !matches!(lookup(var), Some(v) if v == val) {
+                return false;
             }
-        } else {
-            match std::env::var(part) {
-                Ok(v) if !v.is_empty() => {}
-                _ => return false,
-            }
+        } else if !matches!(lookup(part), Some(v) if !v.is_empty()) {
+            return false;
         }
     }
     true
@@ -866,6 +891,9 @@ fn format_step_extras(step: &Step) -> String {
     }
     if let Some(retries) = step.retries() {
         parts.push_str(&format!(", retries = {retries}"));
+    }
+    if let Some(retry_delay) = step.retry_delay() {
+        parts.push_str(&format!(", retry_delay = {retry_delay}"));
     }
     if parts.is_empty() {
         " ".to_string()

--- a/src/lanes/tests.rs
+++ b/src/lanes/tests.rs
@@ -466,6 +466,7 @@ fn format_lane_toml_with_parallel_inline() {
             when: None,
             timeout: None,
             retries: None,
+            retry_delay: None,
         }],
         fail_fast: true,
         source: None,
@@ -682,6 +683,7 @@ fn format_lane_toml_with_inline() {
             when: None,
             timeout: None,
             retries: None,
+            retry_delay: None,
         }],
         fail_fast: true,
         source: None,
@@ -702,6 +704,7 @@ fn format_lane_toml_with_parallel() {
             when: None,
             timeout: None,
             retries: None,
+            retry_delay: None,
         }],
         fail_fast: true,
         source: None,
@@ -1183,60 +1186,95 @@ steps = ["fail", "ok"]
 }
 
 // ── when conditions ──────────────────────────────────────────────────
+//
+// These tests use `evaluate_when_with` and a `HashMap` to avoid mutating
+// process-global env vars. Rust's test runner is multi-threaded, and on
+// edition 2024 `std::env::set_var` is `unsafe` due to soundness issues
+// with concurrent setenv/getenv calls. Routing the lookup through a
+// closure side-steps both concerns.
+
+fn env_map<I, K, V>(pairs: I) -> std::collections::HashMap<String, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    pairs
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect()
+}
+
+fn eval(condition: &str, env: &std::collections::HashMap<String, String>) -> bool {
+    super::evaluate_when_with(condition, |var| env.get(var).cloned())
+}
 
 #[test]
 fn evaluate_when_var_set() {
-    std::env::set_var("FLEDGE_TEST_WHEN_SET", "1");
-    assert!(evaluate_when("FLEDGE_TEST_WHEN_SET"));
-    std::env::remove_var("FLEDGE_TEST_WHEN_SET");
+    let env = env_map([("FLEDGE_TEST_WHEN_SET", "1")]);
+    assert!(eval("FLEDGE_TEST_WHEN_SET", &env));
 }
 
 #[test]
 fn evaluate_when_var_not_set() {
-    std::env::remove_var("FLEDGE_TEST_WHEN_UNSET");
-    assert!(!evaluate_when("FLEDGE_TEST_WHEN_UNSET"));
+    let env = env_map::<_, &str, &str>([]);
+    assert!(!eval("FLEDGE_TEST_WHEN_UNSET", &env));
+}
+
+#[test]
+fn evaluate_when_var_set_but_empty() {
+    let env = env_map([("FLEDGE_TEST_WHEN_EMPTY", "")]);
+    // Empty value is treated as not-set per the bare-VAR semantics
+    assert!(!eval("FLEDGE_TEST_WHEN_EMPTY", &env));
 }
 
 #[test]
 fn evaluate_when_var_equals() {
-    std::env::set_var("FLEDGE_TEST_WHEN_EQ", "true");
-    assert!(evaluate_when("FLEDGE_TEST_WHEN_EQ=true"));
-    assert!(!evaluate_when("FLEDGE_TEST_WHEN_EQ=false"));
-    std::env::remove_var("FLEDGE_TEST_WHEN_EQ");
+    let env = env_map([("FLEDGE_TEST_WHEN_EQ", "true")]);
+    assert!(eval("FLEDGE_TEST_WHEN_EQ=true", &env));
+    assert!(!eval("FLEDGE_TEST_WHEN_EQ=false", &env));
 }
 
 #[test]
 fn evaluate_when_negated_var() {
-    std::env::remove_var("FLEDGE_TEST_WHEN_NEG");
-    assert!(evaluate_when("!FLEDGE_TEST_WHEN_NEG"));
-    std::env::set_var("FLEDGE_TEST_WHEN_NEG", "1");
-    assert!(!evaluate_when("!FLEDGE_TEST_WHEN_NEG"));
-    std::env::remove_var("FLEDGE_TEST_WHEN_NEG");
+    let unset = env_map::<_, &str, &str>([]);
+    assert!(eval("!FLEDGE_TEST_WHEN_NEG", &unset));
+    let set = env_map([("FLEDGE_TEST_WHEN_NEG", "1")]);
+    assert!(!eval("!FLEDGE_TEST_WHEN_NEG", &set));
 }
 
 #[test]
 fn evaluate_when_negated_equals() {
-    std::env::set_var("FLEDGE_TEST_WHEN_NEQ", "prod");
-    assert!(evaluate_when("!FLEDGE_TEST_WHEN_NEQ=dev"));
-    assert!(!evaluate_when("!FLEDGE_TEST_WHEN_NEQ=prod"));
-    std::env::remove_var("FLEDGE_TEST_WHEN_NEQ");
+    let env = env_map([("FLEDGE_TEST_WHEN_NEQ", "prod")]);
+    assert!(eval("!FLEDGE_TEST_WHEN_NEQ=dev", &env));
+    assert!(!eval("!FLEDGE_TEST_WHEN_NEQ=prod", &env));
 }
 
 #[test]
 fn evaluate_when_multiple_conditions() {
-    std::env::set_var("FLEDGE_TEST_A", "1");
-    std::env::set_var("FLEDGE_TEST_B", "2");
-    assert!(evaluate_when("FLEDGE_TEST_A,FLEDGE_TEST_B"));
-    assert!(evaluate_when("FLEDGE_TEST_A=1,FLEDGE_TEST_B=2"));
-    assert!(!evaluate_when("FLEDGE_TEST_A=1,FLEDGE_TEST_B=3"));
-    std::env::remove_var("FLEDGE_TEST_A");
-    std::env::remove_var("FLEDGE_TEST_B");
+    let env = env_map([("FLEDGE_TEST_A", "1"), ("FLEDGE_TEST_B", "2")]);
+    assert!(eval("FLEDGE_TEST_A,FLEDGE_TEST_B", &env));
+    assert!(eval("FLEDGE_TEST_A=1,FLEDGE_TEST_B=2", &env));
+    assert!(!eval("FLEDGE_TEST_A=1,FLEDGE_TEST_B=3", &env));
 }
 
 #[test]
 fn evaluate_when_empty_string() {
-    assert!(evaluate_when(""));
-    assert!(evaluate_when(","));
+    let env = env_map::<_, &str, &str>([]);
+    assert!(eval("", &env));
+    assert!(eval(",", &env));
+}
+
+#[test]
+fn evaluate_when_real_env_smoke() {
+    // One smoke test that goes through the real `evaluate_when` (which
+    // reads `std::env::var`) to confirm the wrapper still works. Uses a
+    // var that's basically always present; falls back if not.
+    if std::env::var("PATH").is_ok() {
+        assert!(evaluate_when("PATH"));
+    }
+    // A definitely-not-set var name
+    assert!(!evaluate_when("FLEDGE_DEFINITELY_NOT_SET_XYZ_8675309"));
 }
 
 #[test]
@@ -1473,6 +1511,51 @@ steps = [{ run = "exit 1", retries = 2 }]
     assert!(result.is_err());
 }
 
+#[test]
+fn parse_retry_delay_on_inline() {
+    let config = parse_config(
+        r#"
+[tasks]
+
+[lanes.ci]
+steps = [{ run = "echo flaky", retries = 3, retry_delay = 5 }]
+"#,
+    );
+    assert_eq!(config.lanes["ci"].steps[0].retries(), Some(3));
+    assert_eq!(config.lanes["ci"].steps[0].retry_delay(), Some(5));
+}
+
+#[test]
+fn execute_retry_delay_zero_skips_sleep() {
+    // With retry_delay = 0 the retry loop sleeps 0s between attempts —
+    // failed-after-exhaustion completes essentially instantly, proving
+    // the delay value is honored (default 1s would make this take ~2s).
+    let config = parse_config(
+        r#"
+[tasks]
+
+[lanes.fast-fail]
+steps = [{ run = "exit 1", retries = 2, retry_delay = 0 }]
+"#,
+    );
+    let project_dir = std::env::current_dir().unwrap();
+    let start = std::time::Instant::now();
+    let result = execute_lane(
+        "fast-fail",
+        &config.lanes["fast-fail"],
+        &config.tasks,
+        &project_dir,
+        false,
+        None,
+    );
+    let elapsed = start.elapsed();
+    assert!(result.is_err());
+    assert!(
+        elapsed < std::time::Duration::from_millis(800),
+        "expected near-instant fail with retry_delay=0, took {elapsed:?}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn execute_retries_succeed_on_third_attempt() {
@@ -1580,6 +1663,7 @@ fn format_lane_toml_with_task_ref_full() {
             when: Some("CI=true".to_string()),
             timeout: Some(60),
             retries: Some(2),
+            retry_delay: None,
         }],
         fail_fast: true,
         source: None,
@@ -1600,6 +1684,7 @@ fn format_lane_toml_inline_with_extras() {
             when: Some("CI".to_string()),
             timeout: None,
             retries: Some(1),
+            retry_delay: None,
         }],
         fail_fast: true,
         source: None,

--- a/src/lanes/tests.rs
+++ b/src/lanes/tests.rs
@@ -1528,8 +1528,9 @@ steps = [{ run = "echo flaky", retries = 3, retry_delay = 5 }]
 #[test]
 fn execute_retry_delay_zero_skips_sleep() {
     // With retry_delay = 0 the retry loop sleeps 0s between attempts —
-    // failed-after-exhaustion completes essentially instantly, proving
-    // the delay value is honored (default 1s would make this take ~2s).
+    // failed-after-exhaustion runs much faster than the ~2s the default
+    // (1s) would take with `retries = 2`. We use 1500ms as the bound so
+    // a slow CI runner still passes as long as no explicit sleep fires.
     let config = parse_config(
         r#"
 [tasks]
@@ -1551,8 +1552,8 @@ steps = [{ run = "exit 1", retries = 2, retry_delay = 0 }]
     let elapsed = start.elapsed();
     assert!(result.is_err());
     assert!(
-        elapsed < std::time::Duration::from_millis(800),
-        "expected near-instant fail with retry_delay=0, took {elapsed:?}"
+        elapsed < std::time::Duration::from_millis(1500),
+        "expected near-instant fail with retry_delay=0 (default 1s × 2 retries = 2s baseline), took {elapsed:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Three follow-up items from #362's review thread that I noted as non-blocking but worth landing.

- **`retry_delay` step option** (configurable inter-attempt sleep, default 1s, supports `retry_delay = 0` for immediate retry)
- **Windows process tree kill on timeout** via Job Object + `TerminateJobObject` — mirrors the v23 Unix `process_group` + `killpg` fix, so `cmd /c "a & b"` no longer leaks grandchildren
- **Thread-safe `when` tests** — `evaluate_when_with` now takes a closure so tests pass a `HashMap` instead of mutating `std::env::set_var` (edition-2024 prep)

## Test plan

- [x] `cargo test --bin fledge` — 834 pass (4 new)
- [x] `cargo test --test lanes` — 9 pass
- [x] `cargo clippy -- -D warnings` clean (Linux + `x86_64-pc-windows-gnu` cross)
- [x] `cargo fmt --check` clean
- [x] `cargo run -- spec check` — 30/30 green
- [x] Manually verified `retry_delay = 0` (16ms total, no inter-attempt sleep) and `retry_delay = 3` (6.03s total = 2 × 3s)
- [x] Cross-compiled to `x86_64-pc-windows-gnu` to validate Windows path

## Behavioral examples

```toml
# Immediate retry, no delay
{ run = "curl health", retries = 3, retry_delay = 0 }

# Backoff-style longer wait
{ task = "deploy", retries = 2, retry_delay = 30 }

# Default — 1s delay, unchanged
{ run = "flaky-test", retries = 3 }
```

Spec bumped 23 → 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)