### PR TITLE
docs: replace mdbook task in fledge-toml example with cargo doc

### DIFF
--- a/site/src/content/docs/reference/fledge-toml.md
+++ b/site/src/content/docs/reference/fledge-toml.md
@@ -285,9 +285,9 @@ fmt         = "cargo fmt --check"
 fmt-fix     = "cargo fmt"
 audit       = "cargo audit"
 
-[tasks.docs-serve]
-cmd = "mdbook serve docs --open"
-description = "Serve docs locally with live reload"
+[tasks.docs-open]
+cmd = "cargo doc --open"
+description = "Build rustdoc and open it in a browser"
 
 [tasks.deploy]
 cmd = "scripts/deploy.sh"


### PR DESCRIPTION
## Summary

Last bit of mdBook polish: `site/src/content/docs/reference/fledge-toml.md` "Full worked example" still used `mdbook serve docs --open` to illustrate the `[tasks.docs-serve]` block. mdBook is no longer relevant to fledge's toolchain — replaced with `cargo doc --open`, which ships with cargo and fits the surrounding Rust example better.

## Test plan

- [x] One-line docs change, no code paths affected
- [ ] After deploy: confirm the rendered example on `/fledge/docs/reference/fledge-toml` shows `cargo doc --open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)