### PR TITLE
Refactor: hoist per-call regex compilation to LazyLock

### DIFF
--- a/src/release/toml_utils.rs
+++ b/src/release/toml_utils.rs
@@ -1,8 +1,23 @@
 use regex_lite::Regex;
+use std::sync::LazyLock;
+
+/// Top-level `version = "X.Y.Z"` (multi-line anchored). Compiled once.
+static TOP_LEVEL_VERSION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?m)^version\s*=\s*"([^"]+)""#).unwrap());
+
+/// A bare `version = "X.Y.Z"` line within a section. Compiled once.
+static SECTION_VERSION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*version\s*=\s*"([^"]+)"\s*$"#).unwrap());
+
+/// Capturing form that preserves the prefix/suffix around the version value so
+/// it can be rewritten in place. Compiled once.
+static SECTION_VERSION_REPLACE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^(\s*version\s*=\s*")[^"]+("\s*)$"#).unwrap());
 
 pub(super) fn extract_toml_version(content: &str) -> Option<String> {
-    let re = Regex::new(r#"(?m)^version\s*=\s*"([^"]+)""#).unwrap();
-    re.captures(content).map(|c| c[1].to_string())
+    TOP_LEVEL_VERSION_RE
+        .captures(content)
+        .map(|c| c[1].to_string())
 }
 
 /// Extract `version = "X.Y.Z"` from a specific `[section]` table within a TOML
@@ -11,7 +26,6 @@ pub(super) fn extract_toml_version(content: &str) -> Option<String> {
 pub(super) fn extract_versioned_toml_section(content: &str, section: &str) -> Option<String> {
     let header = format!("[{section}]");
     let mut in_section = false;
-    let version_re = Regex::new(r#"^\s*version\s*=\s*"([^"]+)"\s*$"#).unwrap();
     for line in content.lines() {
         let trimmed = line.trim_start();
         if trimmed.starts_with('[') {
@@ -19,7 +33,7 @@ pub(super) fn extract_versioned_toml_section(content: &str, section: &str) -> Op
             continue;
         }
         if in_section {
-            if let Some(caps) = version_re.captures(line) {
+            if let Some(caps) = SECTION_VERSION_RE.captures(line) {
                 return Some(caps[1].to_string());
             }
         }
@@ -37,7 +51,6 @@ pub(super) fn replace_versioned_toml_section(
     new_version: &str,
 ) -> Option<String> {
     let header = format!("[{section}]");
-    let version_re = Regex::new(r#"^(\s*version\s*=\s*")[^"]+("\s*)$"#).unwrap();
     let crlf = content.contains("\r\n");
     let line_sep = if crlf { "\r\n" } else { "\n" };
     let trailing_newline = content.ends_with('\n');
@@ -55,7 +68,7 @@ pub(super) fn replace_versioned_toml_section(
             continue;
         }
         if in_section && !replaced {
-            if let Some(caps) = version_re.captures(line) {
+            if let Some(caps) = SECTION_VERSION_REPLACE_RE.captures(line) {
                 out_lines.push(format!("{}{}{}", &caps[1], new_version, &caps[2]));
                 replaced = true;
                 continue;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::LazyLock;
 
 /// Global flag: when set, every prompt site must either auto-answer (because
 /// its command also has `--yes`/`--force` passed explicitly or now forced by
@@ -189,17 +190,22 @@ pub fn redact_secrets(input: &str) -> String {
     // (?i) = case-insensitive. Match the value to end-of-line so multi-token
     // header values (`Basic <base64>`, `token <opaque>`, etc.) are fully
     // redacted — `\S+` only catches the first whitespace-delimited token.
-    let auth = regex_lite::Regex::new(r"(?i)(authorization:)[^\n]*").unwrap();
-    let xat = regex_lite::Regex::new(r"(?i)(x-access-token:)[^\n]*").unwrap();
-    let bearer = regex_lite::Regex::new(r"(?i)(bearer )[^\s\n]+").unwrap();
+    // Patterns are compiled once and reused across calls.
+    static AUTH: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?i)(authorization:)[^\n]*").unwrap());
+    static XAT: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?i)(x-access-token:)[^\n]*").unwrap());
+    static BEARER: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?i)(bearer )[^\s\n]+").unwrap());
     // Credentials embedded in URLs: scheme://user:pass@host
-    let url_creds =
-        regex_lite::Regex::new(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^\s/@]+:[^\s/@]+@").unwrap();
+    static URL_CREDS: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
+        regex_lite::Regex::new(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^\s/@]+:[^\s/@]+@").unwrap()
+    });
 
-    let s = auth.replace_all(input, "$1 [REDACTED]");
-    let s = xat.replace_all(&s, "$1[REDACTED]");
-    let s = bearer.replace_all(&s, "$1[REDACTED]");
-    let s = url_creds.replace_all(&s, "$1[REDACTED]@");
+    let s = AUTH.replace_all(input, "$1 [REDACTED]");
+    let s = XAT.replace_all(&s, "$1[REDACTED]");
+    let s = BEARER.replace_all(&s, "$1[REDACTED]");
+    let s = URL_CREDS.replace_all(&s, "$1[REDACTED]@");
     s.into_owned()
 }
 
@@ -340,6 +346,18 @@ mod tests {
     fn test_is_truthy_rejects_common_falsy_values() {
         for v in ["", "0", "false", "no", "off", "nope", "blue"] {
             assert!(!is_truthy(v), "expected '{v}' to be falsy");
+        }
+    }
+
+    #[test]
+    fn test_is_truthy_env_mirrors_is_truthy() {
+        // The public wrapper must accept/reject exactly what the private
+        // parser does so env-var spellings stay consistent across the CLI.
+        for v in ["1", "true", "Yes", "  on "] {
+            assert!(is_truthy_env(v), "expected '{v}' to be truthy");
+        }
+        for v in ["", "0", "false", "off", "blue"] {
+            assert!(!is_truthy_env(v), "expected '{v}' to be falsy");
         }
     }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use console::style;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use tera::Tera;
 use walkdir::WalkDir;
 
@@ -262,13 +263,16 @@ fn validate_single(path: &Path) -> Result<ValidationReport> {
 }
 
 fn extract_variables(content: &str) -> HashSet<String> {
-    let re = regex_lite::Regex::new(r"\{\{[\s]*([a-zA-Z_][a-zA-Z0-9_]*)").unwrap();
-    let dollar_re = regex_lite::Regex::new(r"\$\{\{").unwrap();
-    let dollar_positions: HashSet<usize> = dollar_re
+    static VAR_RE: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\{\{[\s]*([a-zA-Z_][a-zA-Z0-9_]*)").unwrap());
+    static DOLLAR_RE: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\$\{\{").unwrap());
+    let dollar_positions: HashSet<usize> = DOLLAR_RE
         .find_iter(content)
         .map(|m| m.start() + 1)
         .collect();
-    re.captures_iter(content)
+    VAR_RE
+        .captures_iter(content)
         .filter(|cap| {
             let start = cap.get(0).unwrap().start();
             !dollar_positions.contains(&start)


### PR DESCRIPTION
## Summary

Jules (Google) left 27 review suggestions on the repo. I reviewed all of them and actioned **only the valid ones**. The valid subset turned out to be a single coherent theme — **regexes recompiled on every call** — plus one genuine test gap.

### Done

- **Hoist per-call regex compilation to `std::sync::LazyLock`** (compile once per process instead of on every invocation):
  - `release/toml_utils.rs` — `extract_toml_version`, `extract_versioned_toml_section`, `replace_versioned_toml_section`
  - `utils.rs` — `redact_secrets` (4 patterns; called per subprocess-error scrub)
  - `validate.rs` — `extract_variables` (2 patterns; called per template file during validation)
- **Add a direct test for `is_truthy_env`** — the public env-var wrapper was only covered transitively through the private `is_truthy`.

### Reviewed and intentionally skipped

| Suggestion(s) | Why not actioned |
|---|---|
| Test `is_cloud_model`, `redact_secrets`, `check_fledge_version` error paths, `check_requirements` missing deps, `require_interactive` error paths | **Already tested** — these tests exist today. |
| Sync file I/O "inside loop" (lanes config, `list_specs`) | fledge is a **synchronous CLI** with no async runtime; blocking I/O is correct here. |
| "Unnecessary String cloning" in `step_description` | Returns an **owned `String`** built from borrowed input — the clones are required. |
| Command Injection in `run_post_create_hooks`, `execute_task`, protocol plugin `exec` | Executing configured commands **is the feature** (task runner / hooks / plugins), gated by explicit consent prompts and trust flags. Not injection. |
| Unsafe Deserialization in Plugin Validation | Doesn't apply to memory-safe `serde`. |
| Deprecated `Pr` command in `WorkAction` | Deliberate hidden deprecation shim (`WorkAction::DeprecatedPr`). |
| Dead code in `PluginMeta` / `PluginCommand` | Required fields enforce the manifest schema at deserialize time; already `#[allow(dead_code)]`. |
| Excessive arguments in `emit_init_envelope` / `commit` | Already carry deliberate `#[allow(clippy::too_many_arguments)]`. |

## Test Plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (all suites pass)
- [x] `cargo run -- spec check` (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
