### PR TITLE
fix: auto-route Ollama Cloud models to ollama.com when API key is set

### DIFF
--- a/specs/llm/llm.spec.md
+++ b/specs/llm/llm.spec.md
@@ -1,6 +1,6 @@
 ---
 module: llm
-version: 3
+version: 4
 status: active
 files:
   - src/llm.rs
@@ -33,6 +33,9 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 | `resolve_provider_kind` | Determine active provider given config + override |
 | `build_provider` | Construct the concrete provider box from config + env + overrides |
 | `normalize_ollama_host` | Ensures `OllamaProvider.host` always has a scheme; prepends `http://` to bare `host:port` values |
+| `resolve_effective_host` | Picks the Ollama host: env var > custom config > cloud auto-route > default localhost |
+| `is_cloud_model` | Returns `true` when a model tag contains `-cloud` (e.g. `qwen3-coder:480b-cloud`) |
+| `DEFAULT_OLLAMA_CLOUD_HOST` | `"https://ollama.com"` — the Ollama Cloud API endpoint |
 | `describe` | Human string: `"claude (sonnet-4.5)"` or `"ollama (llama3.3)"` |
 
 ### Structs & Enums
@@ -59,6 +62,8 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 | `build_provider` | `(&Config, &ProviderOverride) -> Result<Box<dyn LlmProvider>>` | Builds a concrete provider; model follows the same precedence order |
 | `normalize_ollama_host` | `(&str) -> String` | Trims whitespace and trailing `/`; prepends `http://` when no scheme is present |
 | `describe` | `(&dyn LlmProvider) -> String` | Pretty formatter for spinner messages and JSON payloads |
+| `resolve_effective_host` | `(&Config, &str, &Option<String>) -> String` | Cloud-aware host resolution: `OLLAMA_HOST` env > custom config > cloud auto-route (when API key + cloud model) > default localhost |
+| `is_cloud_model` | `(&str) -> bool` | True when model name contains `-cloud` qualifier |
 | `ProviderKind::parse` | `(&str) -> Result<Self>` | Case-insensitive parse; trims whitespace |
 | `ProviderKind::as_str` | `(&self) -> &'static str` | `"claude"` or `"ollama"` |
 
@@ -73,6 +78,9 @@ Provider abstraction for LLM-backed commands. `fledge ask` and `fledge review` b
 7. Network errors from Ollama surface with the full URL in the message so users can diagnose host / port / daemon-down issues quickly
 8. No provider implementation modifies the prompt text — spec context composition stays in `ask` / `review`
 9. `OllamaProvider.timeout` is resolved by `build_provider` with precedence `FLEDGE_AI_TIMEOUT` env var (seconds, integer) > `ai.ollama.timeout_seconds` config > default 600s; a non-integer env value is ignored and falls through to config
+10. When the model tag contains `-cloud` and an API key is available, `resolve_effective_host` auto-routes to `https://ollama.com` — bypassing the local daemon which cannot forward client Bearer tokens. An explicit `OLLAMA_HOST` env var or non-default config host always take priority over cloud auto-routing.
+11. `build_provider` bails early with a descriptive error when a cloud model is selected but no API key is configured (`OLLAMA_API_KEY` env or `ai.ollama.api_key` config)
+12. Empty API key strings (from config or env) are treated as absent — they do not trigger Bearer headers or cloud routing
 
 ## Behavioral Examples
 
@@ -91,13 +99,14 @@ $ fledge ask "what does the trust module do?"
 [Local-model answer]
 ```
 
-### Switch to Ollama Cloud / Turbo
+### Switch to Ollama Cloud (auto-routed)
 ```
 $ fledge config set ai.provider ollama
-$ fledge config set ai.ollama.host https://ollama.com
 $ fledge config set ai.ollama.api_key sk-...
