### PR TITLE
🧪 [Testing Improvement] Add known value test for compute_file_hash in meta.rs

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -130,6 +130,21 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn compute_file_hash_known_values() {
+        // Test empty input
+        assert_eq!(
+            compute_file_hash(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+
+        // Test known string
+        assert_eq!(
+            compute_file_hash(b"hello world"),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
     fn compute_file_hash_is_deterministic() {
         let h1 = compute_file_hash(b"hello world");
         let h2 = compute_file_hash(b"hello world");


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage verifying the actual output values of `compute_file_hash` in `src/meta.rs`. The function is a pure function taking a byte slice and returning a hex string, making it easy to test against known inputs and outputs.
📊 **Coverage:** The new `compute_file_hash_known_values` test case covers testing `compute_file_hash` against known standard inputs (`b""` and `b"hello world"`) and their correct SHA-256 hex string outputs.
✨ **Result:** The test coverage for `compute_file_hash` is improved, ensuring the function correctly computes SHA-256 hashes for different types of inputs and that the outputs are accurate. The function is now fully tested.

---
*PR created automatically by Jules for task [12051132266958993774](https://jules.google.com/task/12051132266958993774) started by @0xLeif*