### PR TITLE
🧹 Refactor README.md.tera template to remove TODO

### DIFF
--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -232,7 +232,7 @@ fn write_example_files(target: &Path) -> Result<()> {
 
 ## Getting Started
 
-TODO: Add setup instructions here.
+> Add instructions on how to set up and run {{ project_name }}.
 
 ## License
 


### PR DESCRIPTION
🎯 **What:** Removed `TODO` string in the generated `README.md.tera` template and replaced it with generic instructions and a template variable: `> Add instructions on how to set up and run {{ project_name }}.`
💡 **Why:** It removes a hardcoded TODO inside a generated template string replacing it with something sensible which utilizes Tera template engine and acts as a better placeholder for the user. It improves the code health.
✅ **Verification:** Verified that tests pass via `cargo test` and ensured the fix affects only a single template string, without functional side-effects.
✨ **Result:** Cleaned up code health issue.

---
*PR created automatically by Jules for task [5385571934410186655](https://jules.google.com/task/5385571934410186655) started by @0xLeif*