### PR TITLE
🧹 [code health improvement] Remove unused schema_version field from FledgeFile

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -16,8 +16,6 @@ const RUN_INIT_SCHEMA: u32 = 1;
 struct FledgeFile {
     #[serde(default)]
     tasks: BTreeMap<String, TaskDef>,
-    #[allow(dead_code)]
-    schema_version: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
🎯 **What:** Removed the unused `schema_version` field from the `FledgeFile` struct in `src/run.rs`.
💡 **Why:** This is dead code that was marked with `#[allow(dead_code)]`. Removing it improves code health and readability without changing behavior.
✅ **Verification:** Verified by running `cargo test` which confirmed no regressions or broken functionality. 
✨ **Result:** A cleaner struct definition that only contains fields that are actively used.

---
*PR created automatically by Jules for task [3929878372658690201](https://jules.google.com/task/3929878372658690201) started by @0xLeif*