### PR TITLE
docs(lanes): document when, timeout, retries, retry_delay, --from

### DIFF
--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -56,7 +56,7 @@ Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 | `fledge plugins validate --json` | `{schema_version: 1, path, plugin_name, errors, warnings}` |
 | `fledge lanes list --json` | `{schema_version: 1, lanes: [...]}` |
 | `fledge lanes search --json` | `{schema_version: 1, results: [...]}` |
-| `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps, failures}` |
+| `fledge lanes run <name> --json` | `{schema_version: 1, lane, success, duration_ms, fail_fast, steps, failures}`. Each `steps` entry has `step, name, success, duration_ms, error`; retried steps additionally carry `attempts: <n>`; skipped steps carry `skipped: true, reason: "when 'X' not met"` or `reason: "--from"` (with `success: null, duration_ms: null, error: null`). `--from <step\|index>` is also supported on `lanes run`. |
 | `fledge lanes validate --json` | `{schema_version: 1, path, lane_count, errors, warnings}` |
 | `fledge work start <name> --json` | `{schema_version: 1, action: "work_start", branch, base, type, prefix, issue}` |
 | `fledge work commit --json` | `{schema_version: 1, action: "work_commit", hash, message, branch}` |

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -207,7 +207,7 @@ fledge lanes <run|list|init|search|import|publish|create|validate>
 
 **Subcommands:**
 
-- `run <name>` - Run a lane by name (`--dry-run` to preview, `--json` for JSON output)
+- `run <name>` - Run a lane by name (`--dry-run` to preview, `--json` for JSON output, `--from <step|index>` to resume from a specific step)
 - `list` - List available lanes (`--json` for JSON output)
 - `init` - Add default lanes to `fledge.toml`
 - `search [query]` - Search GitHub for community lanes (`--author`, `--json`)
