### PR TITLE
Support local plugin installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ sha2 = "0.11.0"
 base64 = "0.22"
 notify = "7"
 shell-words = "1.1.1"
-wasmtime = "43"
-wasmtime-wasi = "43"
+wasmtime = "44.0.2"
+wasmtime-wasi = "44.0.2"
 
 [build-dependencies]
 toml = "0.8"

--- a/specs/plugin/context.md
+++ b/specs/plugin/context.md
@@ -9,7 +9,7 @@ The plugin system lets the community extend fledge without forking. It follows t
 ## Related Modules
 
 - `config` — plugin directory paths under the platform config directory (`dirs::config_dir()`)
-- `github` — GitHub API for search and clone operations
+- `github` — GitHub API for search and publish operations
 
 ## Design Decisions
 
@@ -17,3 +17,5 @@ The plugin system lets the community extend fledge without forking. It follows t
 - Plugin manifest (`plugin.toml`) — explicit declaration of commands and hooks
 - Symlinks into `plugins/bin/` — centralized lookup without modifying PATH
 - GitHub topic convention (`fledge-plugin`) — same discovery pattern as templates
+- Local path installs live-link by default — plugin authors can dogfood scaffolded plugins without publishing or reinstalling after every edit
+- Generic git URL installs clone as-is — GitHub shorthand remains a convenience, not a hard dependency

--- a/specs/plugin/plugin.spec.md
+++ b/specs/plugin/plugin.spec.md
@@ -1,6 +1,6 @@
 ---
 module: plugin
-version: 28
+version: 29
 status: active
 files:
   - src/plugin/mod.rs
@@ -26,7 +26,7 @@ depends_on:
 
 ## Purpose
 
-Plugin system for community extensions. Plugins are external executables that register as fledge subcommands, lane steps, or template post-processors. Discovery uses the same GitHub topic convention as templates (`fledge-plugin`).
+Plugin system for community extensions. Plugins are external executables that register as fledge subcommands, lane steps, or template post-processors. Discovery uses the same GitHub topic convention as templates (`fledge-plugin`), while installation supports local paths, generic git URLs, and GitHub shorthand.
 
 ## Public API
 
@@ -43,7 +43,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `PluginCapabilities` | `pub` | Declared capabilities — exec, store, metadata (all default false) |
 | `install_action` | `pub(crate)` | Top-level dispatcher for `fledge plugins install`. Routes single-source installs vs `--defaults` bulk installs |
 | `install_defaults` | `pub(crate)` | Install every entry in `DEFAULT_PLUGINS` with per-plugin error collection |
-| `install_plugin` | `pub(crate)` | Install a single plugin from source ref. Returns a JSON report for the caller to envelope |
+| `install_plugin` | `pub(crate)` | Install a single plugin from a local path or git source. Returns a JSON report for the caller to envelope |
 | `list_plugins` | `pub(crate)` | List installed plugins with trust tier, version, and source info |
 | `audit_plugins` | `pub(crate)` | Security audit of installed plugins — trust tiers, capabilities, hooks, and warnings |
 | `has_lifecycle_hooks` | `pub(crate)` | Check whether a plugin has any lifecycle hooks defined in its manifest |
@@ -77,9 +77,9 @@ Plugin system for community extensions. Plugins are external executables that re
 | `run` | `mod.rs` | `(PluginOptions) -> Result<()>` | Main entry — dispatch to install/list/remove/run/audit |
 | `resolve_plugin_command` | `mod.rs` | `(&str) -> Option<PathBuf>` | Find plugin executable by command name |
 | `run_lifecycle_hook` | `mod.rs` | `(&str) -> Result<()>` | Run a named lifecycle hook across all installed plugins |
-| `install_action` | `install.rs` | `(Option<&str>, bool, bool, bool) -> Result<()>` | Top-level dispatcher for `fledge plugins install`. Routes single-source installs vs `--defaults` bulk installs |
+| `install_action` | `install.rs` | `(Option<&str>, bool, bool, bool, bool) -> Result<()>` | Top-level dispatcher for `fledge plugins install`. Routes single-source installs vs `--defaults` bulk installs |
 | `install_defaults` | `install.rs` | `(bool, bool) -> Result<()>` | Install every entry in `DEFAULT_PLUGINS` with per-plugin error collection |
-| `install_plugin` | `install.rs` | `(&str, bool, bool) -> Result<Value>` | Install a single plugin from source ref. Returns a JSON report for the caller to envelope |
+| `install_plugin` | `install.rs` | `(&str, bool, bool, bool) -> Result<Value>` | Install a single plugin from a local path or git source. Returns a JSON report for the caller to envelope |
 | `list_plugins` | `list.rs` | `(bool) -> Result<()>` | List installed plugins with trust tier, version, and source info |
 | `audit_plugins` | `list.rs` | `(bool) -> Result<()>` | Security audit of installed plugins — trust tiers, capabilities, hooks, and warnings |
 | `has_lifecycle_hooks` | `list.rs` | `(&str) -> bool` | Check whether a plugin has any lifecycle hooks defined in its manifest |
@@ -88,7 +88,7 @@ Plugin system for community extensions. Plugins are external executables that re
 | `create_plugin` | `create.rs` | `(&str, &Path, Option<&str>, bool, bool) -> Result<()>` | Scaffold a new plugin directory with plugin.toml, entry-point script, README, and .gitignore |
 | `publish_plugin` | `publish.rs` | `(&Path, Option<&str>, bool, Option<&str>, bool, bool) -> Result<()>` | Validate and publish a plugin directory to GitHub with `fledge-plugin` topic |
 | `update_plugins` | `update.rs` | `(Option<&str>, bool, bool) -> Result<()>` | Update installed plugins via git pull + rebuild. Supports single, all, or `--defaults` scope |
-| `find_latest_tag` | `update.rs` | `(&Path) -> Option<String>` | Fetch tags and return the latest version-sorted tag for a plugin repo |
+| `find_latest_tag` | `update.rs` | `(&Path, &str) -> Option<String>` | Fetch tags and return the latest version-sorted tag for a plugin repo |
 | `validate_plugin` | `validate.rs` | `(&Path, bool, bool) -> Result<()>` | Validate a plugin.toml manifest: check name, version, binaries, and hooks |
 | `print_plugin_report` | `validate.rs` | `(&PluginValidationReport, bool, bool) -> Result<()>` | Print validation results in human or JSON format. Fails if errors (or warnings in strict mode) |
 | `search_plugins` | `search.rs` | `(Option<&str>, Option<&str>, Option<&str>, usize, bool, bool) -> Result<()>` | Search GitHub for plugins by query, author, topic, limit, interactive, json |
@@ -150,11 +150,12 @@ Plugins are classified by their source into trust tiers:
 
 | Tier | Criteria | Display |
 |------|----------|---------|
+| Local | Source is a filesystem path installed from the local machine | Magenta `[local]` |
 | Official | Source org is `CorvidLabs` (case-insensitive) | Green bold `[official]` |
 | Team | Source owner is a human member of the CorvidLabs org (`TEAM_MEMBERS` allowlist in `src/trust.rs`), or listed in `trust.orgs` or `trust.users` in the user's config | Cyan `[team]` |
 | Unverified | All other sources | Yellow `[unverified]` |
 
-Trust tiers are shown in `plugin list`, `plugin audit`, and during `plugin install`. Unverified plugins requesting `exec` or `network` capabilities are **blocked at install time** — the install is aborted, the partially-cloned directory is cleaned up, and the user is told to fork the plugin under a trusted source. Official and team-tier plugins are unaffected.
+Trust tiers are shown in `plugin list`, `plugin audit`, and during `plugin install`. Unverified plugins requesting `exec` or `network` capabilities are **blocked at install time** — the install is aborted, the partially-cloned directory is cleaned up, and the user is told to fork the plugin under a trusted source. Local, official, and team-tier plugins are unaffected by that block, but still require normal capability/hook confirmation.
 
 Users can extend the team tier via config without recompiling:
 
@@ -174,7 +175,13 @@ Plugins are discovered via:
 
 ### Plugin Installation
 
-`fledge plugins install <repo>[@ref]` clones the repo to `<config_dir>/fledge/plugins/<name>/`, optionally checks out a pinned git ref (tag, branch, or commit), reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks them.
+`fledge plugins install <source>` installs from one of three source forms:
+
+- Local paths (`./my-plugin`, `../my-plugin`, `/abs/my-plugin`) are live-linked into `<config_dir>/fledge/plugins/<name>/` by default. The plugin name comes from `plugin.toml`. Pass `--copy` to snapshot the directory into fledge's config dir instead.
+- Generic git URLs (`https://...`, `ssh://...`, `git://...`, `file://...`, `git@host:org/repo.git`) are cloned as-is.
+- GitHub shorthand (`owner/repo[@ref]`) remains supported and expands to `https://github.com/owner/repo.git`.
+
+After materializing the source, fledge reads `plugin.toml`, runs the `build` hook (or auto-detects the build system), validates binaries, and symlinks commands.
 
 ### Plugin Runtime Environment
 
@@ -214,12 +221,12 @@ pinned_ref = "v0.2.0"
 1. Plugins are installed to `<config_dir>/fledge/plugins/<name>/` (where `<config_dir>` = `dirs::config_dir()`)
 2. Plugin binaries are symlinked to `<config_dir>/fledge/plugins/bin/`
 3. `resolve_plugin_command` checks `plugins/bin/` then PATH for `fledge-<name>`
