### PR TITLE
🔒 Fix Command/Flag Injection in git checkout (plugin install and update)

### DIFF
--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -260,6 +260,13 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     }
 
     if let Some(ref_str) = git_ref {
+        if ref_str.starts_with('-') {
+            fs::remove_dir_all(&plugin_dir).ok();
+            bail!(
+                "Invalid git ref '{}': references cannot start with a hyphen.",
+                ref_str
+            );
+        }
         let status = Command::new("git")
             .args(["checkout", ref_str])
             .current_dir(&plugin_dir)

--- a/src/plugin/update.rs
+++ b/src/plugin/update.rs
@@ -160,6 +160,12 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
                             )))
                         };
 
+                        if tag.starts_with('-') {
+                            bail!(
+                                "Invalid git tag '{}': references cannot start with a hyphen.",
+                                tag
+                            );
+                        }
                         let checkout = Command::new("git")
                             .args(["checkout", tag])
                             .current_dir(&plugin_dir)


### PR DESCRIPTION
🎯 **What:** Command/Flag Injection in `git checkout` during plugin installation and update.
⚠️ **Risk:** A malicious or malformed plugin source could provide a git reference starting with a hyphen (e.g., `-B`), causing `git checkout` to interpret it as a command-line option rather than a reference, potentially leading to unauthorized execution flags or failures.
🛡️ **Solution:** Added explicit validation to check if the git reference (`ref_str` or `tag`) starts with a hyphen (`-`). If it does, the operation fails and the installation is aborted with an appropriate error message, cleaning up any partially installed files. This ensures that user-provided data cannot inject flags into the git command.

---
*PR created automatically by Jules for task [1711700031451668183](https://jules.google.com/task/1711700031451668183) started by @0xLeif*