@@ -244,13 +244,17 @@ steps = [
 
 | Type | Syntax | |
 |------|--------|-|
-| Task reference | `"task_name"` | Runs a task from `[tasks]` |
+| Task reference | `"task_name"` or `{ task = "name" }` | Runs a task from `[tasks]` |
 | Inline command | `{ run = "command" }` | Shell command |
 | Parallel group | `{ parallel = ["a", "b"] }` | Concurrent execution |
 
+**Step options** (on table-form steps): `when` (env-var condition), `timeout` (per-attempt seconds), `retries` (count), `retry_delay` (seconds between attempts, default `1`). See [`fledge.toml` Reference](./fledge-toml.md#step-options) for the full forms.
+
 ```bash
-fledge lanes run ci           # run a lane
+fledge lanes run ci                   # run a lane
 fledge lanes run ci --dry-run
+fledge lanes run ci --from build      # resume from a step (name or 1-based index)
+fledge lanes run ci --json            # per-step results, including `skipped` rows
 fledge lanes list
 fledge lanes list --json
 fledge lanes init

--- a/docs/src/fledge-toml.md
+++ b/docs/src/fledge-toml.md
@@ -120,7 +120,14 @@ fail_fast = true
 
 ### Step types
 
-A step can be one of three shapes. Mix them freely.
+A step can be one of three shapes. Mix them freely. Bare-string task references are shorthand; the table form (`{ task = "name" }`) is required when you want step options like `when`, `timeout`, `retries`, or `retry_delay`.
+
+| Shape | Form | Notes |
+|-------|------|-------|
+| Task reference (short) | `"name"` | Bare string. Shorthand for `{ task = "name" }`. |
+| Task reference (full) | `{ task = "name" }` | Table form. Accepts step options. |
+| Inline command | `{ run = "..." }` | One-off shell command. Accepts step options. |
+| Parallel group | `{ parallel = [...] }` | Items run concurrently. Accepts step options. |
 
 #### Task reference
 
@@ -169,6 +176,30 @@ steps = [
 ```
 
 Parallel groups cannot be nested.
+
+### Step options
+
+Table-form steps (`{ task = "..." }`, `{ run = "..." }`, `{ parallel = [...] }`) accept four optional fields.
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `when` | string | always run | Skip the step unless an env-var condition is met. Forms: `VAR` (set & non-empty), `VAR=value` (equals), `!VAR` (unset/empty), `!VAR=value` (not equals). Comma-separated values are AND'd. |
+| `timeout` | integer | unlimited | Per-attempt deadline in seconds. The whole process tree is killed on exceed (Unix: `killpg(SIGKILL)`; Windows: `TerminateJobObject`). Includes task-dependency resolution. |
+| `retries` | integer | `0` | Retry attempts after failure. Total attempts = `retries + 1`. The step re-runs as a whole; per-step, not per-command. |
+| `retry_delay` | integer | `1` | Sleep between retry attempts in seconds. Set `0` for immediate retry. Only meaningful when `retries > 0`. |
+
+```toml
+[lanes.release]
+description = "Test, build, deploy with retries"
+steps = [
+  { task = "test", when = "!SKIP_TESTS", timeout = 300 },
+  { task = "build", timeout = 600 },
+  { run = "scripts/publish.sh", retries = 3, retry_delay = 5 },
+  { task = "deploy", when = "CI=true,BRANCH=main", timeout = 120 },
+]
+```
+
+Skipped steps appear in the human-readable output (`⏭ Step N <label> (skipped: when 'X' not met)`) and in `--json` output (`"skipped": true, "reason": "..."`). The `--from` flag adds its own skip reason: `"reason": "--from"`.
 
 ### `fail_fast`
 

--- a/docs/src/lanes.md
+++ b/docs/src/lanes.md
@@ -149,6 +149,66 @@ steps = [
 ]
 ```
 
+### Step Options
+
+Table-form steps accept four optional fields: `when`, `timeout`, `retries`, and `retry_delay`. They work on task references (`{ task = "name" }`), inline commands (`{ run = "..." }`), and parallel groups (`{ parallel = [...] }`).
+
+| Option | Type | Default | What it does |
+|--------|------|---------|--------------|
+| `when` | string | always run | Skip the step unless an env-var condition is met. See forms below. |
+| `timeout` | integer (seconds) | unlimited | Per-attempt deadline. The whole process tree is killed on exceed. |
+| `retries` | integer | `0` | Retry attempts after failure. Total attempts = `retries + 1`. |
+| `retry_delay` | integer (seconds) | `1` | Sleep between retry attempts. Set `0` for immediate retry. |
+
+```toml
+[lanes.release]
+description = "Build and ship"
+steps = [
+  { task = "test", when = "!SKIP_TESTS" },
+  { task = "build", timeout = 120 },
+  { run = "scripts/publish.sh", retries = 3, retry_delay = 5 },
+  { task = "deploy", when = "CI=true,DEPLOY_ENV=production", timeout = 60 },
+]
+```
+
+#### Conditional steps with `when`
+
+The `when` string supports four condition forms. Multiple comma-separated conditions are AND'd.
+
+| Form | Meaning |
+|------|---------|
+| `VAR` | Run when `VAR` is set and non-empty |
+| `VAR=value` | Run when `VAR` equals `value` exactly |
+| `!VAR` | Run when `VAR` is unset or empty |
+| `!VAR=value` | Run when `VAR` does not equal `value` |
+| `VAR1,VAR2=x` | AND: every condition must hold |
+
+Skipped steps are visible in the output (`⏭ Step N name (skipped: when 'X' not met)`) and in JSON output (`"skipped": true, "reason": "..."`).
+
+#### Per-step timeouts
+
+`timeout` sets a per-attempt deadline. On exceed, fledge sends `SIGKILL` to the process group on Unix or `TerminateJobObject` on Windows, so multi-statement shells (`sh -c "a && b"`, `cmd /c "a & b"`) don't leak grandchildren. If the step has `retries`, each attempt gets a fresh deadline.
+
+#### Retries with `retry_delay`
+
+`retries` re-runs the entire step on failure. `retry_delay` controls the sleep between attempts (default 1s). `retry_delay = 0` retries immediately — useful when you want to absorb a flake without slowing down the lane.
+
+```toml
+# Immediate-retry flake mitigation
+{ run = "curl https://api.example.com/health", retries = 5, retry_delay = 0 }
+```
+
+### Resuming with `--from`
+
+`fledge lanes run <name> --from <step>` skips every step before the target. Useful for "I already ran lint and test, just resume from build."
+
+```bash
+fledge lanes run ci --from build      # by step name
+fledge lanes run ci --from 3          # by 1-based index
+```
+
+Resume is stateless — no run history is persisted. Skipped steps appear in the output (`⏭ Step N (skipped by --from)`) and in JSON output (`"skipped": true, "reason": "--from"`). Targeting a parallel-group step by name doesn't work; use the index instead.
+
 ### Failure Behavior
 
 Default is `fail_fast = true`. Pipeline stops on the first failure.
@@ -256,6 +316,19 @@ steps = [
 ]
 ```
 
+#### Real CI with conditional deploy and flake retries
+
+```toml
+[lanes.ci]
+description = "Lint, test, build, and deploy on main"
+steps = [
+  { parallel = ["fmt", "lint"] },
+  { task = "test", timeout = 300 },
+  "build",
+  { task = "deploy", when = "CI=true,BRANCH=main", timeout = 120, retries = 2, retry_delay = 5 },
+]
+```
+
 ### Auto-Generated Defaults
 
 `fledge lanes init` detects your project type:
@@ -272,6 +345,8 @@ steps = [
 ```bash
 fledge lanes run ci                   # run a lane
 fledge lanes run ci --dry-run         # preview the plan
+fledge lanes run ci --from build      # resume from a step (by name or 1-based index)
+fledge lanes run ci --json            # machine-readable per-step results
 fledge lanes list                     # list lanes
 fledge lanes list --json
 fledge lanes init                     # generate defaults


### PR DESCRIPTION
## Summary

Bring the mdBook chapters in sync with the lane improvements that landed in #362 and #363. The features were spec'd and shipped in code (specs/lanes v21→v24), but the user-facing book still only described `tasks` / `inline` / `parallel` / `fail_fast`.

- **`docs/src/lanes.md`** — new "Step Options" section covering all four `when` forms (set, equals, negated, negated-value, AND), `timeout` with process-tree reaping, `retries` + `retry_delay` (default 1s, `0` for immediate); new "Resuming with `--from`" section; added a real-CI example mixing every feature; CLI cheatsheet updated with `--from` and `--json`.
- **`docs/src/fledge-toml.md`** — extended step-shape table with the table-form task reference (`{ task = "name" }`); new "Step options" subsection mirroring the spec table with concrete defaults and Unix (`killpg(SIGKILL)`) / Windows (`TerminateJobObject`) semantics; documented the JSON skip shape.
- **`docs/src/cli-reference.md`** — `--from` listed in `lanes run` flags; cheatsheet example added; cross-link to `fledge-toml.md#step-options`.
- **`docs/src/agents.md`** — `lanes run` JSON shape line now mentions `attempts` on retried steps and the `skipped: true, reason: "..."` shape (with null `success`/`duration_ms`/`error`) for both `when`-skips and `--from` skips.

JSON `schema_version` stays at `1` — additions are additive only (matches `LANES_RUN_SCHEMA` / `LANES_DRY_RUN_SCHEMA` in `src/lanes/mod.rs` and the v23 changelog entry in `specs/lanes/lanes.spec.md` that explicitly reverted the bump).

Verified end-to-end against [`corvid-agent/fledge-test-lanes`](https://github.com/corvid-agent/fledge-test-lanes) — all 45 lanes (basics, inline, parallel, deps, conditionals, timeouts, retries, fail_fast, --from, real-world, kitchen-sink, dry-run, JSON, error cases) behave as documented.

## Test plan

- [x] `fledge spec check` — 30 specs, 0 errors
- [x] `cargo test --release` — 1011 passed, 0 failed
- [x] `cargo clippy --release --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All 45 lanes in `corvid-agent/fledge-test-lanes` pass (env-on and env-off paths)
- [x] `retry_delay` verified end-to-end with custom lane: `0` → 35ms, default → ~1s/delay, `3` → ~3s/delay
- [x] JSON `reason` field confirmed for both `when`-skips (`"when 'CI' not met"`) and `--from` skips (`"--from"`)
- [ ] Local mdBook build renders the new sections cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)