### PR TITLE
fix: Windows plugin system — hook execution, stale state, binary resolution

### DIFF
--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -421,7 +421,10 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
         }
     }
 
-    run_build(&plugin_dir, &manifest)?;
+    if let Err(e) = run_build(&plugin_dir, &manifest) {
+        fs::remove_dir_all(&plugin_dir).ok();
+        return Err(e.context("build failed; installation rolled back"));
+    }
 
     if manifest.plugin.is_wasm() {
         for cmd in &manifest.commands {
@@ -448,6 +451,20 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     let command_names = link_commands(&plugin_dir, &bin_dir, &manifest).inspect_err(|_| {
         fs::remove_dir_all(&plugin_dir).ok();
     })?;
+
+    // Run post_install hook BEFORE persisting to registry so a hook failure
+    // doesn't leave the plugin marked as installed but non-functional.
+    if let Some(hook) = &manifest.hooks.post_install {
+        if let Err(e) = run_hook(&plugin_dir, hook, "post_install") {
+            // Roll back: remove symlinks and plugin directory
+            for cmd_name in &command_names {
+                let link_path = bin_dir.join(format!("fledge-{cmd_name}"));
+                fs::remove_file(&link_path).ok();
+            }
+            fs::remove_dir_all(&plugin_dir).ok();
+            return Err(e.context("post_install hook failed; installation rolled back"));
+        }
+    }
 
     let (base_source, _) = parse_source_ref(source);
     let granted_caps = if manifest.plugin.protocol.is_some() {
@@ -493,10 +510,6 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
         if !command_names.is_empty() {
             println!("  Commands: {}", style(command_names.join(", ")).cyan());
         }
-    }
-
-    if let Some(hook) = &manifest.hooks.post_install {
-        run_hook(&plugin_dir, hook, "post_install")?;
     }
 
     Ok(serde_json::json!({

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -348,9 +348,18 @@ pub fn run_lifecycle_hook(event: &str) -> Result<()> {
 
 pub fn resolve_plugin_command(name: &str) -> Option<PathBuf> {
     let bin_dir = plugin_bin_dir();
-    let bin_path = bin_dir.join(format!("fledge-{name}"));
+    let base = format!("fledge-{name}");
+    let bin_path = bin_dir.join(&base);
     if bin_path.exists() {
         return Some(bin_path);
+    }
+    if cfg!(windows) {
+        for ext in &[".exe", ".bat", ".cmd"] {
+            let with_ext = bin_dir.join(format!("{base}{ext}"));
+            if with_ext.exists() {
+                return Some(with_ext);
+            }
+        }
     }
     run_plugin::which_fledge_plugin(name)
 }

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -164,7 +164,7 @@ fn run_hook_file(hook_path: &Path, plugin_dir: &Path) -> Result<std::process::Ex
                 // Shell script or extensionless — try sh, bash, git-bash
                 for shell in &["sh", "bash"] {
                     if let Ok(status) = Command::new(shell)
-                        .arg(&hook_path)
+                        .arg(hook_path)
                         .current_dir(plugin_dir)
                         .env("FLEDGE_PLUGIN_DIR", plugin_dir)
                         .status()
@@ -176,7 +176,7 @@ fn run_hook_file(hook_path: &Path, plugin_dir: &Path) -> Result<std::process::Ex
                 let git_bash = Path::new("C:\\Program Files\\Git\\bin\\bash.exe");
                 if git_bash.exists() {
                     return Command::new(git_bash)
-                        .arg(&hook_path)
+                        .arg(hook_path)
                         .current_dir(plugin_dir)
                         .env("FLEDGE_PLUGIN_DIR", plugin_dir)
                         .status()

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -115,8 +115,7 @@ pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()>
             bail!("Hook path '{}' escapes plugin directory", hook);
         }
         super::make_executable(&hook_path)?;
-        run_hook_file(&hook_path, plugin_dir)
-            .with_context(|| format!("running {event} hook"))?
+        run_hook_file(&hook_path, plugin_dir).with_context(|| format!("running {event} hook"))?
     } else {
         let parts = shell_words::split(hook)
             .with_context(|| format!("parsing {event} hook command: {hook}"))?;
@@ -144,10 +143,7 @@ pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()>
 /// `.bat` and `.cmd` files are executed via `cmd /c`.
 fn run_hook_file(hook_path: &Path, plugin_dir: &Path) -> Result<std::process::ExitStatus> {
     if cfg!(windows) {
-        let ext = hook_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
+        let ext = hook_path.extension().and_then(|e| e.to_str()).unwrap_or("");
         match ext {
             "bat" | "cmd" => {
                 return Command::new("cmd")

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -115,10 +115,7 @@ pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()>
             bail!("Hook path '{}' escapes plugin directory", hook);
         }
         super::make_executable(&hook_path)?;
-        Command::new(&hook_path)
-            .current_dir(plugin_dir)
-            .env("FLEDGE_PLUGIN_DIR", plugin_dir)
-            .status()
+        run_hook_file(&hook_path, plugin_dir)
             .with_context(|| format!("running {event} hook"))?
     } else {
         let parts = shell_words::split(hook)
@@ -139,6 +136,70 @@ pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()>
         bail!("Hook '{}' exited with code {}", event, code);
     }
     Ok(())
+}
+
+/// Execute a hook file, handling platform differences. On Windows, shell
+/// scripts (`.sh` or extensionless) are wrapped with `sh` / `bash` /
+/// `git-bash` since `Command::new("script.sh")` produces OS error 193.
+/// `.bat` and `.cmd` files are executed via `cmd /c`.
+fn run_hook_file(hook_path: &Path, plugin_dir: &Path) -> Result<std::process::ExitStatus> {
+    if cfg!(windows) {
+        let ext = hook_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        match ext {
+            "bat" | "cmd" => {
+                return Command::new("cmd")
+                    .args(["/c", &hook_path.to_string_lossy()])
+                    .current_dir(plugin_dir)
+                    .env("FLEDGE_PLUGIN_DIR", plugin_dir)
+                    .status()
+                    .context("running hook via cmd /c");
+            }
+            "exe" => {
+                return Command::new(hook_path)
+                    .current_dir(plugin_dir)
+                    .env("FLEDGE_PLUGIN_DIR", plugin_dir)
+                    .status()
+                    .context("running hook exe");
+            }
+            _ => {
+                // Shell script or extensionless — try sh, bash, git-bash
+                for shell in &["sh", "bash"] {
+                    if let Ok(status) = Command::new(shell)
+                        .arg(&hook_path)
+                        .current_dir(plugin_dir)
+                        .env("FLEDGE_PLUGIN_DIR", plugin_dir)
+                        .status()
+                    {
+                        return Ok(status);
+                    }
+                }
+                // git-bash as last resort (common on Windows via Git for Windows)
+                let git_bash = Path::new("C:\\Program Files\\Git\\bin\\bash.exe");
+                if git_bash.exists() {
+                    return Command::new(git_bash)
+                        .arg(&hook_path)
+                        .current_dir(plugin_dir)
+                        .env("FLEDGE_PLUGIN_DIR", plugin_dir)
+                        .status()
+                        .context("running hook via git-bash");
+                }
+                bail!(
+                    "Cannot run hook '{}': no shell interpreter found.\n  \
+                     Install Git for Windows (which includes bash) or add sh/bash to PATH.",
+                    hook_path.display()
+                );
+            }
+        }
+    }
+
+    Command::new(hook_path)
+        .current_dir(plugin_dir)
+        .env("FLEDGE_PLUGIN_DIR", plugin_dir)
+        .status()
+        .context("running hook")
 }
 
 fn resolve_plugin_by_name(plugin_name: &str) -> Option<PathBuf> {
@@ -235,6 +296,14 @@ pub(super) fn which_fledge_plugin(name: &str) -> Option<PathBuf> {
         let candidate = dir.join(&target);
         if candidate.exists() {
             return Some(candidate);
+        }
+        if cfg!(windows) {
+            for ext in &[".exe", ".bat", ".cmd"] {
+                let with_ext = dir.join(format!("{target}{ext}"));
+                if with_ext.exists() {
+                    return Some(with_ext);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that made plugins completely unusable on Windows (#372):

- **Hook execution**: Shell script hooks (`.sh`/extensionless) now try `sh`, `bash`, and git-bash on Windows instead of failing with OS error 193. `.bat`/`.cmd` hooks execute via `cmd /c`, `.exe` hooks run directly.
- **Stale install state**: `post_install` hook now runs *before* persisting to the plugin registry. On hook/build failure, symlinks and the plugin directory are cleaned up so reinstall isn't blocked by "already installed".
- **Binary resolution**: `resolve_plugin_command()` and `which_fledge_plugin()` now check `.exe`, `.bat`, `.cmd` extensions on Windows when resolving plugin binaries.

## Files Changed

- `src/plugin/run_plugin.rs` — New `run_hook_file()` helper for platform-aware hook execution; Windows extension search in `which_fledge_plugin()`
- `src/plugin/mod.rs` — Windows extension search in `resolve_plugin_command()`
- `src/plugin/install.rs` — Moved `post_install` before `save_registry()` with rollback; added rollback for `run_build()` failures

## Test Plan

- [x] `cargo check` passes
- [x] All 151 plugin unit tests pass (1 pre-existing integration test failure on `main`, unrelated)
- [ ] Manual test on Windows 11 with `fledge-plugin-bridge` (needs Windows CI or @kyntrin to verify)

Fixes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)