### PR TITLE
fix(site): broken doc cross-links, plugin counts, missing canonical/twitter meta + RSS

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
+import remarkResolveDocLinks from './scripts/remark-resolve-doc-links.ts'
 
 export default defineConfig({
   site: 'https://corvidlabs.github.io',
@@ -8,6 +9,9 @@ export default defineConfig({
   trailingSlash: 'never',
   integrations: [mdx(), sitemap()],
   markdown: {
+    // Rewrites relative `.md` links in docs/ to absolute Astro URLs so
+    // cross-page references resolve at runtime instead of 404'ing.
+    remarkPlugins: [remarkResolveDocLinks],
     shikiConfig: {
       // github-dark-high-contrast passes WCAG AA for all token colors
       // (#6A737D comment color in github-dark fails 3.05:1 on its #24292e bg)

--- a/site/scripts/build-plugin-registry.ts
+++ b/site/scripts/build-plugin-registry.ts
@@ -203,7 +203,7 @@ async function main() {
   for (const { entry, repo, readme } of entries) {
     const full: FullEntry = {
       ...entry,
-      readme_html: renderReadme(readme),
+      readme_html: renderReadme(readme, { repoUrl: repo.html_url, defaultBranch: repo.default_branch }),
       license: repo.license?.spdx_id ?? null,
       open_issues: repo.open_issues_count,
       related_slugs: relatedSlugs(entry.slug, miniUniverse, 3),

--- a/site/scripts/remark-resolve-doc-links.test.ts
+++ b/site/scripts/remark-resolve-doc-links.test.ts
@@ -83,4 +83,21 @@ describe('resolveLink', () => {
   test('custom base URL', () => {
     expect(resolveLink('./plugins.md', 'lanes.md', idx, '/other/')).toBe('/other/docs/plugins')
   })
+
+  test('last-resort branch emits a console.warn and returns stripped URL', () => {
+    const warnings: string[] = []
+    const orig = console.warn
+    console.warn = (m: string) => warnings.push(m)
+    let result: string | null
+    try {
+      // 'nonexistent-file.md' has no match in byStem or byRelStem so it hits the last-resort path.
+      result = resolveLink('./nonexistent-file.md', 'lanes.md', idx, '/fledge/', 'lanes.md')
+    } finally {
+      console.warn = orig
+    }
+    expect(result).toBe('/fledge/docs/nonexistent-file')
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('nonexistent-file.md')
+    expect(warnings[0]).toContain('lanes.md')
+  })
 })

--- a/site/scripts/remark-resolve-doc-links.test.ts
+++ b/site/scripts/remark-resolve-doc-links.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test'
+import { resolveLink, buildDocIndex } from './remark-resolve-doc-links'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DOCS_DIR = join(__dirname, '..', 'src', 'content', 'docs')
+
+describe('buildDocIndex', () => {
+  const idx = buildDocIndex(DOCS_DIR)
+
+  test('indexes top-level docs by stem', () => {
+    expect(idx.byStem.get('lanes')).toBe('lanes')
+    expect(idx.byStem.get('plugins')).toBe('plugins')
+    expect(idx.byStem.get('spec')).toBe('spec')
+  })
+
+  test('indexes nested docs by stem', () => {
+    expect(idx.byStem.get('fledge-toml')).toBe('reference/fledge-toml')
+    expect(idx.byStem.get('cli-reference')).toBe('reference/cli-reference')
+    expect(idx.byStem.get('changelog')).toBe('resources/changelog')
+  })
+
+  test('relStem set contains full relative paths without extension', () => {
+    expect(idx.byRelStem.has('lanes')).toBe(true)
+    expect(idx.byRelStem.has('reference/fledge-toml')).toBe(true)
+    expect(idx.byRelStem.has('getting-started/quick-start')).toBe(true)
+  })
+})
+
+describe('resolveLink', () => {
+  const idx = buildDocIndex(DOCS_DIR)
+
+  test('strips .md from same-dir relative link that resolves cleanly', () => {
+    // lanes.md -> ./plugins.md (both at docs root)
+    expect(resolveLink('./plugins.md', 'lanes.md', idx)).toBe('/fledge/docs/plugins')
+  })
+
+  test('redirects wrong-folder .md link to the actual location', () => {
+    // lanes.md says ./fledge-toml.md but the file lives in reference/
+    expect(resolveLink('./fledge-toml.md', 'lanes.md', idx)).toBe('/fledge/docs/reference/fledge-toml')
+    expect(resolveLink('./configuration.md', 'lanes.md', idx)).toBe('/fledge/docs/reference/configuration')
+    expect(resolveLink('./cli-reference.md', 'lanes.md', idx)).toBe('/fledge/docs/reference/cli-reference')
+  })
+
+  test('preserves anchors', () => {
+    expect(resolveLink('./cli-reference.md#ai-ask-and-review', 'ai.md', idx)).toBe(
+      '/fledge/docs/reference/cli-reference#ai-ask-and-review',
+    )
+  })
+
+  test('handles ../ links', () => {
+    // getting-started/quick-start.md -> ../templates.md
+    expect(resolveLink('../templates.md', 'getting-started/quick-start.md', idx)).toBe(
+      '/fledge/docs/templates',
+    )
+  })
+
+  test('handles nested-to-nested via basename fallback', () => {
+    // reference/fledge-toml.md says ./plugins.md but plugins is at root
+    expect(resolveLink('./plugins.md', 'reference/fledge-toml.md', idx)).toBe('/fledge/docs/plugins')
+  })
+
+  test('handles same-folder nested link via direct relative match', () => {
+    // resources/github-integration.md -> ./ship.md (ship is at root, not in resources/)
+    expect(resolveLink('./ship.md', 'resources/github-integration.md', idx)).toBe('/fledge/docs/ship')
+  })
+
+  test('leaves external URLs alone', () => {
+    expect(resolveLink('https://example.com/foo.md', 'lanes.md', idx)).toBeNull()
+    expect(resolveLink('mailto:hi@example.com', 'lanes.md', idx)).toBeNull()
+  })
+
+  test('leaves already-absolute URLs alone', () => {
+    expect(resolveLink('/fledge/docs/plugins', 'lanes.md', idx)).toBeNull()
+  })
+
+  test('leaves non-.md links alone', () => {
+    expect(resolveLink('./plugins', 'lanes.md', idx)).toBeNull()
+    expect(resolveLink('#section', 'lanes.md', idx)).toBeNull()
+  })
+
+  test('custom base URL', () => {
+    expect(resolveLink('./plugins.md', 'lanes.md', idx, '/other/')).toBe('/other/docs/plugins')
+  })
+})

--- a/site/scripts/remark-resolve-doc-links.ts
+++ b/site/scripts/remark-resolve-doc-links.ts
@@ -39,7 +39,7 @@ export interface DocIndex {
 
 function walk(dir: string, prefix = ''): string[] {
   const out: string[] = []
-  for (const entry of readdirSync(dir)) {
+  for (const entry of readdirSync(dir).sort()) {
     const full = join(dir, entry)
     const rel = prefix ? `${prefix}/${entry}` : entry
     if (statSync(full).isDirectory()) out.push(...walk(full, rel))
@@ -58,7 +58,11 @@ export function buildDocIndex(docsDir: string): DocIndex {
     const base = relStem.split('/').pop()!
     // First occurrence wins (basenames are unique in our docs tree today; if
     // that changes we'll get a clear precedence here rather than silent overwrite).
-    if (!byStem.has(base)) byStem.set(base, relStem)
+    if (!byStem.has(base)) {
+      byStem.set(base, relStem)
+    } else if (byStem.get(base) !== relStem) {
+      console.warn(`[remark-resolve-doc-links] duplicate basename "${base}": kept ${byStem.get(base)}, ignored ${relStem}`)
+    }
   }
   return { byStem, byRelStem }
 }
@@ -83,6 +87,7 @@ export function resolveLink(
   sourceRelPath: string,
   index: DocIndex,
   base = BASE,
+  currentFile = sourceRelPath,
 ): string | null {
   if (!href) return null
   if (isExternal(href)) return null
@@ -115,7 +120,10 @@ export function resolveLink(
     return `${base}docs/${found}${hash}`
   }
   // Last resort: just strip the .md so we don't leave a guaranteed-404 link.
-  return `${base}docs/${resolvedRel}${hash}`
+  // Emit a warning so authors notice during local dev / CI rather than shipping a silent 404.
+  const strippedUrl = `${base}docs/${resolvedRel}${hash}`
+  console.warn(`[remark-resolve-doc-links] could not resolve "${href}" from ${currentFile}; emitting stripped URL (will 404)`)
+  return strippedUrl
 }
 
 /** The remark plugin. */
@@ -135,7 +143,7 @@ export default function remarkResolveDocLinks(opts: Options = {}) {
     // narrow inline rather than pulling in heavy mdast typings.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     visit(tree as any, 'link', (node: any) => {
-      const rewritten = resolveLink(node.url, rel, index, base)
+      const rewritten = resolveLink(node.url, rel, index, base, filePath)
       if (rewritten !== null) node.url = rewritten
     })
   }

--- a/site/scripts/remark-resolve-doc-links.ts
+++ b/site/scripts/remark-resolve-doc-links.ts
@@ -1,0 +1,142 @@
+/**
+ * remark plugin: resolve relative .md links in docs/ content to absolute Astro URLs.
+ *
+ * Why this exists:
+ *   - Source docs use markdown-friendly relative links like `./plugins.md` or
+ *     `../foo.md#anchor`. Astro renders these verbatim, so the browser tries to
+ *     fetch a non-existent `.md` page and 404s.
+ *   - Cross-folder links are also unreliable: an author writes `./plugins.md`
+ *     from `reference/fledge-toml.md` even though `plugins.md` lives at the
+ *     docs root. We resolve by indexing every `.md` in docs/ by basename and
+ *     looking the target up there before falling back to a strip-extension fix.
+ *
+ * The plugin only touches links that:
+ *   - end in `.md` or `.md#anchor`
+ *   - are not absolute URLs (no protocol, no leading `/`)
+ */
+import { readdirSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { visit } from 'unist-util-visit'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DOCS_DIR = join(__dirname, '..', 'src', 'content', 'docs')
+const BASE = '/fledge/'
+
+export interface Options {
+  /** Override docs directory (tests). */
+  docsDir?: string
+  /** Override base URL (tests). */
+  base?: string
+}
+
+export interface DocIndex {
+  /** stem (no .md) -> path relative to docs/ without extension, e.g. "plugins" or "reference/fledge-toml" */
+  byStem: Map<string, string>
+  /** rel paths like "reference/fledge-toml" for direct lookup by rel-without-ext */
+  byRelStem: Set<string>
+}
+
+function walk(dir: string, prefix = ''): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const rel = prefix ? `${prefix}/${entry}` : entry
+    if (statSync(full).isDirectory()) out.push(...walk(full, rel))
+    else if (entry.endsWith('.md')) out.push(rel)
+  }
+  return out
+}
+
+export function buildDocIndex(docsDir: string): DocIndex {
+  const byStem = new Map<string, string>()
+  const byRelStem = new Set<string>()
+  for (const rel of walk(docsDir)) {
+    if (rel === 'SUMMARY.md') continue
+    const relStem = rel.replace(/\.md$/, '')
+    byRelStem.add(relStem)
+    const base = relStem.split('/').pop()!
+    // First occurrence wins (basenames are unique in our docs tree today; if
+    // that changes we'll get a clear precedence here rather than silent overwrite).
+    if (!byStem.has(base)) byStem.set(base, relStem)
+  }
+  return { byStem, byRelStem }
+}
+
+/** Parses `./foo.md#anchor` -> { target: "./foo.md", hash: "#anchor" } */
+function splitHash(url: string): { target: string; hash: string } {
+  const idx = url.indexOf('#')
+  if (idx === -1) return { target: url, hash: '' }
+  return { target: url.slice(0, idx), hash: url.slice(idx) }
+}
+
+function isExternal(url: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith('//') || url.startsWith('mailto:')
+}
+
+/**
+ * Resolve a single href against the source file's location.
+ * Returns the rewritten href, or null to keep the original.
+ */
+export function resolveLink(
+  href: string,
+  sourceRelPath: string,
+  index: DocIndex,
+  base = BASE,
+): string | null {
+  if (!href) return null
+  if (isExternal(href)) return null
+  if (href.startsWith('/')) return null // already absolute
+
+  const { target, hash } = splitHash(href)
+  if (!target.endsWith('.md')) return null
+
+  // Resolve relative to the source file's directory.
+  const srcDir = sourceRelPath.includes('/') ? sourceRelPath.split('/').slice(0, -1).join('/') : ''
+  // Manual posix join + normalize so we don't pull in node:path on hot mdast paths.
+  const segments = (srcDir ? `${srcDir}/${target}` : target).split('/')
+  const normalized: string[] = []
+  for (const seg of segments) {
+    if (!seg || seg === '.') continue
+    if (seg === '..') normalized.pop()
+    else normalized.push(seg)
+  }
+  const resolvedRel = normalized.join('/').replace(/\.md$/, '')
+
+  // If the relative resolution lands on a real file, use it.
+  if (index.byRelStem.has(resolvedRel)) {
+    return `${base}docs/${resolvedRel}${hash}`
+  }
+  // Otherwise, try basename lookup — handles `./plugins.md` from
+  // reference/fledge-toml.md when plugins.md lives at the docs root.
+  const baseName = target.replace(/^.*\//, '').replace(/\.md$/, '')
+  const found = index.byStem.get(baseName)
+  if (found) {
+    return `${base}docs/${found}${hash}`
+  }
+  // Last resort: just strip the .md so we don't leave a guaranteed-404 link.
+  return `${base}docs/${resolvedRel}${hash}`
+}
+
+/** The remark plugin. */
+export default function remarkResolveDocLinks(opts: Options = {}) {
+  const docsDir = opts.docsDir ?? DOCS_DIR
+  const base = opts.base ?? BASE
+  const index = buildDocIndex(docsDir)
+
+  return function transformer(tree: unknown, file: { path?: string; history?: string[] }) {
+    const filePath = file.path ?? (file.history && file.history[file.history.length - 1])
+    if (!filePath) return
+    // Path relative to docsDir, posix-normalized.
+    const rel = filePath.startsWith(docsDir) ? filePath.slice(docsDir.length + 1).replace(/\\/g, '/') : ''
+    if (!rel) return
+
+    // unist-util-visit's types aren't great in JS-friendly TS configs; we
+    // narrow inline rather than pulling in heavy mdast typings.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    visit(tree as any, 'link', (node: any) => {
+      const rewritten = resolveLink(node.url, rel, index, base)
+      if (rewritten !== null) node.url = rewritten
+    })
+  }
+}

--- a/site/scripts/render-readme.test.ts
+++ b/site/scripts/render-readme.test.ts
@@ -30,4 +30,49 @@ describe('renderReadme', () => {
     expect(renderReadme('')).toBe('')
     expect(renderReadme(null as unknown as string)).toBe('')
   })
+
+  test('rewrites relative links to GitHub blob URL when repo opts given', () => {
+    const html = renderReadme('See [LICENSE](./LICENSE) and [docs](docs/api.md).', {
+      repoUrl: 'https://github.com/CorvidLabs/fledge-plugin-x',
+      defaultBranch: 'main',
+    })
+    expect(html).toContain('href="https://github.com/CorvidLabs/fledge-plugin-x/blob/main/LICENSE"')
+    expect(html).toContain('href="https://github.com/CorvidLabs/fledge-plugin-x/blob/main/docs/api.md"')
+  })
+
+  test('rewrites relative image src to raw.githubusercontent.com', () => {
+    const html = renderReadme('![logo](./logo.png)', {
+      repoUrl: 'https://github.com/CorvidLabs/fledge-plugin-x',
+      defaultBranch: 'main',
+    })
+    expect(html).toContain(
+      'src="https://raw.githubusercontent.com/CorvidLabs/fledge-plugin-x/main/logo.png"',
+    )
+  })
+
+  test('leaves absolute and external links alone when rewriting', () => {
+    const html = renderReadme(
+      '[ext](https://example.com/x) [root](/about) [hash](#section)',
+      {
+        repoUrl: 'https://github.com/CorvidLabs/fledge-plugin-x',
+        defaultBranch: 'main',
+      },
+    )
+    expect(html).toContain('href="https://example.com/x"')
+    expect(html).toContain('href="/about"')
+    expect(html).toContain('href="#section"')
+  })
+
+  test('does not rewrite when opts missing (back-compat)', () => {
+    const html = renderReadme('[LICENSE](./LICENSE)')
+    expect(html).toContain('href="./LICENSE"')
+  })
+
+  test('rewrites legacy mdBook plugin-protocol URL to the Astro docs anchor', () => {
+    const html = renderReadme(
+      'Uses the [fledge-v1 protocol](https://corvidlabs.github.io/fledge/plugin-protocol.html).',
+    )
+    expect(html).toContain('href="https://corvidlabs.github.io/fledge/docs/plugins#plugin-protocol-fledge-v1"')
+    expect(html).not.toContain('plugin-protocol.html')
+  })
 })

--- a/site/scripts/render-readme.ts
+++ b/site/scripts/render-readme.ts
@@ -1,12 +1,71 @@
 import { marked } from 'marked'
 import DOMPurify from 'isomorphic-dompurify'
 
-export function renderReadme(markdown: string | null | undefined): string {
+export interface RenderOptions {
+  /** GitHub repo URL, e.g. https://github.com/CorvidLabs/fledge-plugin-foo */
+  repoUrl?: string
+  /** Default branch, e.g. "main" */
+  defaultBranch?: string
+}
+
+function isExternal(url: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith('//') || url.startsWith('mailto:')
+}
+
+/**
+ * Rewrite relative links/images in plugin READMEs to point at GitHub so they
+ * resolve instead of 404'ing under the site's plugin route.
+ *
+ * Why: marked emits hrefs verbatim. A README `[LICENSE](./LICENSE)` becomes
+ * `<a href="./LICENSE">` and lands at `/fledge/plugins/<slug>/LICENSE`, which
+ * doesn't exist. Rewriting to the GitHub blob URL keeps the link useful.
+ */
+function rewriteRelative(html: string, repoUrl: string, branch: string): string {
+  // Strip trailing slash from repo URL so blob path joins cleanly.
+  const repo = repoUrl.replace(/\/$/, '')
+  const blobBase = `${repo}/blob/${branch}/`
+  const rawBase = repo.replace(/^https:\/\/github\.com\//, 'https://raw.githubusercontent.com/') + `/${branch}/`
+
+  // Rewrite href= and src= for relative URLs only (skip absolute, mailto, fragments).
+  return html.replace(/\b(href|src)="([^"]+)"/g, (match, attr, url) => {
+    if (!url || url.startsWith('#')) return match
+    if (isExternal(url)) return match
+    if (url.startsWith('/')) return match // absolute path, leave alone
+    // Normalize a leading ./ for cleaner URLs
+    const cleaned = url.startsWith('./') ? url.slice(2) : url
+    const base = attr === 'src' ? rawBase : blobBase
+    return `${attr}="${base}${cleaned}"`
+  })
+}
+
+export function renderReadme(
+  markdown: string | null | undefined,
+  opts: RenderOptions = {},
+): string {
   if (!markdown) return ''
   const rawHtml = marked.parse(markdown, { async: false })
-  return DOMPurify.sanitize(rawHtml, {
+  let cleaned = DOMPurify.sanitize(rawHtml, {
     USE_PROFILES: { html: true },
     FORBID_TAGS: ['style'],
     FORBID_ATTR: ['style'],
   })
+  if (opts.repoUrl && opts.defaultBranch) {
+    cleaned = rewriteRelative(cleaned, opts.repoUrl, opts.defaultBranch)
+  }
+  cleaned = rewriteLegacyDocLinks(cleaned)
+  return cleaned
+}
+
+/**
+ * Several plugin READMEs hardcode the old mdBook URL
+ * `https://corvidlabs.github.io/fledge/plugin-protocol.html` for the plugin
+ * protocol page. That page doesn't exist on the Astro site; the equivalent
+ * lives at `/fledge/docs/plugins#plugin-protocol-fledge-v1`. Until the plugin
+ * READMEs are updated upstream, rewrite at render time.
+ */
+function rewriteLegacyDocLinks(html: string): string {
+  return html.replace(
+    /https:\/\/corvidlabs\.github\.io\/fledge\/plugin-protocol\.html/g,
+    'https://corvidlabs.github.io/fledge/docs/plugins#plugin-protocol-fledge-v1',
+  )
 }

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -13,7 +13,7 @@ const base = import.meta.env.BASE_URL
         <h3>Product</h3>
         <a href={`${base}/plugins`}>Plugins</a>
         <a href={`${base}/examples`}>Examples</a>
-        <a href={`${base}/docs/changelog`}>Changelog</a>
+        <a href={`${base}/docs/resources/changelog`}>Changelog</a>
       </div>
       <div class="foot-col">
         <h3>Resources</h3>

--- a/site/src/content/docs/reference/cli-reference.md
+++ b/site/src/content/docs/reference/cli-reference.md
@@ -12,7 +12,7 @@ Every command, every flag. If it's in fledge core, it's here. Plugin commands (`
 [Run](#run-tasks-and-lanes) |
 [Spec](#spec-spec-sync) |
 [AI](#ai-ask-and-review) |
-[Ship](#ship-branch-pr-release) |
+[Ship](#ship-branch-commit-push-release) |
 [Extend](#extend-plugins-config-tools)
 
 ## Scaffold: Templates

--- a/site/src/content/docs/resources/github-integration.md
+++ b/site/src/content/docs/resources/github-integration.md
@@ -58,4 +58,4 @@ fledge github checks --json
 ## Related
 
 - [Ship: Branch, Commit, Push, Release](./ship.md). Branch creation, commit, push, release workflow
-- [AI: Ask and Review](./review.md). Multi-model review panels, spec-awareness, output formats
+- [AI: Ask and Review](../ai.md). Multi-model review panels, spec-awareness, output formats

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -8,6 +8,10 @@ interface Props {
 }
 const { title, description = "Dev lifecycle CLI. Get your projects ready to fly." } = Astro.props
 const base = import.meta.env.BASE_URL
+// Canonical: prefer the site origin + the current pathname so crawlers don't
+// treat trailing-slash/no-slash or query-string variants as duplicates.
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin).toString()
+const ogImage = new URL(`${base}/og-default.png`.replace(/\/+/g, '/'), Astro.site ?? Astro.url.origin).toString()
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -17,11 +21,16 @@ const base = import.meta.env.BASE_URL
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
+  <link rel="canonical" href={canonical} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content={Astro.url.href} />
-  <meta property="og:image" content={`${base}/og-default.png`} />
+  <meta property="og:url" content={canonical} />
+  <meta property="og:image" content={ogImage} />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={ogImage} />
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import PostCard from '../../components/PostCard.astro'
 import CategoryTag from '../../components/CategoryTag.astro'
+import plugins from '../../data/plugins.json' with { type: 'json' }
 const base = import.meta.env.BASE_URL
 const posts = (await getCollection('blog', p => !p.data.draft))
   .sort((a, b) => +b.data.date - +a.data.date)
@@ -56,7 +57,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
 
 <section class="read-more">
   <div class="container">
-    <a href={`${base}/plugins`} class="rm-card">Browse 31 plugins <span aria-hidden="true">→</span></a>
+    <a href={`${base}/plugins`} class="rm-card">Browse {plugins.length} plugins <span aria-hidden="true">→</span></a>
     <a href={`${base}/docs`} class="rm-card">Read the docs <span aria-hidden="true">→</span></a>
     <a href="https://github.com/CorvidLabs/fledge" class="rm-card">Star on GitHub <span aria-hidden="true">↗</span></a>
   </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -27,7 +27,7 @@ const spotlight = (plugins as RegistryEntry[])
         <h1 id="hero-h" class="hero-h1">Get your projects<br>ready to <span class="fly">fly.</span></h1>
         <p class="hero-sub">One CLI for the dev loop. Any language. JSON by default. Scaffold, run, ship — without the bash spaghetti.</p>
         <div class="hero-actions">
-          <Button href={`${base}/docs/getting-started`} variant="primary">Get started <span aria-hidden="true">→</span></Button>
+          <Button href={`${base}/docs/getting-started/installation`} variant="primary">Get started <span aria-hidden="true">→</span></Button>
           <Button href={`${base}/plugins`} variant="secondary">Browse {plugins.length} plugins</Button>
         </div>
         <p class="hero-fineprint">Install in a single command: <code>cargo install fledge</code></p>
@@ -76,7 +76,7 @@ const spotlight = (plugins as RegistryEntry[])
       <Pillar numeral="iii." title="Spec"    command="$ fledge spec check">Specs as constraints. Validate code matches spec. Agent-friendly source of truth.</Pillar>
       <Pillar numeral="iv."  title="AI"      command="$ fledge review">Spec-aware ask and review. Works with Claude, Ollama, OpenAI, any provider.</Pillar>
       <Pillar numeral="v."   title="Ship"    command="$ fledge work commit --ai">Branch → commit (AI optional) → push → release → changelog.</Pillar>
-      <Pillar numeral="vi."  title="Extend"  command="$ fledge plugins install">Plugin protocol in any language. 31 plugins to install. Or write your own.</Pillar>
+      <Pillar numeral="vi."  title="Extend"  command="$ fledge plugins install">Plugin protocol in any language. {plugins.length} plugins to install. Or write your own.</Pillar>
     </ul>
   </div>
 </section>

--- a/site/src/pages/plugins/[slug].astro
+++ b/site/src/pages/plugins/[slug].astro
@@ -100,7 +100,7 @@ const related = plugin.related_slugs
 <section class="cta-thin">
   <div class="container" style="text-align: center;">
     <p style="color: var(--text-muted); margin-bottom: 16px;">Built something similar?</p>
-    <Button href={`${base}/docs/template-authoring`} variant="primary">Submit your plugin</Button>
+    <Button href={`${base}/docs/plugins`} variant="primary">Submit your plugin</Button>
   </div>
 </section>
 

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal RSS 2.0 feed for the fledge blog.
+ *
+ * Avoids pulling in @astrojs/rss as a new dependency — the feed shape is small
+ * and we already escape the few characters that matter (XML doesn't allow
+ * unescaped &, <, > in element text or CDATA-less descriptions).
+ */
+import type { APIContext } from 'astro'
+import { getCollection } from 'astro:content'
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET(context: APIContext) {
+  const site = context.site?.toString().replace(/\/$/, '') ?? 'https://corvidlabs.github.io'
+  const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '')
+  const posts = (await getCollection('blog', (p) => !p.data.draft)).sort(
+    (a, b) => +b.data.date - +a.data.date,
+  )
+
+  const items = posts
+    .map((p) => {
+      const url = `${site}${base}/blog/${p.slug}`
+      return `    <item>
+      <title>${xmlEscape(p.data.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${p.data.date.toUTCString()}</pubDate>
+      <description>${xmlEscape(p.data.description)}</description>
+      <author>noreply@corvidlabs.xyz (${xmlEscape(p.data.author)})</author>
+    </item>`
+    })
+    .join('\n')
+
+  const lastBuild = (posts[0]?.data.date ?? new Date()).toUTCString()
+  const channelLink = `${site}${base}/blog`
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>fledge blog</title>
+    <link>${channelLink}</link>
+    <description>Release notes, plugin spotlights, and workflow deep-dives for fledge.</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuild}</lastBuildDate>
+    <atom:link href="${site}${base}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
## Summary

Finishes the known F1–F3 fledge marketing-site issues and sweeps a handful of related findings turned up by a deep crawl of the live deploy.

### The three known issues

- **F1 — Registry shadowing** (already fixed in #402; nothing to add here.)
- **F2 — Cross-doc `.md` links 404** (e.g. four broken links on `/fledge/docs/lanes`). Diagnosis: there was **no remark plugin** wired up at all to strip `.md`, and a strip-only plugin would still have produced wrong-folder URLs (`./fledge-toml.md` from `lanes.md` belongs in `reference/`, not the docs root). Fix: a new `remark-resolve-doc-links` plugin that indexes every `.md` in `src/content/docs` by basename + relative stem, then rewrites relative `.md` hrefs to the correct `/fledge/docs/<rel>` URL, preserving anchors. Wired into `astro.config.mjs`. Covered by unit tests.
- **F3 — 31 vs 41 plugins**. The home page already used `plugins.length` in 4 places; the two remaining hardcoded `"31 plugins"` strings (Extend pillar card, blog footer) now also use `plugins.length`. Single source of truth.

### Additional findings (fixed in this PR)

- Footer **Changelog** link pointed at `/docs/changelog` (404). Real path is `/docs/resources/changelog`.
- Hero **Get started** CTA pointed at `/docs/getting-started` (no index page exists). Now `/docs/getting-started/installation`.
- `cli-reference.md` TOC anchor `#ship-branch-pr-release` didn't match the heading slug `#ship-branch-commit-push-release`.
- `resources/github-integration.md` linked to `./review.md` (doesn't exist). Now `../ai.md`.
- Plugin detail page **Submit your plugin** CTA pointed at the templates authoring guide. Repointed to `/docs/plugins`.
- Plugin README rendering left relative links (`./LICENSE` etc.) as site-local paths, 404'ing under `/plugins/<slug>/LICENSE`. Render-time rewriter now resolves them to `github.com/blob/<branch>/...` (and image `src` to `raw.githubusercontent.com`).
- Several plugin READMEs hardcode `https://corvidlabs.github.io/fledge/plugin-protocol.html` (old mdBook URL). Rewritten at render time to `/fledge/docs/plugins#plugin-protocol-fledge-v1`.
- Blog linked to `/rss.xml` but no feed existed. Added a minimal RSS 2.0 endpoint (`src/pages/rss.xml.ts`); no new dependency required.
- Every page was missing `rel="canonical"` and `twitter:card` meta. Added both to `BaseLayout`, plus matching `twitter:title`/`description`/`image`.

## Test plan

- [x] `bun test scripts/` — 47 pass, 0 fail (includes new `remark-resolve-doc-links` and updated `render-readme` tests)
- [x] `bun run lint` — 0 errors / 0 warnings / 0 hints across 39 files
- [x] `bun run build` — 74 pages built
- [x] Local crawl of `dist/`: **0 broken internal links** (down from 7 pre-fix)
- [x] OG/canonical/twitter audit on built pages: 0 missing
- [ ] On deploy, spot-check `/fledge/docs/lanes` cross-links and `/fledge/rss.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)