### PR TITLE
Release v1.4.2 — security fixes for git command injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.2] - 2026-05-18
+
+### Security
+
+- Fix Command/Flag Injection in `git checkout` (plugin install/update) (#394)
+- Fix command injection in changelog generation (#396)
+- Fix command injection vulnerability in `git diff` (#397)
+
+### Fixes
+
+- Provide fledge setup instructions in template README (#393)
+
+### Internal
+
+- Remove unused `schema_version` field from `FledgeFile` (#386)
+- Remove unused functions: `generate_title_from_branch` (#388), `format_commit_subject_as_bullet` (#389), `resolve_meta_path` (#392)
+- Add tests: `compute_file_hash` known-value (#385), `build_commit_message` whitespace cases (#390), `check_requirements` invalid chars (#391), empty commit scope validation (#395)
+
+### Site
+
+- Marketing site rebuild (Astro + plugin registry), doc redirects, mobile responsiveness, and metadata fixes (#398–#405)
+
 ## [v1.4.1] - 2026-05-11
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.4.1";
+          version = "1.4.2";
           src = self;
 
           cargoLock = {

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -2,7 +2,7 @@
 import Button from './Button.astro'
 const base = import.meta.env.BASE_URL
 const current = Astro.url.pathname.replace(/\/$/, '') || base.replace(/\/$/, '')
-const VERSION = 'v1.4.1'
+const VERSION = 'v1.4.2'
 const links = [
   { href: `${base}/plugins`, label: 'Plugins' },
   { href: `${base}/examples`, label: 'Examples' },


### PR DESCRIPTION
## Security Fixes

This release patches **three command injection vulnerabilities** found in the git integration layer. All are rated high-severity and should be prioritized.

- **#394** — Fix Command/Flag Injection in `git checkout` (plugin install/update): user-supplied plugin names were passed unsanitized to the git subprocess, allowing flag injection via names like `--upload-pack=…`
- **#396** — Fix command injection in changelog generation: tag names used in `git log` range arguments were not sanitized
- **#397** — Fix command injection vulnerability in `git diff`: file/ref arguments to `git diff` were passed without escaping

## Other Fixes

- **#393** — Provide fledge setup instructions in template README

## Internal / Code Health

- **#386** — Remove unused `schema_version` field from `FledgeFile` (refactor)
- **#388, #389, #392** — Remove three dead functions: `generate_title_from_branch`, `format_commit_subject_as_bullet`, `resolve_meta_path`
- **#385, #390, #391, #395** — New tests: `compute_file_hash` known-value, `build_commit_message` whitespace cases, `check_requirements` invalid chars, empty commit scope validation

## Site

- **#398–#405** — Marketing site rebuild (Astro + plugin registry), doc cross-link fixes, mobile responsiveness (hamburger, viewport grids, tap targets), canonical/twitter meta, RSS, redirects

---

## Version bumps

| File | Old | New |
|------|-----|-----|
| `Cargo.toml` | 1.4.1 | 1.4.2 |
| `flake.nix` | 1.4.1 | 1.4.2 |
| `site/src/components/Header.astro` | v1.4.1 | v1.4.2 |

---

## Tagging note

**Do not push the tag from this PR.** Once this branch is squash-merged into `main`, create and push the tag at the resulting merge commit on `main`:

```bash
git tag v1.4.2 <merge-commit-sha>
git push origin v1.4.2
```

Pushing `v1.4.2` to `origin` is what triggers `.github/workflows/release.yml` (it fires on `push: tags: v*`), which builds cross-platform binaries and creates the GitHub release. The workflow does **not** auto-tag on PR merge — the tag must be created manually after merge.

---

## Test results

- `cargo test --all-features`: 78 passed, 1 pre-existing failure (`cli_plugin_update_no_plugins` — fails because `fledge-plugin-bridge` requires Java, which is not installed in this environment; confirmed pre-existing before this branch)
- `cd site && bun run lint`: 0 errors, 0 warnings
- `cd site && GITHUB_TOKEN=… bun run build`: 74 pages built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)