### PR TITLE
🔒 Fix command injection vulnerability in git diff

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -487,6 +487,9 @@ fn default_branch() -> Result<String> {
 }
 
 fn get_diff(base: &str, file: Option<&str>) -> Result<String> {
+    if base.starts_with('-') {
+        bail!("Invalid base revision: cannot start with '-'");
+    }
     let mut args = vec!["diff", base];
     if let Some(f) = file {
         args.push("--");
@@ -503,6 +506,9 @@ fn get_diff(base: &str, file: Option<&str>) -> Result<String> {
 }
 
 fn get_diff_stats(base: &str, file: Option<&str>) -> Result<String> {
+    if base.starts_with('-') {
+        bail!("Invalid base revision: cannot start with '-'");
+    }
     let mut args = vec!["diff", "--stat", base];
     if let Some(f) = file {
         args.push("--");
@@ -514,6 +520,9 @@ fn get_diff_stats(base: &str, file: Option<&str>) -> Result<String> {
 }
 
 fn get_changed_files(base: &str, file: Option<&str>) -> Result<Vec<String>> {
+    if base.starts_with('-') {
+        bail!("Invalid base revision: cannot start with '-'");
+    }
     let mut args = vec!["diff", "--name-only", base];
     if let Some(f) = file {
         args.push("--");


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
A Command/Flag Injection vulnerability in `src/review.rs` caused by passing an unsanitized `base` parameter (derived from CLI input) into `git diff`, which allowed git to interpret inputs starting with a hyphen as arbitrary flags.

⚠️ **Risk:** The potential impact if left unfixed
An attacker (or user tricked into passing a malicious string) could pass arbitrary flags to `git diff` (like `--output=path`), leading to arbitrary file overwrite and potentially arbitrary code execution if critical files are overwritten.

🛡️ **Solution:** How the fix addresses the vulnerability
This change adds an early validation check in `get_diff`, `get_diff_stats`, and `get_changed_files` to ensure that `base` does not start with a hyphen (`-`). If it does, the function immediately bails out. Because valid Git references and commit hashes cannot start with a hyphen, this prevents the flag injection without affecting valid use cases.

---
*PR created automatically by Jules for task [11650463467420088031](https://jules.google.com/task/11650463467420088031) started by @0xLeif*