### PR TITLE
fix(release): build Linux binary with musl for glibc compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             artifact: fledge-linux-x86_64
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -34,6 +34,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
       - name: Rename binary


### PR DESCRIPTION
## Summary

Fixes the `GLIBC_2.39 not found` error when running fledge on Linux systems with older glibc.

- Switch Linux build target from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl`
- Add `musl-tools` package installation step in CI
- Produces a fully statically-linked binary that works on **any** Linux distro regardless of glibc version

**Root cause**: `ubuntu-latest` runners now use Ubuntu 24.04 (glibc 2.39). The gnu-target binary dynamically links against glibc, so it fails on any system with glibc < 2.39.

**Why musl**: fledge uses rustls (pure Rust TLS) — no native C library dependencies — so musl works cleanly with zero tradeoffs.

## Test plan
- [ ] Tag a release and verify the Linux binary is built successfully
- [ ] Download and run on a system with older glibc (e.g. Ubuntu 22.04)
- [ ] Verify `ldd fledge-linux-x86_64` shows "not a dynamic executable" (static)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6