### PR TITLE
chore(release): prepare v1.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.4.3";
+          version = "1.4.4";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
Release prep for v1.4.4 includes version bumps in Cargo.toml and flake.nix and tags v1.4.4.