### PR TITLE
🧹 [code health improvement] Remove unused `resolve_meta_path` function

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -115,7 +115,6 @@ fn write_dot_fledge_gitignore(dot_fledge_dir: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-
     #[test]
     fn compute_file_hash_is_deterministic() {
         let h1 = compute_file_hash(b"hello world");
@@ -128,5 +127,4 @@ mod tests {
     fn compute_file_hash_changes_with_content() {
         assert_ne!(compute_file_hash(b"a"), compute_file_hash(b"b"));
     }
-
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -27,19 +27,6 @@ pub struct SourceInfo {
     pub updated: Option<String>,
 }
 
-#[allow(dead_code)]
-pub fn resolve_meta_path(project_dir: &Path) -> Option<PathBuf> {
-    let new_path = project_dir.join(".fledge").join("meta.toml");
-    if new_path.exists() {
-        return Some(new_path);
-    }
-    let legacy_path = project_dir.join(".fledge.toml");
-    if legacy_path.exists() {
-        return Some(legacy_path);
-    }
-    None
-}
-
 fn ensure_dot_fledge_dir(project_dir: &Path) -> Result<PathBuf> {
     let dir = project_dir.join(".fledge");
     if !dir.exists() {
@@ -127,7 +114,7 @@ fn write_dot_fledge_gitignore(dot_fledge_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+
 
     #[test]
     fn compute_file_hash_is_deterministic() {
@@ -142,25 +129,4 @@ mod tests {
         assert_ne!(compute_file_hash(b"a"), compute_file_hash(b"b"));
     }
 
-    #[test]
-    fn resolve_meta_path_finds_new_layout() {
-        let tmp = TempDir::new().unwrap();
-        let dot_fledge = tmp.path().join(".fledge");
-        std::fs::create_dir_all(&dot_fledge).unwrap();
-        std::fs::write(dot_fledge.join("meta.toml"), "").unwrap();
-        assert!(resolve_meta_path(tmp.path()).is_some());
-    }
-
-    #[test]
-    fn resolve_meta_path_finds_legacy_file() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join(".fledge.toml"), "").unwrap();
-        assert!(resolve_meta_path(tmp.path()).is_some());
-    }
-
-    #[test]
-    fn resolve_meta_path_missing_returns_none() {
-        let tmp = TempDir::new().unwrap();
-        assert!(resolve_meta_path(tmp.path()).is_none());
-    }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the presence of an unused `resolve_meta_path` function in `src/meta.rs` and its associated tests.
💡 **Why:** Removing dead code simplifies the codebase, improving readability and maintainability.
✅ **Verification:** I ran `cargo test` and `cargo fix` to ensure no functionality is broken and no unused imports remain.
✨ **Result:** The unused function and its tests are successfully removed from the codebase.

---
*PR created automatically by Jules for task [18409085049702608179](https://jules.google.com/task/18409085049702608179) started by @0xLeif*