### PR TITLE
🔒 Fix command injection in changelog generation

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -186,8 +186,13 @@ fn commits_between(from: Option<&str>, to: &str) -> Result<Vec<(String, String)>
 }
 
 fn build_release(tag: &str, date: &str, prev: Option<&str>) -> Result<Release> {
-    let to_ref = if tag == "Unreleased" { "HEAD" } else { tag };
-    let raw_commits = commits_between(prev, to_ref)?;
+    let to_ref = if tag == "Unreleased" {
+        "HEAD".to_string()
+    } else {
+        format!("refs/tags/{tag}")
+    };
+    let prev_ref = prev.map(|p| format!("refs/tags/{p}"));
+    let raw_commits = commits_between(prev_ref.as_deref(), &to_ref)?;
 
     let mut groups: std::collections::BTreeMap<String, Vec<CommitEntry>> =
         std::collections::BTreeMap::new();


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a flag injection issue where git log might interpret a tag starting with a hyphen as a flag instead of a revision.
⚠️ **Risk:** A malicious or unintentional tag starting with a hyphen (e.g. `-foo`) could lead to unexpected behavior and git command failures when generating the changelog. This could be exploited by an attacker to execute unintended commands if the tag is fetched from an external source or created locally, potentially leading to command injection or exposing sensitive local files through flags.
🛡️ **Solution:** The tag names are now safely formatted with the `refs/tags/` prefix before being passed to `commits_between` and `git log`. This forces git to interpret the argument string as a revision reference rather than a command flag, completely closing the injection vector. The special "Unreleased" case retains the `HEAD` string which is also safe.

---
*PR created automatically by Jules for task [5040380281439539328](https://jules.google.com/task/5040380281439539328) started by @0xLeif*