### PR TITLE
🧪 [testing improvement] Add edge case test for check_requirements invalid characters

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1110,6 +1110,21 @@ ignore = ["template.toml"]
     }
 
     #[test]
+    fn check_requirements_rejects_invalid_chars() {
+        let (found, missing) = check_requirements(&[
+            "".to_string(),
+            "tool/path".to_string(),
+            "tool\\path".to_string(),
+            "tool\0path".to_string(),
+        ]);
+        assert!(found.is_empty());
+        assert_eq!(
+            missing,
+            vec!["", "tool/path", "tool\\path", "tool\0path"]
+        );
+    }
+
+    #[test]
     fn safe_join_rejects_traversal() {
         let base = Path::new("/tmp/project");
         assert!(safe_join(base, "../etc/passwd").is_err());

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1118,10 +1118,7 @@ ignore = ["template.toml"]
             "tool\0path".to_string(),
         ]);
         assert!(found.is_empty());
-        assert_eq!(
-            missing,
-            vec!["", "tool/path", "tool\\path", "tool\0path"]
-        );
+        assert_eq!(missing, vec!["", "tool/path", "tool\\path", "tool\0path"]);
     }
 
     #[test]


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed: added an edge-case test covering the input validation logic within `check_requirements` that prevents invalid strings containing `/`, `\`, or `\0` from being executed as subcommands.
* 📊 **Coverage:** What scenarios are now tested: inputs like an empty string, strings containing `/`, strings containing `\`, and strings containing `\0` are all tested to ensure they are immediately returned as missing and bypassed safely.
* ✨ **Result:** The improvement in test coverage: better confidence in the parsing/validation of system commands before they are tested against the path, covering all edge-cases for invalid executable characters across platforms.

---
*PR created automatically by Jules for task [10860637025065076653](https://jules.google.com/task/10860637025065076653) started by @0xLeif*