### PR TITLE
fix(site): /fledge/plugins serves registry, not redirect to docs

### DIFF
--- a/site/scripts/generate-doc-redirects.test.ts
+++ b/site/scripts/generate-doc-redirects.test.ts
@@ -17,4 +17,19 @@ describe('computeRedirects', () => {
     expect(mapped['pillars.html']).toBe('/fledge/docs/pillars')
     expect(mapped['getting-started/installation.html']).toBe('/fledge/docs/getting-started/installation')
   })
+
+  test('skips top-level .md whose stem collides with an Astro page dir', () => {
+    // plugins.md would emit public/plugins.html, which on GitHub Pages
+    // shadows the Astro-built plugins/index.html (the registry). Skip it.
+    const mapped = computeRedirects(['plugins.md', 'lanes.md'], new Set(['plugins']))
+    expect(mapped['plugins.html']).toBeUndefined()
+    expect(mapped['lanes.html']).toBe('/fledge/docs/lanes')
+  })
+
+  test('skip only applies to top-level files, not nested ones', () => {
+    // getting-started/plugins.md emits getting-started/plugins.html and can't
+    // collide with the top-level plugins/ dir, so it stays.
+    const mapped = computeRedirects(['getting-started/plugins.md'], new Set(['plugins']))
+    expect(mapped['getting-started/plugins.html']).toBe('/fledge/docs/getting-started/plugins')
+  })
 })

--- a/site/scripts/generate-doc-redirects.ts
+++ b/site/scripts/generate-doc-redirects.ts
@@ -20,12 +20,20 @@ export function redirectHtml(target: string): string {
 `
 }
 
-export function computeRedirects(mdFiles: string[]): Record<string, string> {
+export function computeRedirects(
+  mdFiles: string[],
+  skipStems: Set<string> = new Set(),
+): Record<string, string> {
   const out: Record<string, string> = {}
   for (const f of mdFiles) {
     if (f === 'SUMMARY.md') continue
+    // Only top-level files can shadow a sibling Astro pages/ directory at the
+    // site root, so the skip check is scoped to those.
+    const isTopLevel = !f.includes('/')
+    const stem = f.replace(/\.md$/, '')
+    if (isTopLevel && skipStems.has(stem)) continue
     const html = f.replace(/\.md$/, '.html')
-    const newPath = `${BASE}docs/${f.replace(/\.md$/, '')}`.replace(/\/+/g, '/')
+    const newPath = `${BASE}docs/${stem}`.replace(/\/+/g, '/')
     out[html] = newPath
   }
   return out
@@ -42,15 +50,32 @@ function walk(dir: string, prefix = ''): string[] {
   return out
 }
 
+function topLevelPageDirs(): Set<string> {
+  // GitHub Pages serves /foo by checking foo.html before foo/index.html, so a
+  // redirect we write at public/foo.html would shadow an Astro-built page at
+  // pages/foo/index.html. Skip any redirect whose stem matches one of these.
+  const pagesDir = join(__dirname, '..', 'src', 'pages')
+  return new Set(
+    readdirSync(pagesDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name),
+  )
+}
+
 function main() {
   // Source-of-truth = the migrated docs/ tree under site/src/content/docs
   const docsSrc = join(__dirname, '..', 'src', 'content', 'docs')
   const mdFiles = walk(docsSrc)
-  const mapped = computeRedirects(mdFiles)
+  const skip = topLevelPageDirs()
+  const mapped = computeRedirects(mdFiles, skip)
   for (const [oldPath, newPath] of Object.entries(mapped)) {
     const dest = join(PUBLIC_DIR, oldPath)
     mkdirSync(dirname(dest), { recursive: true })
     writeFileSync(dest, redirectHtml(newPath))
+  }
+  const skipped = mdFiles.filter((f) => !f.includes('/') && skip.has(f.replace(/\.md$/, '')))
+  if (skipped.length > 0) {
+    console.log(`[generate-doc-redirects] skipped ${skipped.length} colliding: ${skipped.join(', ')}`)
   }
   console.log(`[generate-doc-redirects] wrote ${Object.keys(mapped).length} redirect files`)
 }


### PR DESCRIPTION
## Summary

Live-site bug spotted post-deploy. **The plugin registry is unreachable from the site's own UI.** Header, Footer, the hero "Browse N plugins" button, the plugin strip "Browse the registry →" link, and the bottom CTA all link to `/fledge/plugins` (no trailing slash — `astro.config.mjs` uses `trailingSlash: 'never'`). On GitHub Pages today, that URL serves a redirect to `/fledge/docs/plugins` (the prose docs page) instead of the registry.

## Reproduction

```
$ curl -sL https://corvidlabs.github.io/fledge/plugins | head -7
<!DOCTYPE html>
<html><head>
<meta charset="utf-8">
<title>Redirecting…</title>
<link rel="canonical" href="/fledge/docs/plugins">
<meta http-equiv="refresh" content="0; url=/fledge/docs/plugins">
<script>location.replace("/fledge/docs/plugins")</script>

# vs the registry, only reachable with a trailing slash:
$ curl -sL https://corvidlabs.github.io/fledge/plugins/ | grep -m1 -o '<title>[^<]*</title>'
<title>fledge — plugin registry</title>
```

## Root cause

`site/scripts/generate-doc-redirects.ts` walks every `.md` in `site/src/content/docs/` and writes `<stem>.html` redirects into `public/`. `plugins.md` exists (prose docs about plugins), so the script writes `public/plugins.html` → redirect to `/fledge/docs/plugins`. After build:

- `site/dist/plugins.html` — the redirect
- `site/dist/plugins/index.html` — the actual registry

GitHub Pages resolves `/fledge/plugins` by checking `plugins.html` first → serves the redirect, shadowing the registry. `/fledge/plugins/` skips the `.html` check and reaches the real index. Every internal link uses the shadowed form.

## Fix

`computeRedirects` takes an optional `skipStems: Set<string>`; `main()` populates it from the top-level directory names under `site/src/pages/`. The skip check is scoped to top-level `.md` files (nested files like `getting-started/foo.md` can't shadow a top-level `pages/foo/` dir, so they pass through).

Generic — catches any future doc stem that adds a same-name top-level page (e.g. if someone adds `blog.md` or `examples.md` to `content/docs/`, those would be skipped too).

## Tradeoff

`/fledge/plugins.html` (old mdBook URL) now 404s. Acceptable — the registry being unreachable from the site's own nav is the worse break, and `/fledge/docs/plugins` still serves the prose page. The other 22 mdBook redirects (`lanes.html`, `pillars.html`, etc.) are unchanged.

## Test plan

- [x] TDD: added 2 tests to `generate-doc-redirects.test.ts` — saw the collision-skip test fail first, then pass after the implementation change. Nested-file test guards against over-skipping.
- [x] `cd site && bun test` — 29 pass, 0 fail (was 27 before)
- [x] `cd site && bun run lint` — 0 errors / 0 warnings / 0 hints
- [x] `cd site && bun run build` — emits `[generate-doc-redirects] skipped 1 colliding: plugins.md`; `dist/plugins.html` is absent, `dist/plugins/index.html` is the registry (30KB, `<title>fledge — plugin registry</title>`), `dist/lanes.html` redirect still present, `dist/docs/plugins/index.html` prose docs still present
- [ ] After merge + deploy: `curl -sL https://corvidlabs.github.io/fledge/plugins | grep title` returns `fledge — plugin registry`, not "Redirecting…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)