-$ fledge config set ai.ollama.model "claude-sonnet-4.5"  # if the endpoint supports it
-$ fledge ask --with-specs work "why does work sanitize branch names?"
+$ fledge config set ai.ollama.model "qwen3-coder:480b-cloud"
+$ fledge ask "why does work sanitize branch names?"
+● Thinking [ollama (qwen3-coder:480b-cloud)]:
+# Host auto-routed to https://ollama.com (cloud model + API key)
 ```
 
 ### Per-invocation override
@@ -114,6 +123,7 @@ $ fledge review --provider claude --model opus-4
 | `claude` CLI not installed | Active provider is `claude` | Bail via existing `github::ensure_claude_cli` check |
 | Ollama host unreachable | POST to `<host>/api/generate` fails | Bail with the full URL and a "(is the Ollama server running?)" hint |
 | Malformed Ollama response | `/api/generate` returns non-JSON or missing `response` field | Bail with decoding error |
+| Cloud model without API key | Model tag contains `-cloud` but no `OLLAMA_API_KEY` env or `ai.ollama.api_key` config | Bail with "requires authentication" and setup instructions |
 
 ## Dependencies
 
@@ -126,6 +136,7 @@ $ fledge review --provider claude --model opus-4
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-05-08 | Add cloud auto-routing: `resolve_effective_host`, `is_cloud_model`, `DEFAULT_OLLAMA_CLOUD_HOST`; `build_provider` bails on cloud models without API key; empty API keys treated as absent |
 | 3 | 2026-04-27 | Document `normalize_ollama_host`, ensures bare `host:port` values get an `http://` scheme; update invariant 3 to describe full normalization behavior |
 | 2 | 2026-04-24 | `OllamaProvider` gains a `timeout: Duration` field populated by `build_provider`; adds `ai.ollama.timeout_seconds` config fallback so the per-request timeout is tunable without env vars (`FLEDGE_AI_TIMEOUT` still wins) |
 | 1 | 2026-04-23 | Initial spec, provider abstraction with Claude + Ollama implementations, env-var and config resolution, CLI overrides |

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -92,11 +92,11 @@ fn status(json: bool) -> Result<()> {
                 .ok()
                 .or_else(|| config.ai.ollama.api_key.clone())
                 .filter(|k| !k.is_empty());
-            let effective_host =
-                crate::llm::resolve_effective_host(&config, &m, &api_key);
+            let effective_host = crate::llm::resolve_effective_host(&config, &m, &api_key);
             let is_cloud = crate::llm::is_cloud_model(&m);
-            let routed_to_cloud =
-                is_cloud && api_key.is_some() && effective_host == crate::llm::DEFAULT_OLLAMA_CLOUD_HOST;
+            let routed_to_cloud = is_cloud
+                && api_key.is_some()
+                && effective_host == crate::llm::DEFAULT_OLLAMA_CLOUD_HOST;
 
             let h_source = if std::env::var("OLLAMA_HOST").is_ok() {
                 Source::Env
@@ -172,7 +172,7 @@ fn status(json: bool) -> Result<()> {
     }
     if let (Some(h), Some(src)) = (&report.host, &report.host_source) {
         let cloud_note = if report.cloud_routed == Some(true) {
-            format!(" (auto-routed to cloud)")
+            " (auto-routed to cloud)".to_string()
         } else {
             format!(" (from {})", src.label())
         };

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -70,21 +70,55 @@ struct StatusReport {
     model_source: Option<Source>,
     host: Option<String>,
     host_source: Option<Source>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    api_key_source: Option<Source>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cloud_routed: Option<bool>,
 }
 
 fn status(json: bool) -> Result<()> {
     let config = Config::load().context("loading config")?;
     let (kind, provider_source) = resolve_provider_with_source(&config)?;
 
-    let (model, model_source, host, host_source) = match kind {
+    let (model, model_source, host, host_source, api_key_source, cloud_routed) = match kind {
         ProviderKind::Claude => {
             let (m, s) = resolve_claude_model(&config);
-            (m, s, None, None)
+            (m, s, None, None, None, None)
         }
         ProviderKind::Ollama => {
             let (m, ms) = resolve_ollama_model(&config);
-            let (h, hs) = resolve_ollama_host(&config);
-            (Some(m), Some(ms), Some(h), Some(hs))
+            let aks = resolve_ollama_api_key_source(&config);
+            let api_key = std::env::var("OLLAMA_API_KEY")
+                .ok()
+                .or_else(|| config.ai.ollama.api_key.clone())
+                .filter(|k| !k.is_empty());
+            let effective_host =
+                crate::llm::resolve_effective_host(&config, &m, &api_key);
+            let is_cloud = crate::llm::is_cloud_model(&m);
+            let routed_to_cloud =
+                is_cloud && api_key.is_some() && effective_host == crate::llm::DEFAULT_OLLAMA_CLOUD_HOST;
+
+            let h_source = if std::env::var("OLLAMA_HOST").is_ok() {
+                Source::Env
+            } else if routed_to_cloud {
+                Source::Default
+            } else {
+                let default_host = "http://localhost:11434";
+                if crate::llm::normalize_ollama_host(&config.ai.ollama.host) == default_host {
+                    Source::Default
+                } else {
+                    Source::ConfigFile
+                }
+            };
+
+            (
+                Some(m),
+                Some(ms),
+                Some(effective_host),
+                Some(h_source),
+                aks,
+                Some(routed_to_cloud),
+            )
         }
     };
 
@@ -95,6 +129,8 @@ fn status(json: bool) -> Result<()> {
         model_source,
         host,
         host_source,
+        api_key_source,
+        cloud_routed,
     };
 
     if json {
@@ -107,6 +143,9 @@ fn status(json: bool) -> Result<()> {
             "model_source": report.model_source,
             "host": report.host,
             "host_source": report.host_source,
+            "api_key_set": report.api_key_source.is_some(),
+            "api_key_source": report.api_key_source,
+            "cloud_routed": report.cloud_routed,
         });
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
@@ -132,12 +171,32 @@ fn status(json: bool) -> Result<()> {
         ),
     }
     if let (Some(h), Some(src)) = (&report.host, &report.host_source) {
+        let cloud_note = if report.cloud_routed == Some(true) {
+            format!(" (auto-routed to cloud)")
+        } else {
+            format!(" (from {})", src.label())
+        };
         println!(
             "      {} {} {}",
             style("Host:").bold(),
             style(h).cyan(),
-            style(format!("(from {})", src.label())).dim()
+            style(cloud_note).dim()
         );
+    }
+    if report.provider == "ollama" {
+        match &report.api_key_source {
+            Some(src) => println!(
+                "   {} {} {}",
+                style("API Key:").bold(),
+                style("***").green(),
+                style(format!("(from {})", src.label())).dim()
+            ),
+            None => println!(
+                "   {} {}",
+                style("API Key:").bold(),
+                style("(not set — required for cloud models)").dim()
+            ),
+        }
     }
     Ok(())
 }
@@ -177,6 +236,28 @@ fn resolve_ollama_model(config: &Config) -> (String, Source) {
     }
 }
 
+fn resolve_ollama_api_key_source(config: &Config) -> Option<Source> {
+    if std::env::var("OLLAMA_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+        .is_some()
+    {
+        return Some(Source::Env);
+    }
+    if config
+        .ai
+        .ollama
+        .api_key
+        .as_ref()
+        .filter(|k| !k.is_empty())
+        .is_some()
+    {
+        return Some(Source::ConfigFile);
+    }
+    None
+}
+
+#[cfg(test)]
 fn resolve_ollama_host(config: &Config) -> (String, Source) {
     if let Ok(v) = std::env::var("OLLAMA_HOST") {
         return (crate::llm::normalize_ollama_host(&v), Source::Env);
@@ -339,6 +420,11 @@ fn models(provider: Option<String>, search: Option<String>, json: bool) -> Resul
 }
 
 fn list_ollama_models(config: &Config) -> Result<Vec<ModelEntry>> {
+    let api_key = std::env::var("OLLAMA_API_KEY")
+        .ok()
+        .or_else(|| config.ai.ollama.api_key.clone())
+        .filter(|k| !k.is_empty());
+
     let host = crate::llm::normalize_ollama_host(
         &std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone()),
     );
@@ -350,10 +436,7 @@ fn list_ollama_models(config: &Config) -> Result<Vec<ModelEntry>> {
         .into();
 
     let mut req = ureq::Agent::get(&agent, &url).header("User-Agent", "fledge-cli");
-    if let Some(key) = std::env::var("OLLAMA_API_KEY")
-        .ok()
-        .or_else(|| config.ai.ollama.api_key.clone())
-    {
+    if let Some(ref key) = api_key {
         req = req.header("Authorization", &format!("Bearer {key}"));
     }
 
@@ -421,6 +504,34 @@ fn use_provider(provider: Option<String>, model: Option<String>) -> Result<()> {
         Some(m) => Some(m),
         None => prompt_for_model(kind, &config)?,
     };
+
+    // If a cloud model is selected and no API key is configured, prompt for one.
+    if let Some(ref m) = chosen_model {
+        if matches!(kind, ProviderKind::Ollama)
+            && crate::llm::is_cloud_model(m)
+            && resolve_ollama_api_key_source(&config).is_none()
+            && utils::is_interactive()
+        {
+            eprintln!(
+                "  {} Cloud model '{}' requires an API key.",
+                style("⚠").yellow().bold(),
+                style(m).cyan()
+            );
+            eprintln!(
+                "  Get one at {} or run {}",
+                style("https://ollama.com/settings/keys").underlined(),
+                style("ollama signin").cyan()
+            );
+            let key: String = dialoguer::Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Ollama API key (empty to skip)")
+                .allow_empty_password(true)
+                .interact()
+                .context("reading API key")?;
+            if !key.is_empty() {
+                config.set("ai.ollama.api_key", &key)?;
+            }
+        }
+    }
 
     // Persist to config.
     config.set("ai.provider", kind.as_str())?;

--- a/src/config_cmds.rs
+++ b/src/config_cmds.rs
@@ -182,10 +182,7 @@ pub fn handle_config(action: ConfigAction) -> Result<()> {
             if key_override.is_some() {
                 print_config_value_described(
                     "ai.ollama.api_key",
-                    &format!(
-                        "*** {}",
-                        style("(from OLLAMA_API_KEY env)").dim()
-                    ),
+                    &format!("*** {}", style("(from OLLAMA_API_KEY env)").dim()),
                     "Ollama Cloud API key",
                 );
             } else {

--- a/src/config_cmds.rs
+++ b/src/config_cmds.rs
@@ -156,16 +156,46 @@ pub fn handle_config(action: ConfigAction) -> Result<()> {
                 &config.ai.claude.model,
                 "Claude model name",
             );
-            print_config_value_described(
-                "ai.ollama.host",
-                &config.ai.ollama.host,
-                "Ollama API endpoint URL",
-            );
-            print_config_described(
-                "ai.ollama.api_key",
-                &config.ai.ollama.api_key.as_ref().map(|_| "***".to_string()),
-                "Ollama Cloud API key",
-            );
+
+            let host_override = std::env::var("OLLAMA_HOST").ok();
+            if host_override.is_some() {
+                print_config_value_described(
+                    "ai.ollama.host",
+                    &format!(
+                        "{} {}",
+                        config.ai.ollama.host,
+                        style("(⚠ overridden by OLLAMA_HOST env)").yellow()
+                    ),
+                    "Ollama API endpoint URL",
+                );
+            } else {
+                print_config_value_described(
+                    "ai.ollama.host",
+                    &config.ai.ollama.host,
+                    "Ollama API endpoint URL",
+                );
+            }
+
+            let key_override = std::env::var("OLLAMA_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty());
+            if key_override.is_some() {
+                print_config_value_described(
+                    "ai.ollama.api_key",
+                    &format!(
+                        "*** {}",
+                        style("(from OLLAMA_API_KEY env)").dim()
+                    ),
+                    "Ollama Cloud API key",
+                );
+            } else {
+                print_config_described(
+                    "ai.ollama.api_key",
+                    &config.ai.ollama.api_key.as_ref().map(|_| "***".to_string()),
+                    "Ollama Cloud API key",
+                );
+            }
+
             print_config_value_described(
                 "ai.ollama.model",
                 &config.ai.ollama.model,

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,6 +29,45 @@ impl ProviderKind {
     }
 }
 
+pub const DEFAULT_OLLAMA_CLOUD_HOST: &str = "https://ollama.com";
+
+/// Returns `true` when the model tag looks like an Ollama Cloud model.
+/// Cloud model names use a `-cloud` qualifier (e.g. `qwen3-coder:480b-cloud`).
+pub fn is_cloud_model(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    lower.ends_with("-cloud") || lower.contains("-cloud:")
+}
+
+/// Resolve the effective Ollama host, accounting for cloud model auto-routing.
+///
+/// Precedence:
+/// 1. `OLLAMA_HOST` env var (explicit user override — always wins)
+/// 2. Non-default config host (user explicitly configured a custom host)
+/// 3. Cloud host when API key is present AND model is a cloud model
+/// 4. Config host (default: `http://localhost:11434`)
+pub fn resolve_effective_host(
+    config: &Config,
+    model: &str,
+    api_key: &Option<String>,
+) -> String {
+    if let Ok(host) = std::env::var("OLLAMA_HOST") {
+        return normalize_ollama_host(&host);
+    }
+
+    let config_host = normalize_ollama_host(&config.ai.ollama.host);
+    let default_host = "http://localhost:11434";
+
+    if config_host != default_host {
+        return config_host;
+    }
+
+    if api_key.is_some() && is_cloud_model(model) {
+        return DEFAULT_OLLAMA_CLOUD_HOST.to_string();
+    }
+
+    config_host
+}
+
 /// Ensure a host string has a scheme; prepend `http://` when missing.
 pub fn normalize_ollama_host(host: &str) -> String {
     let h = host.trim().trim_end_matches('/');
@@ -233,17 +272,25 @@ pub fn build_provider(
                 .or_else(|| config.ai.claude.model.clone()),
         })),
         ProviderKind::Ollama => {
-            let host = normalize_ollama_host(
-                &std::env::var("OLLAMA_HOST").unwrap_or_else(|_| config.ai.ollama.host.clone()),
-            );
             let api_key = std::env::var("OLLAMA_API_KEY")
                 .ok()
-                .or_else(|| config.ai.ollama.api_key.clone());
+                .or_else(|| config.ai.ollama.api_key.clone())
+                .filter(|k| !k.is_empty());
             let model = overrides
                 .model
                 .clone()
                 .or(env_model)
                 .unwrap_or_else(|| config.ai.ollama.model.clone());
+            let host = resolve_effective_host(config, &model, &api_key);
+
+            if is_cloud_model(&model) && api_key.is_none() {
+                bail!(
+                    "Cloud model '{}' requires authentication.\n  \
+                     Set OLLAMA_API_KEY env var or run: fledge config set ai.ollama.api_key <key>",
+                    model
+                );
+            }
+
             let timeout = resolve_ollama_timeout(config);
             Ok(Box::new(OllamaProvider {
                 host,
@@ -537,5 +584,155 @@ mod tests {
         // sane. Timeout value is verified directly in resolve_ollama_timeout
         // tests above.
         let _ = build_provider(&config, &ProviderOverride::default()).unwrap();
+    }
+
+    #[test]
+    fn is_cloud_model_matches_variants() {
+        assert!(is_cloud_model("qwen3-coder:480b-cloud"));
+        assert!(is_cloud_model("llama3-cloud"));
+        assert!(is_cloud_model("model-cloud:latest"));
+        assert!(!is_cloud_model("llama3.3"));
+        assert!(!is_cloud_model("qwen3-coder:480b"));
+        assert!(!is_cloud_model("cloudflare-model"));
+    }
+
+    #[test]
+    fn resolve_host_local_by_default() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config::default();
+        let host = resolve_effective_host(&config, "llama3.3", &None);
+        assert_eq!(host, "http://localhost:11434");
+    }
+
+    #[test]
+    fn resolve_host_routes_cloud_model_when_key_present() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config::default();
+        let key = Some("test-key".to_string());
+        let host = resolve_effective_host(&config, "qwen3-coder:480b-cloud", &key);
+        assert_eq!(host, DEFAULT_OLLAMA_CLOUD_HOST);
+    }
+
+    #[test]
+    fn resolve_host_stays_local_for_cloud_model_without_key() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config::default();
+        let host = resolve_effective_host(&config, "qwen3-coder:480b-cloud", &None);
+        assert_eq!(host, "http://localhost:11434");
+    }
+
+    #[test]
+    fn resolve_host_respects_explicit_config_host() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config {
+            ai: AiConfig {
+                ollama: OllamaConfig {
+                    host: "https://custom.example.com".into(),
+                    ..OllamaConfig::default()
+                },
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        let key = Some("test-key".to_string());
+        let host = resolve_effective_host(&config, "qwen3-coder:480b-cloud", &key);
+        assert_eq!(host, "https://custom.example.com");
+    }
+
+    #[test]
+    fn resolve_host_env_var_wins_over_cloud_auto() {
+        let _g = test_lock();
+        clear_env();
+        std::env::set_var("OLLAMA_HOST", "https://override.example.com");
+        let config = Config::default();
+        let key = Some("test-key".to_string());
+        let host = resolve_effective_host(&config, "qwen3-coder:480b-cloud", &key);
+        assert_eq!(host, "https://override.example.com");
+        clear_env();
+    }
+
+    #[test]
+    fn resolve_host_stays_local_for_non_cloud_with_key() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config::default();
+        let key = Some("test-key".to_string());
+        let host = resolve_effective_host(&config, "llama3.3", &key);
+        assert_eq!(host, "http://localhost:11434");
+    }
+
+    #[test]
+    fn build_ollama_cloud_model_without_key_errors() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config {
+            ai: AiConfig {
+                provider: Some("ollama".into()),
+                ollama: OllamaConfig {
+                    model: "qwen3-coder:480b-cloud".into(),
+                    ..OllamaConfig::default()
+                },
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        match build_provider(&config, &ProviderOverride::default()) {
+            Err(e) => assert!(
+                e.to_string().contains("requires authentication"),
+                "unexpected error: {e}"
+            ),
+            Ok(_) => panic!("expected error for cloud model without API key"),
+        }
+    }
+
+    #[test]
+    fn build_ollama_cloud_model_with_key_succeeds() {
+        let _g = test_lock();
+        clear_env();
+        std::env::set_var("OLLAMA_API_KEY", "test-key");
+        let config = Config {
+            ai: AiConfig {
+                provider: Some("ollama".into()),
+                ollama: OllamaConfig {
+                    model: "qwen3-coder:480b-cloud".into(),
+                    ..OllamaConfig::default()
+                },
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        let provider = build_provider(&config, &ProviderOverride::default()).unwrap();
+        assert_eq!(provider.kind(), ProviderKind::Ollama);
+        assert_eq!(provider.model_name(), Some("qwen3-coder:480b-cloud"));
+        clear_env();
+    }
+
+    #[test]
+    fn empty_api_key_treated_as_none() {
+        let _g = test_lock();
+        clear_env();
+        let config = Config {
+            ai: AiConfig {
+                provider: Some("ollama".into()),
+                ollama: OllamaConfig {
+                    api_key: Some("".into()),
+                    model: "qwen3-coder:480b-cloud".into(),
+                    ..OllamaConfig::default()
+                },
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        match build_provider(&config, &ProviderOverride::default()) {
+            Err(e) => assert!(
+                e.to_string().contains("requires authentication"),
+                "unexpected error: {e}"
+            ),
+            Ok(_) => panic!("expected error for cloud model with empty API key"),
+        }
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -45,11 +45,7 @@ pub fn is_cloud_model(model: &str) -> bool {
 /// 2. Non-default config host (user explicitly configured a custom host)
 /// 3. Cloud host when API key is present AND model is a cloud model
 /// 4. Config host (default: `http://localhost:11434`)
-pub fn resolve_effective_host(
-    config: &Config,
-    model: &str,
-    api_key: &Option<String>,
-) -> String {
+pub fn resolve_effective_host(config: &Config, model: &str, api_key: &Option<String>) -> String {
     if let Ok(host) = std::env::var("OLLAMA_HOST") {
         return normalize_ollama_host(&host);
     }


### PR DESCRIPTION
## Summary

- Cloud models (e.g. `qwen3-coder:480b-cloud`) now auto-route to `https://ollama.com` when `OLLAMA_API_KEY` is configured, instead of going through `localhost:11434` where the local daemon can't forward auth
- `fledge ai status` now shows API key source (env/config/not set) and whether cloud routing is active
- `fledge ai use` prompts for API key when selecting a cloud model without one configured
- `fledge config list` now shows env var override indicators for `OLLAMA_HOST` and `OLLAMA_API_KEY`
- Empty API keys are filtered as `None` — prevents sending `Authorization: Bearer ` with no token

## Host resolution precedence

1. `OLLAMA_HOST` env var (explicit user override — always wins)
2. Non-default config host (user explicitly configured a custom endpoint)
3. Cloud host (`https://ollama.com`) when API key present AND model is cloud
4. Default localhost (`http://localhost:11434`)

## Test plan

- [x] 844 unit tests pass
- [x] `is_cloud_model` correctly matches `-cloud` variants
- [x] `resolve_effective_host` routes cloud models to ollama.com with key
- [x] Cloud model stays local when no key is present
- [x] Explicit `OLLAMA_HOST` env var overrides cloud auto-routing
- [x] Custom config host overrides cloud auto-routing
- [x] Non-cloud models stay local even with API key set
- [x] `build_provider` errors early when cloud model lacks API key
- [x] Empty API key string treated as missing

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)