### PR TITLE
test(plugin): isolate cli_plugin_update_no_plugins

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,3 +23,15 @@ pub fn run_fledge_in(dir: &Path, args: &[&str]) -> std::process::Output {
         .output()
         .unwrap()
 }
+
+/// Run fledge with HOME pointed at a fresh tempdir so the invocation sees an
+/// empty plugin registry.  The caller owns the `TempDir` — keep it in scope
+/// for the duration of the test so the directory is not removed early.
+pub fn run_fledge_isolated(args: &[&str], home: &tempfile::TempDir) -> std::process::Output {
+    let bin = cargo_bin();
+    Command::new(&bin)
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .unwrap()
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -654,7 +654,12 @@ fn cli_plugin_list_json() {
 
 #[test]
 fn cli_plugin_update_no_plugins() {
-    let output = run_fledge(&["plugin", "update"]);
+    // Isolate HOME to a fresh tempdir so the test sees an empty plugin
+    // registry and cannot be affected by externally-installed plugins whose
+    // build hooks may require toolchains absent on the test host (e.g.
+    // fledge-plugin-bridge needing Java).
+    let home = tempfile::TempDir::new().unwrap();
+    let output = run_fledge_isolated(&["plugin", "update"], &home);
     assert!(output.status.success());
 }
 


### PR DESCRIPTION
## Summary

- **Failure mode**: `cli_plugin_update_no_plugins` called `fledge plugin update` against the user's real `~/.fledge` directory. If any externally-installed plugin (e.g. `fledge-plugin-bridge`) has a build hook that requires a toolchain absent on the test host (such as Java), the update fails and the test reports a false failure — not a real fledge bug.
- **Fix**: Applied the same `HOME=tempdir` isolation pattern already used by the sibling `cli_plugin_update_json_emits_envelope` test. Added a `run_fledge_isolated(args, &home)` helper to `tests/common/mod.rs` so the pattern is reusable. The test now sees a genuinely empty plugin registry.
- **Why this matters**: CI is unaffected (GitHub Actions runners have clean home directories), but developers running `cargo test` locally with a populated `~/.fledge` hit the false failure. This surfaced during recent v1.4.2 release prep.

## Changes

- `tests/common/mod.rs`: adds `run_fledge_isolated(args, home)` helper
- `tests/main.rs`: updates `cli_plugin_update_no_plugins` to use it

No source code (`src/`) changes.

## Test plan

- [x] `cargo test --test main cli_plugin_update_no_plugins` — passes (was failing locally)
- [x] `cargo test --test main` — 79 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)