-4. `plugin install` clones the repo, reads `plugin.toml`, runs build hook (or auto-detects), creates symlinks
-5. `plugin remove` deletes the plugin directory and its symlinks
-6. `plugin update` git pulls and rebuilds unpinned plugins; pinned plugins check for newer tags
+4. `plugin install` materializes the source, reads `plugin.toml`, runs build hook (or auto-detects), creates symlinks
+5. `plugin remove` deletes the installed plugin directory/symlink and command symlinks, but never deletes the original source behind a local live-link
+6. `plugin update` git pulls and rebuilds unpinned git plugins; pinned plugins check for newer tags; local plugins are skipped
 7. `plugin list` shows installed plugins with name, version, trust tier, source, runtime (`native`/`wasm`), and commands
 8. `plugin audit` shows trust tier, runtime/sandbox status, capabilities, lifecycle hooks, and warnings for each plugin
-9. `plugin search` uses GitHub topic search (same as template search). Optional `--trust-tier {official,team,unverified}` filter is applied client-side after fetching (the GitHub API has no concept of fledge tiers); each result's tier is computed via `determine_trust_tier_from_owner`
+9. `plugin search` uses GitHub topic search (same as template search). Optional `--trust-tier {local,official,team,unverified}` filter is applied client-side after fetching (the GitHub API has no concept of fledge tiers); each result's tier is computed via `determine_trust_tier_from_owner`, so local naturally returns no search results
 10. Plugin commands are dispatched via clap's `external_subcommand` and do **not** appear in `fledge --help` or `fledge introspect --json`. Discoverability of installed plugin verbs happens via `fledge plugins list` (or `--json`). This is intentional: the core help is a static contract, while installed plugin verbs are machine-dependent and live under the `plugins` namespace
 11. `plugin recommend` detects project language (via `run::detect_project_type`) and existing tooling (`Dockerfile`, `docker-compose.yml`, `.github/`), filters out already-installed plugins from the curated list, and emits language-specific suggestions. Interactive mode offers a single bulk-install confirmation
 12. `--json` (the global flag at the `plugins` parent command) outputs structured data for **every** plugin subcommand: `list`, `audit`, `search`, `recommend`, `install`, `install --defaults`, `remove`, `update`, `update --defaults`, `create`, `publish`, `validate`. Every output is a JSON **object** at the top level with `schema_version: 1`. The list/audit/search outputs use a named-array envelope: `{schema_version: 1, plugins: [...]}`, `{schema_version: 1, audit: [...]}`, `{schema_version: 1, results: [...]}`. Mutating commands use `{schema_version: 1, action, scope?, installed?|removed?|results?, summary?}`. Recommend uses `{schema_version: 1, action: "plugins_recommend", language, installed_count, recommendations: [{repo, reason}]}`. Scaffold/publish use `{schema_version: 1, action, path|repo, name|owner, files_created?|topic?, ...}`. Validate uses the report struct flattened with `schema_version` at top. **No top-level arrays** — agents `jq` the named key (`.plugins[]`, `.audit[]`, `.results[]`, `.recommendations[]`). Prose, spinners, and capability prompts are suppressed in JSON mode (warnings still go to stderr). Errors continue to surface via stderr with non-zero exit code — JSON mode never silently turns a failure into a success exit code
@@ -228,7 +235,7 @@ pinned_ref = "v0.2.0"
 15. `fledge plugins update --defaults` (mutually exclusive with a plugin name) updates only the installed plugins from the curated `DEFAULT_PLUGINS` set, matching by source string against either the shorthand (`owner/repo`) or the normalized URL form. Community plugins (e.g. `fledge-plugin-figma`) are left untouched. If none of the defaults are installed, the command suggests `fledge plugins install --defaults` and exits 0
 16. Protocol plugins without `exec` capability cannot run lifecycle hooks — `run_lifecycle_hook` skips them silently. Non-protocol plugins (no capability entry in the registry) are unaffected
 17. `plugin install` displays lifecycle hooks (with their shell commands) in the approval prompt alongside capabilities. Hooks-only plugins (no protocol capabilities) still require user approval before install completes
-18. `plugin install` rejects unverified plugins that request `exec` or `network` capabilities — the install is aborted before the approval prompt. Only official-tier and team-tier plugins may use these capabilities
+18. `plugin install` rejects unverified plugins that request `exec` or `network` capabilities — the install is aborted before the approval prompt. Local, official-tier, and team-tier plugins may use these capabilities after normal confirmation
 19. Trust tiers are extensible via config: `trust.orgs` and `trust.users` (list keys in `config.toml`) add entries to the team tier. Compared case-insensitively. Config entries never grant official tier — that remains hardcoded to `OFFICIAL_ORGS`
 
 ## Behavioral Examples
@@ -236,6 +243,21 @@ pinned_ref = "v0.2.0"
 ```
 # Install a plugin from GitHub
 $ fledge plugins install someone/fledge-deploy
+✅ Installed fledge-deploy v0.1.0
+  Commands: deploy
+
+# Install a plugin from a local path (live-linked)
+$ fledge plugins install ./my-tool
+✅ Installed my-tool v0.1.0
+  Commands: my-tool
+
+# Snapshot-copy a local plugin instead of live-linking it
+$ fledge plugins install ./my-tool --copy
+✅ Installed my-tool v0.1.0
+  Commands: my-tool
+
+# Install from a generic git URL
+$ fledge plugins install https://gitlab.com/org/fledge-deploy.git
 ✅ Installed fledge-deploy v0.1.0
   Commands: deploy
 
@@ -325,13 +347,14 @@ Installed plugins:
 | Error | When | Behavior |
 |-------|------|----------|
 | Plugin not found | install with invalid repo | Error with suggestion |
-| No plugin.toml | Repo missing manifest | Error explaining requirement |
+| No plugin.toml | Repo or local plugin path missing manifest | Error explaining requirement |
 | Already installed | install when present | Error with `--force` suggestion |
 | Not installed | remove when absent | Error listing installed plugins |
 | Binary not found | plugin.toml references missing binary | Error with build hint |
 | Build failed | build hook or auto-detect build fails | Error with toolchain suggestion |
 | Ref not found | `@ref` doesn't exist in repo | Error with `git ls-remote` hint |
 | Permission denied | Binary not executable | Error with guidance |
+| Copy with git source | `--copy` passed with a git source | Error explaining `--copy` is only for local paths |
 | Create dir exists | `create` target directory already exists | Error |
 | Validate no plugin.toml | `validate` path missing plugin.toml | Error |
 | Validate empty name | `plugin.name` is empty string | Validation error |
@@ -348,6 +371,7 @@ Installed plugins:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 29 | 2026-06-03 | Add local path and generic git URL plugin installs. Local path installs live-link by default, support `--copy` snapshots, classify as `[local]`, and are skipped by `plugins update`. Generic git URLs clone as-is while GitHub shorthand remains supported |
 | 28 | 2026-05-11 | `plugins update` skips workspace-managed plugins (no `.git` in install dir) with an informational `skipped` status instead of warning on a guaranteed-to-fail `git pull`. Detects both `.git` directories (standard clones) and `.git` files (worktrees / submodules). Lets host projects like Merlin register their internal plugins via `source = "owner/repo"` without triggering noisy errors on routine `fledge plugins update` runs (#382) |
 | 27 | 2026-05-07 | Frontmatter bump; no functional change |
 | 26 | 2026-05-05 | Add `--trust-tier {official,team,unverified}` filter to `plugins search`. Lets agents pre-filter results to first-party only (`official`) without post-processing. `TrustTier` now derives `clap::ValueEnum`. Filter is client-side (GitHub doesn't expose tier semantics). Invariant 9 updated |

--- a/specs/plugin/requirements.md
+++ b/specs/plugin/requirements.md
@@ -2,7 +2,7 @@
 
 ## Functional Requirements
 
-1. Install plugins from GitHub repositories via `fledge plugins install <repo>`
+1. Install plugins from GitHub shorthand, generic git URLs, and local paths via `fledge plugins install <source>`
 2. Remove installed plugins via `fledge plugins remove <name>`
 3. List installed plugins with metadata via `fledge plugins list`
 4. Search for plugins on GitHub via `fledge plugins search <query>`
@@ -13,6 +13,8 @@
 9. Scaffold a new plugin via `fledge plugins create <name>` with plugin.toml, bin/, README, and .gitignore
 10. Validate plugin manifests via `fledge plugins validate [path]` — check name, version, binary existence, command definitions
 11. `publish` validates before pushing
+12. Local path installs are live-linked by default and support `--copy` for snapshot installs
+13. Removing a live-linked local plugin must not delete the original local source directory
 
 ## Non-Functional Requirements
 

--- a/specs/plugin/testing.md
+++ b/specs/plugin/testing.md
@@ -7,8 +7,10 @@ spec: plugin.spec.md
 ### Unit Tests
 
 - Source URL normalization (owner/repo to full URL)
+- Source parsing for local paths, generic git URLs, GitHub shorthand, and `--copy` validation
 - Plugin name extraction from source
 - Plugin manifest TOML parsing
+- Safe removal of live-link symlinks without deleting their targets
 - resolve_plugin_command finds installed plugins
 
 ### Integration Tests
@@ -16,4 +18,6 @@ spec: plugin.spec.md
 - `fledge plugins list` runs without panic when no plugins installed
 - `fledge plugins list --json` outputs valid JSON
 - Install/remove cycle works end-to-end with a test plugin
+- Scaffolded local plugin installs from `./plugin` without requiring GitHub
+- Local plugin update is skipped with a clear status
 - Missing plugin produces clear error

--- a/specs/spec/spec.spec.md
+++ b/specs/spec/spec.spec.md
@@ -1,6 +1,6 @@
 ---
 module: spec
-version: 10
+version: 11
 status: active
 files:
   - src/spec/mod.rs
@@ -51,6 +51,7 @@ Integrates spec-sync validation into fledge as native subcommands. Provides `fle
 | `module_leaf` | (internal) Last `/`-separated segment of a module name; used to derive the spec filename for nested names |
 | `to_title_case` | (internal) Convert snake_case to Title Case for spec scaffolding |
 | `parse_frontmatter` | (internal) Parse YAML frontmatter and body from a spec file string |
