### PR TITLE
Replace `TODO: Add setup instructions here` with concrete `fledge` instructions

### DIFF
--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -232,7 +232,16 @@ fn write_example_files(target: &Path) -> Result<()> {
 
 ## Getting Started
 
-TODO: Add setup instructions here.
+### Prerequisites
+
+- [fledge](https://github.com/CorvidLabs/fledge)
+
+### Setup
+
+```bash
+fledge run build
+fledge run test
+```
 
 ## License
 


### PR DESCRIPTION
Replaced a `TODO` comment with concrete default fledge commands for building and testing the project.

---
*PR created automatically by Jules for task [11555789941780104486](https://jules.google.com/task/11555789941780104486) started by @0xLeif*