+| `parse_yaml_frontmatter` | (internal) Parse YAML frontmatter fields into `SpecFrontmatter` |
 | `extract_sections` | (internal) Extract `## Section` headings from a spec body |
 | `extract_purpose` | (internal) Extract the first paragraph under `## Purpose` |
 | `ValidationIssue` | (internal) Individual validation issue with message and is_error flag |
@@ -269,6 +270,7 @@ $ fledge spec show trust --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 11 | 2026-06-03 | Document `parse_yaml_frontmatter` in the export table to satisfy strict spec-sync validation |
 | 10 | 2026-05-11 | Accept nested module names with `/` for `fledge spec new` (#383). `validate_module_name` allows `game/board`-style names while still rejecting `\`, leading/trailing `/`, `//`, and any `..`/`.` segment. New `module_leaf` helper derives the spec filename for nested names (`game/board` → `board.spec.md`). `new_spec` writes nested directory layout and quotes registry keys containing `/` so the resulting TOML stays valid |
 | 9 | 2026-04-29 | Document all `pub(crate)` exports from module split (`mod.rs`, `parse.rs`, `validation.rs`, `commands.rs`) to satisfy strict spec-sync validation |
 | 8 | 2026-04-27 | Fix nested-spec resolution (#291). `IndexEntry` now carries the spec file's on-disk `path`. `specs_for_changed_files` matches via each spec's actual parent directory rather than the assumed `<specs_dir>/<name>/`, and `load_module_bundle` resolves the spec file through the index instead of guessing. Sub-specs that share a directory with another module (e.g. `specs/plugin/plugin-protocol.spec.md`) now resolve correctly |

--- a/specs/trust/context.md
+++ b/specs/trust/context.md
@@ -5,13 +5,13 @@ spec: trust.spec.md
 ## Key Decisions
 
 - Extracted from `plugin.rs` so `templates`, `lanes`, and `search` can share one classification rule — trust tiers are a cross-cutting concept, not a plugin-only one
-- `TrustTier` serializes as lowercase strings (`"official"`, `"team"`, `"unverified"`) for stable JSON output across commands
+- `TrustTier` serializes as lowercase strings (`"local"`, `"official"`, `"team"`, `"unverified"`) for stable JSON output across commands
 - `OFFICIAL_ORGS` and `TEAM_MEMBERS` are `&[&str]` constants, not runtime config — changing either set is a code change and requires a PR. This keeps the trust surface auditable in git history
 - `Team` tier (renamed from `Community` in spec v2) classifies personal repos owned by **human members of the CorvidLabs org**. The bar for inclusion is org membership — `TEAM_MEMBERS` is the GitHub username of every human in the org, and any new hire/contributor added to the org should land in the same PR that adds them to this list. As of v2, the list is `["0xGaspar", "0xLeif", "Kyntrin", "tofu-ux"]` — every human in CorvidLabs at that point. The `corvid-agent` org member is intentionally excluded (it is an AI agent, not a human). The list grows in lockstep with org membership. A future verified-contributor program for non-CorvidLabs trusted authors could introduce a separate `Verified` tier without disturbing this one
 - `Official` takes precedence over `Team` if an owner ever appears in both lists — defensive ordering, covered by `official_takes_precedence_over_team` test
 - `is_team_member` uses `eq_ignore_ascii_case` because GitHub usernames are case-insensitive (`0xLeif` == `0xleif`). `OFFICIAL_ORGS` keeps its case-sensitive `contains` lookup with both casings hardcoded — historical, low-cost to maintain
 - `parse_source_ref` uses `rsplit_once('@')` and explicitly guards against credential URLs (`https://user:token@host/...`) and SSH prefixes (`git@github.com:...`) to avoid mis-parsing the `@` as a ref delimiter
-- Styled labels use fixed colors (green=official, cyan=team, yellow=unverified) — consistent across every command that shows trust tiers
+- Styled labels use fixed colors (magenta=local, green=official, cyan=team, yellow=unverified) — consistent across every command that shows trust tiers
 
 ## Files to Read First
 
@@ -24,7 +24,7 @@ spec: trust.spec.md
 
 - Fully implemented at v2
 - Consumed by 4 modules: `plugin`, `lanes`, `search`, `init`
-- Unit tests cover all source forms (shorthand, HTTPS, SSH, with/without ref, case sensitivity, credential URLs) for Official, Team, and Unverified tiers
+- Unit tests cover all source forms (local paths, shorthand, HTTPS, SSH, with/without ref, case sensitivity, credential URLs) for Local, Official, Team, and Unverified tiers
 - The previously unused `Community` variant has been renamed to `Team` and is now constructed via `TEAM_MEMBERS` membership
 
 ## Notes

--- a/specs/trust/requirements.md
+++ b/specs/trust/requirements.md
@@ -4,18 +4,19 @@ spec: trust.spec.md
 
 ## User Stories
 
-- As a user installing plugins/templates/lanes, I want to see whether the source is official, team, or unverified so I can make informed trust decisions
+- As a user installing plugins/templates/lanes, I want to see whether the source is local, official, team, or unverified so I can make informed trust decisions
 - As a module author, I want a shared trust classification function so all extension types use consistent logic
 
 ## Acceptance Criteria
 
 - `determine_trust_tier` classifies `CorvidLabs/*` sources as Official
+- `determine_trust_tier` classifies filesystem path sources as Local
 - `determine_trust_tier` classifies sources owned by a human member of the CorvidLabs org (e.g. `0xLeif/*`) as Team
 - `determine_trust_tier` classifies all other sources as Unverified
-- Supports HTTPS URLs, SSH URLs, and `owner/repo` shorthand
+- Supports local paths, HTTPS URLs, SSH URLs, and `owner/repo` shorthand
 - `parse_source_ref` splits `source@ref` without false-splitting on credential `@` signs
 - `label` returns lowercase string representation
-- `styled_label` returns colored console output (green=official, cyan=team, yellow=unverified)
+- `styled_label` returns colored console output (magenta=local, green=official, cyan=team, yellow=unverified)
 
 ## Constraints
 

--- a/specs/trust/tasks.md
+++ b/specs/trust/tasks.md
@@ -5,9 +5,9 @@ spec: trust.spec.md
 ## Tasks
 
 - [x] Extract trust tier logic from `plugin.rs` into shared `trust` module
-- [x] Define `TrustTier` enum (Official, Team, Unverified) with serde lowercase serialization
+- [x] Define `TrustTier` enum (Local, Official, Team, Unverified) with serde lowercase serialization
 - [x] Implement `label` and `styled_label` methods on `TrustTier`
-- [x] Implement `determine_trust_tier` supporting HTTPS, SSH, and shorthand forms
+- [x] Implement `determine_trust_tier` supporting local paths, HTTPS, SSH, and shorthand forms
 - [x] Implement `determine_trust_tier_from_owner` for direct owner classification
 - [x] Implement `parse_source_ref` with credential-URL safety (no false-split on `user:token@host`)
 - [x] Wire module into `plugin`, `lanes`, `search`, and `init`
@@ -18,7 +18,7 @@ spec: trust.spec.md
 ## Gaps
 
 - `OFFICIAL_ORGS` and `TEAM_MEMBERS` are hardcoded constants; no runtime configuration. Intentional for 1.0 — keeps the trust surface auditable in git history
-- No support for non-GitHub sources (GitLab, self-hosted) — all classification assumes GitHub URLs or `owner/repo` shorthand
+- Generic non-GitHub git URLs classify as Unverified unless future trust policy adds host-specific tiers
 - A future `Verified` tier for non-CorvidLabs trusted contributors could be added additively without disturbing `Official` or `Team`
 
 ## Review Sign-offs

--- a/specs/trust/testing.md
+++ b/specs/trust/testing.md
@@ -13,6 +13,7 @@ Located in `src/trust.rs` under `#[cfg(test)] mod tests`:
 - `official_ssh_url` — `git@github.com:CorvidLabs/repo.git` classifies as `Official`
 - `official_with_ref` — `CorvidLabs/repo@v1.0.0` classifies as `Official` (ref stripped before classification)
 - `official_case_insensitive` — lowercase `corvidlabs/repo` classifies as `Official`
+- `local_path` — filesystem path sources classify as `Local`
 - `team_member_shorthand` — `0xLeif/repo` classifies as `Team`
 - `team_member_case_insensitive` — `0xleif/repo` classifies as `Team` (GitHub usernames compare case-insensitively)
 - `team_member_full_url` — `https://github.com/0xLeif/repo` classifies as `Team`
@@ -27,7 +28,7 @@ Located in `src/trust.rs` under `#[cfg(test)] mod tests`:
 - `parse_source_ref_without_tag` — leaves `someone/repo` unsplit, ref `None`
 - `parse_source_ref_full_url_with_tag` — splits `https://github.com/…/repo.git@v2.0.0` correctly
 - `parse_source_ref_credential_url_no_split` — credential URL `https://user:token@github.com/…` does NOT split on credential `@`
-- `labels` — `label()` returns `"official"`, `"team"`, `"unverified"`
+- `labels` — `label()` returns `"local"`, `"official"`, `"team"`, `"unverified"`
 
 ### Integration Tests
 
@@ -57,7 +58,7 @@ fledge search rust           # templates also show tier
 
 # JSON output uses lowercase labels (post-tier-C envelope: .plugins[])
 fledge plugins list --json | jq '.plugins[].trust_tier'
-# -> "official" / "team" / "unverified"
+# -> "local" / "official" / "team" / "unverified"
 ```
 
 ### Regression Watch

--- a/specs/trust/trust.spec.md
+++ b/specs/trust/trust.spec.md
@@ -1,6 +1,6 @@
 ---
 module: trust
-version: 3
+version: 4
 status: active
 files:
   - src/trust.rs
@@ -14,7 +14,7 @@ depends_on:
 
 ## Purpose
 
-Shared trust-tier classification for all extension types (plugins, templates, lanes). Determines whether a source is official (CorvidLabs org), team (a personal repo owned by a CorvidLabs member or listed in user config), or unverified based on the GitHub org/owner in the source URL or shorthand. Extracted from `plugin.rs` so that templates and lanes can reuse the same logic. Users can extend the team tier at runtime via `trust.orgs` and `trust.users` in `config.toml`.
+Shared trust-tier classification for all extension types (plugins, templates, lanes). Determines whether a source is local, official (CorvidLabs org), team (a personal repo owned by a CorvidLabs member or listed in user config), or unverified based on the source form and GitHub org/owner in the source URL or shorthand. Extracted from `plugin.rs` so that templates and lanes can reuse the same logic. Users can extend the team tier at runtime via `trust.orgs` and `trust.users` in `config.toml`.
 
 ## Public API
 
@@ -22,7 +22,7 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 
 | Export | Description |
 |--------|-------------|
-| `TrustTier` | Enum: Official, Team, Unverified — serializes as lowercase strings |
+| `TrustTier` | Enum: Local, Official, Team, Unverified — serializes as lowercase strings |
 | `label` | Return the trust tier as a lowercase string (TrustTier method) |
 | `styled_label` | Return the trust tier as a colored styled string (TrustTier method) |
 | `determine_trust_tier` | Classify a source string into a trust tier by parsing the GitHub org/owner |
@@ -33,14 +33,14 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 
 | Type | Description |
 |------|-------------|
-| `TrustTier` | Enum: Official, Team, Unverified — serializes as lowercase via serde |
+| `TrustTier` | Enum: Local, Official, Team, Unverified — serializes as lowercase via serde |
 
 ### Functions
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `label` | `(&self) -> &'static str` | Return trust tier as lowercase string ("official", "team", "unverified") |
-| `styled_label` | `(&self) -> StyledObject<&'static str>` | Return trust tier as colored console label (green/cyan/yellow) |
+| `label` | `(&self) -> &'static str` | Return trust tier as lowercase string ("local", "official", "team", "unverified") |
+| `styled_label` | `(&self) -> StyledObject<&'static str>` | Return trust tier as colored console label (magenta/green/cyan/yellow) |
 | `determine_trust_tier` | `(&str) -> TrustTier` | Parse source URL/shorthand, extract org/owner, classify tier |
 | `determine_trust_tier_from_owner` | `(&str) -> TrustTier` | Classify by owner name directly (no URL parsing) |
 | `parse_source_ref` | `(&str) -> (&str, Option<&str>)` | Split `source@ref` into base and optional ref; handles SSH URLs |
@@ -50,10 +50,10 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 1. `CorvidLabs` and `corvidlabs` are the only official orgs
 2. `TEAM_MEMBERS` is a hardcoded list of GitHub usernames belonging to **human members of the CorvidLabs org**; their *personal* repos classify as `Team` (sources from the org itself classify as `Official`). The current list is `["0xGaspar", "0xLeif", "Kyntrin", "tofu-ux"]` — every human in the org as of v2 of this spec. The `corvid-agent` org member is excluded (it is an AI agent, not a human). Membership is compared case-insensitively (`0xLeif` and `0xleif` both match)
 3. Official tier takes precedence over Team — if an owner appears in both lists (defensive, should not happen), the source classifies as `Official`
-4. `determine_trust_tier` supports HTTPS URLs, SSH URLs, and `owner/repo` shorthand
+4. `determine_trust_tier` supports local paths, HTTPS URLs, SSH URLs, and `owner/repo` shorthand
 5. `parse_source_ref` does not split on `@` in credential URLs (e.g., `https://user:token@github.com/...`)
 6. `parse_source_ref` handles SSH URLs with `git@` prefix without false-splitting on the prefix `@`
-7. Any source not matching an official org, team member, or config entry returns `Unverified`
+7. Any source not matching a local path, official org, team member, or config entry returns `Unverified`
 8. `OFFICIAL_ORGS` and `TEAM_MEMBERS` are `&[&str]` constants providing the baseline trust lists. Users can extend the team tier at runtime via `trust.orgs` and `trust.users` in `config.toml` — these config entries grant **Team** tier only, never Official
 9. Config-based orgs and users are compared case-insensitively, matching the behavior of hardcoded `TEAM_MEMBERS`
 10. When config cannot be loaded (missing or malformed `config.toml`), the system falls back to an empty `TrustConfig` — only the hardcoded constants apply
@@ -65,6 +65,13 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 determine_trust_tier("CorvidLabs/fledge-plugin-deploy") -> Official
 determine_trust_tier("0xLeif/fledge-plugin-thing")     -> Team
 determine_trust_tier("someuser/fledge-plugin-thing")    -> Unverified
+```
+
+### determine_trust_tier — local paths
+```
+determine_trust_tier("./fledge-plugin-thing")  -> Local
+determine_trust_tier("../fledge-plugin-thing") -> Local
+determine_trust_tier("/tmp/fledge-plugin")     -> Local
 ```
 
 ### determine_trust_tier — full URL
@@ -112,6 +119,7 @@ parse_source_ref("https://user:token@github.com/owner/repo.git") -> ("https://us
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 4 | 2026-06-03 | Add `Local` trust tier for filesystem path plugin installs. Labels and styled labels include `"local"`; GitHub owner-based classification remains unchanged for search/discovery |
 | 3 | 2026-05-03 | Configurable trust: `trust.orgs` and `trust.users` config keys extend the team tier at runtime. Invariant 8 rewritten, invariants 9-10 added. Behavioral examples added for config-driven classification. Depends on `config` module |
 | 2 | 2026-04-25 | Rename `Community` → `Team`; add `TEAM_MEMBERS` allowlist of CorvidLabs members (`["0xGaspar", "0xLeif", "Kyntrin", "tofu-ux"]`) classifying their personal repos as `Team`. Drops the unused-variant `#[allow(dead_code)]` since all three tiers now have construction sites |
 | 1 | 2026-04-23 | Initial spec, extracted from plugin.rs |

--- a/specs/work/work.spec.md
+++ b/specs/work/work.spec.md
@@ -1,6 +1,6 @@
 ---
 module: work
-version: 13
+version: 14
 status: active
 files:
   - src/work.rs
@@ -25,6 +25,7 @@ Provides opinionated git workflow commands for feature branch development. `fled
 |--------|-------------|
 | `run` | Entry point that dispatches to the appropriate work subcommand |
 | `WorkAction` | Enum of subcommands: Start, Commit, Push, Status, DeprecatedPr |
+| `WorkConfig` | Deserializable config with `branch_format` and `default_type` fields |
 | `sanitize_branch_name` | Normalizes a string into a valid git branch name (lowercase, hyphens, no leading/trailing hyphens) |
 | `build_commit_message` | Builds a conventional-commit message string from type, optional scope, and message body |
 | `build_branch_name` | (test-only) Constructs a branch name from components using WorkConfig |
@@ -301,6 +302,7 @@ $ fledge work status --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 14 | 2026-06-03 | Document `WorkConfig` in the export table to satisfy strict spec-sync validation |
 | 12 | 2026-05-01 | **Security:** `commit --ai --scope <s>` now validates `<s>` against `[A-Za-z0-9_-]{1,64}` before interpolating it into the LLM prompt or commit message. Scopes containing whitespace, shell metacharacters, template syntax, or anything that could be read as instructions to the model are rejected at the boundary with a clear error |
 | 11 | 2026-04-30 | Pure git split: removed `pr` subcommand (moved to `fledge-plugin-github`), added `commit` and `push` subcommands with `--ai` support and conventional-commit formatting. `status` drops PR info, adds `dirty` count, bumps schema to v2. `generate_body_from_commits` removed; `build_commit_message` added |
 | 10 | 2026-04-26 | Doc sync, behavioral examples for `work start/pr/status --json` updated to show the post-tier-D envelope shapes (with `schema_version` and `action`). No code change |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -658,9 +658,9 @@ pub enum LaneSubcommand {
 
 #[derive(clap::Subcommand)]
 pub enum PluginSubcommand {
-    /// Install a plugin from GitHub
+    /// Install a plugin from a local path or git source
     Install {
-        /// GitHub repo (`owner/repo[@ref]`) or full URL — use `@tag` to pin a version. Omit when using `--defaults`.
+        /// Local path, git URL, or GitHub repo (`owner/repo[@ref]`). Omit when using `--defaults`.
         source: Option<String>,
         /// Reinstall if already present
         #[arg(long)]
@@ -668,6 +668,9 @@ pub enum PluginSubcommand {
         /// Skip all confirmation prompts (accept defaults)
         #[arg(short, long)]
         yes: bool,
+        /// Copy a local plugin into fledge's config dir instead of live-linking it
+        #[arg(long)]
+        copy: bool,
         /// Install fledge's curated set of default plugins (github, deps, metrics)
         #[arg(long, conflicts_with = "source")]
         defaults: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,10 +280,12 @@ fn run() -> Result<()> {
                     source,
                     force,
                     yes,
+                    copy,
                     defaults,
                 } => plugin::PluginAction::Install {
                     source,
                     force: force || yes,
+                    copy,
                     defaults,
                 },
                 PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -234,7 +234,7 @@ fn clone_git_source(
     cmd.args(&clone_args)
         .arg(plugin_dir)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped());
+        .stderr(std::process::Stdio::null());
     if is_github_clone_url(clone_url) {
         apply_git_auth(&mut cmd);
     }
@@ -264,7 +264,7 @@ fn clone_git_source(
             .args(["checkout", ref_str])
             .current_dir(plugin_dir)
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
             .status()
             .with_context(|| format!("checking out ref '{ref_str}'"))?;
         if !status.success() {
@@ -490,9 +490,18 @@ pub(crate) fn install_plugin(
         remove_plugin_path(&plugin_dir).context("removing existing plugin")?;
     }
 
-    materialize_source(&install_source, &plugin_dir, json)?;
+    if let Err(e) = materialize_source(&install_source, &plugin_dir, json) {
+        remove_plugin_path(&plugin_dir).ok();
+        return Err(e);
+    }
 
-    let manifest = read_manifest(&plugin_dir)?;
+    let manifest = match read_manifest(&plugin_dir) {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            remove_plugin_path(&plugin_dir).ok();
+            return Err(e);
+        }
+    };
 
     let caps = &manifest.capabilities;
     let has_protocol_caps = caps.exec || caps.store || caps.metadata;

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -1,15 +1,142 @@
 use anyhow::{bail, Context, Result};
 use console::style;
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::trust::{determine_trust_tier, parse_source_ref, TrustTier};
 
 use super::{
-    apply_git_auth, extract_name_from_source, link_commands, load_registry, normalize_source,
-    plugin_bin_dir, plugins_dir, run_build, run_hook, save_registry, validate_plugin_name,
-    PluginCapabilities, PluginEntry, PluginManifest, PLUGINS_INSTALL_SCHEMA,
+    apply_git_auth, copy_dir_all, create_dir_symlink, extract_name_from_source, link_commands,
+    load_registry, normalize_source, plugin_bin_dir, plugins_dir, remove_plugin_path, run_build,
+    run_hook, save_registry, validate_plugin_name, PluginCapabilities, PluginEntry, PluginManifest,
+    PLUGINS_INSTALL_SCHEMA,
 };
+
+#[derive(Debug)]
+pub(super) enum InstallSource {
+    LocalPath {
+        original: String,
+        canonical: PathBuf,
+        copy: bool,
+    },
+    Git {
+        original: String,
+        clone_url: String,
+        registry_source: String,
+        git_ref: Option<String>,
+        repo_name: String,
+    },
+}
+
+impl InstallSource {
+    pub(super) fn parse(source: &str, copy: bool) -> Result<Self> {
+        if let Some(local) = Self::local_path(source, copy)? {
+            return Ok(local);
+        }
+        if copy {
+            bail!("--copy is only valid when installing from a local path.");
+        }
+
+        let (base, git_ref) = parse_source_ref(source);
+        let clone_url = if Self::is_git_url(base) {
+            base.to_string()
+        } else {
+            normalize_source(source)
+        };
+        let repo_name = extract_name_from_source(source);
+        validate_plugin_name(&repo_name)?;
+        Ok(Self::Git {
+            original: source.to_string(),
+            clone_url,
+            registry_source: base.to_string(),
+            git_ref: git_ref.map(String::from),
+            repo_name,
+        })
+    }
+
+    fn local_path(source: &str, copy: bool) -> Result<Option<Self>> {
+        if source.starts_with("file://") {
+            return Ok(None);
+        }
+        let path = Path::new(source);
+        let looks_like_path = path.is_absolute()
+            || source.starts_with("./")
+            || source.starts_with("../")
+            || source == "."
+            || source == "..";
+        if !looks_like_path && !path.exists() {
+            return Ok(None);
+        }
+        if !path.exists() {
+            bail!("Local plugin path '{}' does not exist.", source);
+        }
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("resolving local plugin path '{}'", source))?;
+        if !canonical.is_dir() {
+            bail!("Local plugin path '{}' is not a directory.", source);
+        }
+        Ok(Some(Self::LocalPath {
+            original: source.to_string(),
+            canonical,
+            copy,
+        }))
+    }
+
+    fn is_git_url(source: &str) -> bool {
+        source.starts_with("http://")
+            || source.starts_with("https://")
+            || source.starts_with("ssh://")
+            || source.starts_with("git://")
+            || source.starts_with("file://")
+            || source.starts_with("git@")
+    }
+
+    fn install_name(&self) -> Result<String> {
+        match self {
+            Self::LocalPath { canonical, .. } => {
+                let manifest = read_manifest(canonical)?;
+                validate_plugin_name(&manifest.plugin.name)?;
+                Ok(manifest.plugin.name)
+            }
+            Self::Git { repo_name, .. } => Ok(repo_name.clone()),
+        }
+    }
+
+    fn registry_source(&self) -> String {
+        match self {
+            Self::LocalPath { canonical, .. } => canonical.to_string_lossy().to_string(),
+            Self::Git {
+                registry_source, ..
+            } => registry_source.clone(),
+        }
+    }
+
+    fn display_source(&self) -> String {
+        match self {
+            Self::LocalPath {
+                original,
+                canonical,
+                copy,
+            } => {
+                if *copy {
+                    format!("{} ({}, copied)", canonical.display(), original)
+                } else {
+                    format!("{} ({}, linked)", canonical.display(), original)
+                }
+            }
+            Self::Git { clone_url, .. } => clone_url.clone(),
+        }
+    }
+
+    fn trust_tier(&self) -> TrustTier {
+        match self {
+            Self::LocalPath { .. } => TrustTier::Local,
+            Self::Git { original, .. } => determine_trust_tier(original),
+        }
+    }
+}
 
 pub(super) fn check_tier_capabilities(
     tier: TrustTier,
@@ -32,6 +159,132 @@ pub(super) fn check_tier_capabilities(
     }
 }
 
+fn read_manifest(plugin_dir: &Path) -> Result<PluginManifest> {
+    let manifest_path = plugin_dir.join("plugin.toml");
+    if !manifest_path.exists() {
+        bail!(
+            "Plugin directory '{}' has no plugin.toml manifest.\n  See {} for the plugin format.",
+            plugin_dir.display(),
+            style("https://github.com/CorvidLabs/fledge#plugins").cyan()
+        );
+    }
+    let manifest_content = fs::read_to_string(&manifest_path).context("reading plugin.toml")?;
+    toml::from_str(&manifest_content).context("parsing plugin.toml")
+}
+
+fn materialize_source(source: &InstallSource, plugin_dir: &Path, json: bool) -> Result<()> {
+    match source {
+        InstallSource::LocalPath {
+            canonical, copy, ..
+        } => {
+            if *copy {
+                if !json {
+                    println!(
+                        "  {} Copying local plugin from {}",
+                        style("→").dim(),
+                        style(canonical.display()).cyan()
+                    );
+                }
+                copy_dir_all(canonical, plugin_dir)
+            } else {
+                if !json {
+                    println!(
+                        "  {} Linking local plugin from {}",
+                        style("→").dim(),
+                        style(canonical.display()).cyan()
+                    );
+                }
+                create_dir_symlink(canonical, plugin_dir)
+            }
+        }
+        InstallSource::Git {
+            original,
+            clone_url,
+            git_ref,
+            ..
+        } => clone_git_source(original, clone_url, git_ref.as_deref(), plugin_dir, json),
+    }
+}
+
+fn clone_git_source(
+    original: &str,
+    clone_url: &str,
+    git_ref: Option<&str>,
+    plugin_dir: &Path,
+    json: bool,
+) -> Result<()> {
+    let sp = if json {
+        None
+    } else {
+        let clone_msg = match git_ref {
+            Some(r) => format!("Cloning {}@{}:", clone_url, r),
+            None => format!("Cloning {}:", clone_url),
+        };
+        Some(crate::spinner::Spinner::start(&clone_msg))
+    };
+
+    let mut clone_args = vec!["clone"];
+    if git_ref.is_none() {
+        clone_args.push("--depth");
+        clone_args.push("1");
+    }
+    clone_args.push(clone_url);
+
+    let mut cmd = Command::new("git");
+    cmd.args(&clone_args)
+        .arg(plugin_dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+    if is_github_clone_url(clone_url) {
+        apply_git_auth(&mut cmd);
+    }
+
+    let status = cmd.status().context("running git clone")?;
+
+    if let Some(s) = sp {
+        s.finish();
+    }
+
+    if !status.success() {
+        bail!(
+            "Failed to clone '{}'. Check the repository URL and your network connection.",
+            original
+        );
+    }
+
+    if let Some(ref_str) = git_ref {
+        if ref_str.starts_with('-') {
+            remove_plugin_path(plugin_dir).ok();
+            bail!(
+                "Invalid git ref '{}': references cannot start with a hyphen.",
+                ref_str
+            );
+        }
+        let status = Command::new("git")
+            .args(["checkout", ref_str])
+            .current_dir(plugin_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .status()
+            .with_context(|| format!("checking out ref '{ref_str}'"))?;
+        if !status.success() {
+            remove_plugin_path(plugin_dir).ok();
+            bail!(
+                "Git ref '{}' not found in '{}'. Check available tags with:\n  {}",
+                ref_str,
+                original,
+                style(format!("git ls-remote --tags {clone_url}")).cyan()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn is_github_clone_url(clone_url: &str) -> bool {
+    clone_url.starts_with("https://github.com/") || clone_url.starts_with("git@github.com:")
+}
+
 /// Top-level dispatcher for `fledge plugins install`. Splits the
 /// single-source path from the `--defaults` bulk-install path so each
 /// caller stays simple. Reports a per-plugin pass/fail count when
@@ -39,12 +292,16 @@ pub(super) fn check_tier_capabilities(
 pub(crate) fn install_action(
     source: Option<&str>,
     force: bool,
+    copy: bool,
     defaults: bool,
     json: bool,
 ) -> Result<()> {
     if defaults {
         if source.is_some() {
             bail!("--defaults installs the curated set; do not pass a source ref alongside it.");
+        }
+        if copy {
+            bail!("--copy cannot be used with --defaults.");
         }
         return install_defaults(force, json);
     }
@@ -53,7 +310,7 @@ pub(crate) fn install_action(
             "Either pass a source ref (owner/repo[@ref]) or use --defaults to install the curated set."
         )
     })?;
-    let report = install_plugin(source, force, json)?;
+    let report = install_plugin(source, force, copy, json)?;
     if json {
         let result = serde_json::json!({
             "schema_version": PLUGINS_INSTALL_SCHEMA,
@@ -92,7 +349,7 @@ pub(crate) fn install_defaults(force: bool, json: bool) -> Result<()> {
             println!();
             println!("  {} {}", style("→").dim(), style(source).cyan());
         }
-        match install_plugin(source, force, json) {
+        match install_plugin(source, force, false, json) {
             Ok(report) => {
                 installed.push(report);
                 installed_sources.push(source);
@@ -153,22 +410,31 @@ pub(crate) fn install_defaults(force: bool, json: bool) -> Result<()> {
 /// Install a single plugin. Returns a JSON-serializable report describing
 /// what was installed; the caller is responsible for printing the JSON
 /// envelope (so single-install and bulk-install share one shape).
-pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<serde_json::Value> {
+pub(crate) fn install_plugin(
+    source: &str,
+    force: bool,
+    copy: bool,
+    json: bool,
+) -> Result<serde_json::Value> {
     let force = force || crate::utils::is_non_interactive();
-    let (_, git_ref) = parse_source_ref(source);
-    let url = normalize_source(source);
-    let repo_name = extract_name_from_source(source);
-    validate_plugin_name(&repo_name)?;
+    let install_source = InstallSource::parse(source, copy)?;
+    let repo_name = install_source.install_name()?;
+    let display_source = install_source.display_source();
 
-    let tier = determine_trust_tier(source);
+    let tier = install_source.trust_tier();
     if !json {
         println!(
             "\n{} Installing plugin from: {} [{}]",
             style("!").yellow().bold(),
-            style(&url).cyan(),
+            style(&display_source).cyan(),
             tier.styled_label()
         );
-        if tier == TrustTier::Official {
+        if tier == TrustTier::Local {
+            println!(
+                "  {} This is a local plugin. Changes in the source directory are live unless --copy is used.",
+                style("✓").magenta()
+            );
+        } else if tier == TrustTier::Official {
             println!(
                 "  {} This is an official CorvidLabs plugin.",
                 style("✓").green()
@@ -193,7 +459,9 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
             );
         }
         let confirm = dialoguer::Confirm::with_theme(&dialoguer::theme::ColorfulTheme::default())
-            .with_prompt(format!("Install plugin '{repo_name}' from {url}?"))
+            .with_prompt(format!(
+                "Install plugin '{repo_name}' from {display_source}?"
+            ))
             .default(true)
             .interact()?;
         if !confirm {
@@ -219,85 +487,12 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                 style("--force").cyan()
             );
         }
-        fs::remove_dir_all(&plugin_dir).context("removing existing plugin")?;
+        remove_plugin_path(&plugin_dir).context("removing existing plugin")?;
     }
 
-    let sp = if json {
-        None
-    } else {
-        let clone_msg = match git_ref {
-            Some(r) => format!("Cloning {}@{}:", &url, r),
-            None => format!("Cloning {}:", &url),
-        };
-        Some(crate::spinner::Spinner::start(&clone_msg))
-    };
+    materialize_source(&install_source, &plugin_dir, json)?;
 
-    let mut clone_args = vec!["clone"];
-    if git_ref.is_none() {
-        clone_args.push("--depth");
-        clone_args.push("1");
-    }
-    clone_args.push(&url);
-
-    let mut cmd = Command::new("git");
-    cmd.args(&clone_args)
-        .arg(&plugin_dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped());
-    apply_git_auth(&mut cmd);
-
-    let status = cmd.status().context("running git clone")?;
-
-    if let Some(s) = sp {
-        s.finish();
-    }
-
-    if !status.success() {
-        bail!(
-            "Failed to clone '{}'. Check the repository URL and your network connection.",
-            source
-        );
-    }
-
-    if let Some(ref_str) = git_ref {
-        if ref_str.starts_with('-') {
-            fs::remove_dir_all(&plugin_dir).ok();
-            bail!(
-                "Invalid git ref '{}': references cannot start with a hyphen.",
-                ref_str
-            );
-        }
-        let status = Command::new("git")
-            .args(["checkout", ref_str])
-            .current_dir(&plugin_dir)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .status()
-            .with_context(|| format!("checking out ref '{ref_str}'"))?;
-        if !status.success() {
-            fs::remove_dir_all(&plugin_dir).ok();
-            bail!(
-                "Git ref '{}' not found in '{}'. Check available tags with:\n  {}",
-                ref_str,
-                source,
-                style(format!("git ls-remote --tags {url}")).cyan()
-            );
-        }
-    }
-
-    let manifest_path = plugin_dir.join("plugin.toml");
-    if !manifest_path.exists() {
-        fs::remove_dir_all(&plugin_dir).ok();
-        bail!(
-            "Repository '{}' has no plugin.toml manifest.\n  See {} for the plugin format.",
-            source,
-            style("https://github.com/CorvidLabs/fledge#plugins").cyan()
-        );
-    }
-
-    let manifest_content = fs::read_to_string(&manifest_path).context("reading plugin.toml")?;
-    let manifest: PluginManifest =
-        toml::from_str(&manifest_content).context("parsing plugin.toml")?;
+    let manifest = read_manifest(&plugin_dir)?;
 
     let caps = &manifest.capabilities;
     let has_protocol_caps = caps.exec || caps.store || caps.metadata;
@@ -308,7 +503,7 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     let has_hooks = manifest.hooks.has_any();
 
     if let Err(blocked) = check_tier_capabilities(tier, caps) {
-        if let Err(e) = fs::remove_dir_all(&plugin_dir) {
+        if let Err(e) = remove_plugin_path(&plugin_dir) {
             eprintln!(
                 "Warning: failed to clean up partial install at {}: {e}",
                 plugin_dir.display()
@@ -403,7 +598,7 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                 style("WARN").yellow()
             );
         } else if !crate::utils::is_interactive() {
-            fs::remove_dir_all(&plugin_dir).ok();
+            remove_plugin_path(&plugin_dir).ok();
             bail!(
                 "Plugin permissions require confirmation in non-interactive mode.\n  \
                  Use --yes or --force to auto-grant."
@@ -422,14 +617,14 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                     .default(true)
                     .interact()?;
             if !confirm {
-                fs::remove_dir_all(&plugin_dir).ok();
+                remove_plugin_path(&plugin_dir).ok();
                 bail!("Plugin installation cancelled.");
             }
         }
     }
 
     if let Err(e) = run_build(&plugin_dir, &manifest) {
-        fs::remove_dir_all(&plugin_dir).ok();
+        remove_plugin_path(&plugin_dir).ok();
         return Err(e.context("build failed; installation rolled back"));
     }
 
@@ -443,7 +638,7 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                 );
                 super::wasm::compile_and_cache(&wasm_path)?;
             } else {
-                fs::remove_dir_all(&plugin_dir).ok();
+                remove_plugin_path(&plugin_dir).ok();
                 bail!(
                     "WASM binary '{}' not found after build.\n  \
                      Check that the build hook produces a .wasm file at the path declared in plugin.toml.\n  \
@@ -456,7 +651,7 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     }
 
     let command_names = link_commands(&plugin_dir, &bin_dir, &manifest).inspect_err(|_| {
-        fs::remove_dir_all(&plugin_dir).ok();
+        remove_plugin_path(&plugin_dir).ok();
     })?;
 
     // Run post_install hook BEFORE persisting to registry so a hook failure
@@ -468,12 +663,15 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
                 let link_path = bin_dir.join(format!("fledge-{cmd_name}"));
                 fs::remove_file(&link_path).ok();
             }
-            fs::remove_dir_all(&plugin_dir).ok();
+            remove_plugin_path(&plugin_dir).ok();
             return Err(e.context("post_install hook failed; installation rolled back"));
         }
     }
 
-    let (base_source, _) = parse_source_ref(source);
+    let pinned_ref = match &install_source {
+        InstallSource::Git { git_ref, .. } => git_ref.clone(),
+        InstallSource::LocalPath { .. } => None,
+    };
     let granted_caps = if manifest.plugin.protocol.is_some() {
         Some(manifest.capabilities.clone())
     } else {
@@ -481,11 +679,11 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     };
     let entry = PluginEntry {
         name: repo_name.clone(),
-        source: base_source.to_string(),
+        source: install_source.registry_source(),
         version: manifest.plugin.version.clone(),
         installed: chrono::Local::now().format("%Y-%m-%d").to_string(),
         commands: command_names.clone(),
-        pinned_ref: git_ref.map(String::from),
+        pinned_ref,
         capabilities: granted_caps,
         runtime: manifest.plugin.runtime.clone(),
     };
@@ -498,7 +696,7 @@ pub(crate) fn install_plugin(source: &str, force: bool, json: bool) -> Result<se
     save_registry(&registry)?;
 
     if !json {
-        if let Some(ref pinned) = git_ref {
+        if let Some(ref pinned) = entry.pinned_ref {
             println!(
                 "{} Installed {} v{} (pinned to {})",
                 style("✅").green().bold(),

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -596,7 +596,7 @@ fn remove_plugin_path(path: &Path) -> Result<()> {
     if metadata.file_type().is_symlink() {
         #[cfg(windows)]
         {
-            if metadata.is_dir() {
+            if path.is_dir() {
                 fs::remove_dir(path)
                     .with_context(|| format!("removing directory symlink {}", path.display()))?;
             } else {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -593,10 +593,27 @@ fn remove_plugin_path(path: &Path) -> Result<()> {
     }
     let metadata =
         fs::symlink_metadata(path).with_context(|| format!("inspecting {}", path.display()))?;
-    if metadata.file_type().is_symlink() || metadata.is_file() {
-        fs::remove_file(path).with_context(|| format!("removing {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        #[cfg(windows)]
+        {
+            if metadata.is_dir() {
+                fs::remove_dir(path)
+                    .with_context(|| format!("removing directory symlink {}", path.display()))?;
+            } else {
+                fs::remove_file(path)
+                    .with_context(|| format!("removing file symlink {}", path.display()))?;
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            fs::remove_file(path)
+                .with_context(|| format!("removing symlink {}", path.display()))?;
+        }
+    } else if metadata.is_file() {
+        fs::remove_file(path).with_context(|| format!("removing file {}", path.display()))?;
     } else {
-        fs::remove_dir_all(path).with_context(|| format!("removing {}", path.display()))?;
+        fs::remove_dir_all(path)
+            .with_context(|| format!("removing directory {}", path.display()))?;
     }
     Ok(())
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -200,6 +200,7 @@ pub enum PluginAction {
     Install {
         source: Option<String>,
         force: bool,
+        copy: bool,
         /// Install the curated set of default plugins (DEFAULT_PLUGINS)
         defaults: bool,
     },
@@ -254,8 +255,9 @@ pub fn run(opts: PluginOptions) -> Result<()> {
         PluginAction::Install {
             source,
             force,
+            copy,
             defaults,
-        } => install_action(source.as_deref(), force, defaults, opts.json),
+        } => install_action(source.as_deref(), force, copy, defaults, opts.json),
         PluginAction::Remove { name } => remove_plugin(&name, opts.json),
         PluginAction::Update { name, defaults } => {
             update_plugins(name.as_deref(), defaults, opts.json)
@@ -585,6 +587,44 @@ fn validate_plugin_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+fn remove_plugin_path(path: &Path) -> Result<()> {
+    if !path.exists() && !path.is_symlink() {
+        return Ok(());
+    }
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("inspecting {}", path.display()))?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path).with_context(|| format!("removing {}", path.display()))?;
+    } else {
+        fs::remove_dir_all(path).with_context(|| format!("removing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn copy_dir_all(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)
+        .with_context(|| format!("creating {}", destination.display()))?;
+    for entry in fs::read_dir(source).with_context(|| format!("reading {}", source.display()))? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)
+            .with_context(|| format!("inspecting {}", source_path.display()))?;
+        if metadata.file_type().is_symlink() {
+            let target = fs::read_link(&source_path)
+                .with_context(|| format!("reading symlink {}", source_path.display()))?;
+            create_symlink(&target, &destination_path)
+                .with_context(|| format!("copying symlink {}", source_path.display()))?;
+        } else if metadata.is_dir() {
+            copy_dir_all(&source_path, &destination_path)?;
+        } else {
+            fs::copy(&source_path, &destination_path)
+                .with_context(|| format!("copying {}", source_path.display()))?;
+        }
+    }
+    Ok(())
+}
+
 // ─── Git auth helper ─────────────────────────────────────────────────────────
 
 fn apply_git_auth(cmd: &mut Command) {
@@ -643,6 +683,19 @@ fn create_symlink(original: &Path, link: &Path) -> Result<()> {
         // privileges.  Fall back to copying the file when symlink fails.
         std::os::windows::fs::symlink_file(original, link)
             .or_else(|_| std::fs::copy(original, link).map(|_| ()))?;
+    }
+    Ok(())
+}
+
+fn create_dir_symlink(original: &Path, link: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)?;
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(original, link)
+            .or_else(|_| copy_dir_all(original, link))?;
     }
     Ok(())
 }

--- a/src/plugin/recommend.rs
+++ b/src/plugin/recommend.rs
@@ -192,7 +192,7 @@ pub(crate) fn recommend_plugins(json: bool) -> Result<()> {
 
     println!();
     for r in &new_recs {
-        if let Err(e) = super::install::install_action(Some(r.repo), false, false, false) {
+        if let Err(e) = super::install::install_action(Some(r.repo), false, false, false, false) {
             eprintln!("  {} Failed to install {}: {}", style("✗").red(), r.repo, e);
         }
     }

--- a/src/plugin/remove.rs
+++ b/src/plugin/remove.rs
@@ -3,8 +3,8 @@ use console::style;
 use std::fs;
 
 use super::{
-    load_registry, plugin_bin_dir, plugins_dir, run_hook, save_registry, PluginManifest,
-    PLUGINS_REMOVE_SCHEMA,
+    load_registry, plugin_bin_dir, plugins_dir, remove_plugin_path, run_hook, save_registry,
+    PluginManifest, PLUGINS_REMOVE_SCHEMA,
 };
 
 pub(crate) fn remove_plugin(name: &str, json: bool) -> Result<()> {
@@ -53,7 +53,7 @@ pub(crate) fn remove_plugin(name: &str, json: bool) -> Result<()> {
     }
 
     if plugin_dir.exists() {
-        fs::remove_dir_all(&plugin_dir).context("removing plugin directory")?;
+        remove_plugin_path(&plugin_dir).context("removing plugin directory")?;
     }
 
     let removed_name = entry.name.clone();

--- a/src/plugin/search.rs
+++ b/src/plugin/search.rs
@@ -185,5 +185,5 @@ fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
         style(chosen.full_name()).green().bold()
     );
 
-    super::install::install_action(Some(&chosen.full_name()), false, false, false)
+    super::install::install_action(Some(&chosen.full_name()), false, false, false, false)
 }

--- a/src/plugin/tests.rs
+++ b/src/plugin/tests.rs
@@ -1,3 +1,4 @@
+use super::install::InstallSource;
 use super::*;
 use crate::trust::{parse_source_ref, TrustTier};
 
@@ -143,7 +144,7 @@ fn default_plugins_are_well_formed() {
 
 #[test]
 fn install_action_rejects_source_with_defaults() {
-    let err = install_action(Some("someone/foo"), false, true, false)
+    let err = install_action(Some("someone/foo"), false, false, true, false)
         .unwrap_err()
         .to_string();
     assert!(err.contains("--defaults"));
@@ -151,7 +152,7 @@ fn install_action_rejects_source_with_defaults() {
 
 #[test]
 fn install_action_requires_source_or_defaults() {
-    let err = install_action(None, false, false, false)
+    let err = install_action(None, false, false, false, false)
         .unwrap_err()
         .to_string();
     assert!(err.contains("--defaults"));
@@ -217,6 +218,78 @@ fn normalize_full_url() {
 fn normalize_ssh_url() {
     let url = "git@github.com:someone/fledge-deploy.git";
     assert_eq!(normalize_source(url), url);
+}
+
+#[test]
+fn install_source_parses_existing_local_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("plugin.toml"),
+        "[plugin]\nname = \"local-tool\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let source = InstallSource::parse(tmp.path().to_str().unwrap(), false).unwrap();
+    match source {
+        InstallSource::LocalPath {
+            canonical, copy, ..
+        } => {
+            assert_eq!(canonical, tmp.path().canonicalize().unwrap());
+            assert!(!copy);
+        }
+        InstallSource::Git { .. } => panic!("expected local source"),
+    }
+}
+
+#[test]
+fn install_source_parses_generic_git_url_without_github_normalization() {
+    let source = InstallSource::parse(
+        "https://gitlab.com/org/fledge-plugin-demo.git@v1.0.0",
+        false,
+    )
+    .unwrap();
+    match source {
+        InstallSource::Git {
+            clone_url,
+            registry_source,
+            git_ref,
+            repo_name,
+            ..
+        } => {
+            assert_eq!(clone_url, "https://gitlab.com/org/fledge-plugin-demo.git");
+            assert_eq!(
+                registry_source,
+                "https://gitlab.com/org/fledge-plugin-demo.git"
+            );
+            assert_eq!(git_ref.as_deref(), Some("v1.0.0"));
+            assert_eq!(repo_name, "fledge-plugin-demo");
+        }
+        InstallSource::LocalPath { .. } => panic!("expected git source"),
+    }
+}
+
+#[test]
+fn install_source_rejects_copy_for_git_source() {
+    let err = InstallSource::parse("someone/fledge-plugin-demo", true)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("--copy"));
+}
+
+#[test]
+fn remove_plugin_path_removes_symlink_without_removing_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("target");
+    let link = tmp.path().join("link");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(target.join("plugin.toml"), "").unwrap();
+    create_dir_symlink(&target, &link).unwrap();
+
+    remove_plugin_path(&link).unwrap();
+
+    assert!(!link.exists());
+    assert!(target.exists());
+    assert!(target.join("plugin.toml").exists());
 }
 
 #[test]
@@ -887,9 +960,17 @@ fn trust_tier_unverified_no_org() {
 #[test]
 fn trust_tier_label_strings() {
     use crate::trust::TrustTier;
+    assert_eq!(TrustTier::Local.label(), "local");
     assert_eq!(TrustTier::Official.label(), "official");
     assert_eq!(TrustTier::Team.label(), "team");
     assert_eq!(TrustTier::Unverified.label(), "unverified");
+}
+
+#[test]
+fn trust_tier_local_path() {
+    use crate::trust::{determine_trust_tier, TrustTier};
+    assert_eq!(determine_trust_tier("/tmp/fledge-plugin"), TrustTier::Local);
+    assert_eq!(determine_trust_tier("./fledge-plugin"), TrustTier::Local);
 }
 
 #[test]

--- a/src/plugin/update.rs
+++ b/src/plugin/update.rs
@@ -8,7 +8,7 @@ use super::{
     apply_git_auth, link_commands, load_registry, normalize_source, plugin_bin_dir, plugins_dir,
     run_build, save_registry, PluginManifest, PLUGINS_UPDATE_SCHEMA,
 };
-use crate::trust::parse_source_ref;
+use crate::trust::{determine_trust_tier, parse_source_ref, TrustTier};
 
 pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> Result<()> {
     use super::DEFAULT_PLUGINS;
@@ -125,6 +125,22 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
             continue;
         }
 
+        if determine_trust_tier(&entry.source) == TrustTier::Local {
+            if !json {
+                println!(
+                    "  {} {} — local plugin, skipped",
+                    style("*").cyan().bold(),
+                    style(&entry.name).cyan()
+                );
+            }
+            results.push(serde_json::json!({
+                "name": entry.name,
+                "status": "skipped",
+                "detail": "local plugin — reinstall to refresh copied installs; live-linked installs use the source directory directly",
+            }));
+            continue;
+        }
+
         // Workspace-managed plugins (e.g. Merlin's bundled plugins under
         // `plugins/`) have no `.git` and are rebuilt by the host project's
         // init step. Skipping them silently keeps `plugins update` quiet
@@ -147,7 +163,7 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
         }
 
         if let Some(ref pinned) = entry.pinned_ref {
-            let latest = find_latest_tag(&plugin_dir);
+            let latest = find_latest_tag(&plugin_dir, &entry.source);
             match latest {
                 Some(ref tag) if tag != pinned => {
                     if defaults {
@@ -260,7 +276,9 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
             .current_dir(&plugin_dir)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped());
-        apply_git_auth(&mut cmd);
+        if is_github_source(&entry.source) {
+            apply_git_auth(&mut cmd);
+        }
 
         let status = cmd
             .status()
@@ -472,13 +490,15 @@ fn is_git_repo(plugin_dir: &Path) -> bool {
     plugin_dir.join(".git").exists()
 }
 
-pub(crate) fn find_latest_tag(repo_dir: &Path) -> Option<String> {
+pub(crate) fn find_latest_tag(repo_dir: &Path, source: &str) -> Option<String> {
     let mut cmd = Command::new("git");
     cmd.args(["fetch", "--tags"])
         .current_dir(repo_dir)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
-    apply_git_auth(&mut cmd);
+    if is_github_source(source) {
+        apply_git_auth(&mut cmd);
+    }
 
     cmd.status().ok();
     let output = Command::new("git")
@@ -495,6 +515,12 @@ pub(crate) fn find_latest_tag(repo_dir: &Path) -> Option<String> {
         .next()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+fn is_github_source(source: &str) -> bool {
+    source.starts_with("https://github.com/")
+        || source.starts_with("git@github.com:")
+        || (!source.contains("://") && !source.starts_with("git@") && source.contains('/'))
 }
 
 #[cfg(test)]

--- a/src/snapshots/fledge__introspect__tests__introspect_schema.snap
+++ b/src/snapshots/fledge__introspect__tests__introspect_schema.snap
@@ -1047,12 +1047,12 @@ expression: output
       "subcommands": [
         {
           "name": "install",
-          "about": "Install a plugin from GitHub",
+          "about": "Install a plugin from a local path or git source",
           "aliases": [],
           "args": [
             {
               "name": "source",
-              "help": "GitHub repo (`owner/repo[@ref]`) or full URL — use `@tag` to pin a version. Omit when using `--defaults`",
+              "help": "Local path, git URL, or GitHub repo (`owner/repo[@ref]`). Omit when using `--defaults`",
               "required": false,
               "takes_value": true,
               "value_name": "SOURCE",
@@ -1071,6 +1071,14 @@ expression: output
               "long": "yes",
               "short": "y",
               "help": "Skip all confirmation prompts (accept defaults)",
+              "required": false,
+              "takes_value": false,
+              "global": false
+            },
+            {
+              "name": "copy",
+              "long": "copy",
+              "help": "Copy a local plugin into fledge's config dir instead of live-linking it",
               "required": false,
               "takes_value": false,
               "global": false

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -93,6 +93,8 @@ pub fn determine_trust_tier(source: &str) -> TrustTier {
         || source.starts_with("../")
         || source.starts_with(".\\")
         || source.starts_with("..\\")
+        || source.starts_with('/')
+        || source.starts_with('\\')
         || source == "."
         || source == ".."
     {

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,5 +1,6 @@
 use console::style;
 use serde::Serialize;
+use std::path::Path;
 
 use crate::config::TrustConfig;
 
@@ -7,6 +8,7 @@ use crate::config::TrustConfig;
 #[serde(rename_all = "lowercase")]
 #[clap(rename_all = "lowercase")]
 pub enum TrustTier {
+    Local,
     Official,
     Team,
     Unverified,
@@ -15,6 +17,7 @@ pub enum TrustTier {
 impl TrustTier {
     pub fn label(&self) -> &'static str {
         match self {
+            TrustTier::Local => "local",
             TrustTier::Official => "official",
             TrustTier::Team => "team",
             TrustTier::Unverified => "unverified",
@@ -23,6 +26,7 @@ impl TrustTier {
 
     pub fn styled_label(&self) -> console::StyledObject<&'static str> {
         match self {
+            TrustTier::Local => style("local").magenta(),
             TrustTier::Official => style("official").green().bold(),
             TrustTier::Team => style("team").cyan(),
             TrustTier::Unverified => style("unverified").yellow(),
@@ -82,6 +86,16 @@ pub fn parse_source_ref(source: &str) -> (&str, Option<&str>) {
 }
 
 pub fn determine_trust_tier(source: &str) -> TrustTier {
+    let path = Path::new(source);
+    if source.starts_with("local:")
+        || path.is_absolute()
+        || source.starts_with("./")
+        || source.starts_with("../")
+        || source.starts_with(".\\")
+        || source.starts_with("..\\")
+    {
+        return TrustTier::Local;
+    }
     let config = load_trust_config();
     classify_source(source, &config)
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -93,6 +93,8 @@ pub fn determine_trust_tier(source: &str) -> TrustTier {
         || source.starts_with("../")
         || source.starts_with(".\\")
         || source.starts_with("..\\")
+        || source == "."
+        || source == ".."
     {
         return TrustTier::Local;
     }


### PR DESCRIPTION
## Summary
- Add local path plugin installs with live symlink mode and --copy snapshots
- Support generic git URL plugin sources while preserving GitHub shorthand
- Add local trust tier, safe local removal, update skipping, tests, specs, and introspection snapshot updates

## Test Plan
- [x] fledge run test --json
- [x] fledge run spec-check --json
- [x] fledge lanes run pre-commit --json