### PR TITLE
Add: task argument pass-through (fledge run <task> -- <args>)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Specs (`specs/<name>/*.spec.md` and companion files) are the source of truth for
 | `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [{name, checks: [...], informational}], passed, failed}`. Four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational, missing tools don't count toward `failed` | Debugging a broken setup |
 | `fledge changelog --json` | `{schema_version: 1, action: "changelog", releases: [{tag, date, sections}]}` | Generating release notes |
 | `fledge run --list --json` | `{schema_version: 1, action: "run_list", auto_detected, tasks: [...]}` | Discovering tasks defined in `fledge.toml` (or auto-detected) |
-| `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` | Running a task and capturing its output |
+| `fledge run <task> --json` | `{schema_version: 1, action: "run_task", task, command, exit_code, success, stdout, stderr}` (plus `args` when pass-through args are supplied) | Running a task and capturing its output. Forward extra args to the command with `fledge run <task> -- <args…>` |
 | `fledge run --init --json` | `{schema_version: 1, action: "run_init", file, project_type, files_created}` | Scaffolding a `fledge.toml` |
 | `fledge release --dry-run --json` | `{schema_version: 1, action: "release", dry_run: true, version, no_bump, files_to_bump, will_changelog, will_tag, will_push, tag}` | Preview what a release would do |
 | `fledge release --json` | `{schema_version: 1, action: "release", dry_run: false, version, old_version, files_bumped, changelog_updated, commit_created, tag_created, tag, pushed}` | After a real release completes |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Already have a project? `cd` into it, fledge auto-detects the stack:
 ```bash
 fledge run test       # runs your language's test command
 fledge run build      # same for build
+fledge run test -- --nocapture   # pass extra args through to the command after --
 fledge review         # AI code review against the default branch
 fledge review --with-model ollama:gpt-oss:120b-cloud,ollama:qwen3-coder:480b-cloud
               # multi-model panel, parallel critiques on the same diff

--- a/specs/run/run.spec.md
+++ b/specs/run/run.spec.md
@@ -1,6 +1,6 @@
 ---
 module: run
-version: 4
+version: 5
 status: active
 files:
   - src/run.rs
@@ -31,7 +31,7 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 
 | Type | Description |
 |------|-------------|
-| `RunOptions` | Options: `task`, `init`, `list`, `lang`, `json` |
+| `RunOptions` | Options: `task`, `init`, `list`, `lang`, `json`, `args` |
 
 ### Functions
 
@@ -53,6 +53,9 @@ Task runner that reads task definitions from `fledge.toml` and executes them. Su
 6. When auto-detecting, the task list header indicates tasks are auto-detected and suggests creating `fledge.toml` to customize
 7. `--json` outputs structured JSON for both task listing and task execution
 8. `--lang` overrides auto-detected project type (e.g. `rust`, `node`, `go`, `python`, `swift`, `ruby`, `java-gradle`, `java-maven`)
+9. Arguments after a `--` separator are passed through to the target task's command. They apply to the named task only — dependencies always run without them
+10. Pass-through is safe by construction: on POSIX the args become real shell positional parameters (`sh -c '<cmd> "$@"' fledge <args…>`), never interpolated into the command string. `"$@"` is auto-appended unless the command already references a positional (`$1`..`$9`, `$@`, `$*`, or their `${…}` forms), in which case the args fill those positionals without being doubled. With no pass-through args the invocation is identical to before the feature. On Windows (`cmd /C`) there is no `$@`; args are appended as argv (best-effort)
+11. `run <task> --json` includes an `args` array in the envelope only when pass-through args were supplied; arg-less runs keep their prior envelope shape
 
 ## Behavioral Examples
 
@@ -88,6 +91,19 @@ $ fledge run --init --json
 $ fledge run test --json
 {"schema_version": 1, "action": "run_task", "task": "test", "command": "cargo test", "exit_code": 0, "success": true, "stdout": "...", "stderr": "..."}
 
+# Pass arguments through to the task command (after `--`)
+$ fledge run test -- --nocapture --test-threads=1
+▶️ Running task: test
+# → runs: cargo test --nocapture --test-threads=1
+
+# Pass a value through (e.g. a version)
+$ fledge run set-version -- 1.2.3
+# → runs: ./set-version.sh 1.2.3
+
+# Pass-through with JSON adds an `args` array to the envelope
+$ fledge run test --json -- --nocapture
+{"schema_version": 1, "action": "run_task", "task": "test", "command": "cargo test", "exit_code": 0, "success": true, "stdout": "...", "stderr": "...", "args": ["--nocapture"]}
+
 # Override project type
 $ fledge run --lang node
 Available tasks:
@@ -114,6 +130,7 @@ Available tasks:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-06-07 | Add task argument pass-through: `fledge run <task> -- <args…>` forwards args to the target task's command (named task only, not deps). POSIX uses real positional params (`"$@"`, auto-appended unless the command references `$1`/`$@`/…), so values are never interpolated into the command string — no injection surface. `--json` gains an `args` array when args are supplied. Additive and backward-compatible: arg-less runs are byte-identical to before. New `references_positional`/`build_task_command` helpers with unit + injection-safety tests |
 | 4 | 2026-04-26 | Doc sync, behavioral examples updated to show the post-tier-D envelope shapes for `run --json`, `run <task> --json`, and `run --init --json`. No code change |
 | 3 | 2026-04-26 | Tier-D 1.0 envelope: all three `--json` paths now emit `{schema_version: 1, action, ...}`. `run --init --json` previously emitted prose ("✅ Created fledge.toml"), now `{action: "run_init", file, project_type, files_created}`, a real fix not just a wrapping. `run --list --json` adds `action: "run_list"` (was bare `{auto_detected, tasks}`). `run <task> --json` adds `action: "run_task"` (was bare `{task, command, ...}`). Three new integration tests guard each shape |
 | 2 | 2026-04-23 | Add `--json` flag (list + execute), `--lang` override, `detect_node_runner` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,13 @@ pub enum Commands {
         /// Output results as JSON
         #[arg(long)]
         json: bool,
+        /// Arguments passed through to the task's command, after a `--`
+        /// separator. Example: `fledge run test -- --nocapture` or
+        /// `fledge run set-version -- 1.2.3`. They are appended to the
+        /// command (or fill `$1`, `$@` if it references them) and never
+        /// spliced into the command string.
+        #[arg(last = true, value_name = "ARGS")]
+        args: Vec<String>,
     },
     /// Manage specs (check, init, new)
     Spec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn run() -> Result<()> {
             list,
             lang,
             json,
+            args,
         } => {
             run::run(run::RunOptions {
                 task,
@@ -129,6 +130,7 @@ fn run() -> Result<()> {
                 list,
                 lang,
                 json,
+                args,
             })?;
         }
         Commands::Watch {

--- a/src/run.rs
+++ b/src/run.rs
@@ -82,6 +82,9 @@ pub struct RunOptions {
     pub list: bool,
     pub lang: Option<String>,
     pub json: bool,
+    /// Pass-through arguments for the target task's command (everything after
+    /// `--` on the CLI). Applied to the named task only, never its deps.
+    pub args: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -159,7 +162,82 @@ pub fn run(opts: RunOptions) -> Result<()> {
     }
 
     let mut visited = HashSet::new();
-    execute_task(task_name, &tasks, &project_dir, &mut visited, opts.json)
+    execute_task(
+        task_name,
+        &tasks,
+        &project_dir,
+        &mut visited,
+        opts.json,
+        &opts.args,
+    )
+}
+
+/// Does a shell command reference a positional parameter (`$1`..`$9`, `$@`,
+/// `$*`, or their `${...}` braced forms)? When it does, the task author is
+/// explicitly placing the pass-through args, so we must NOT also auto-append
+/// `"$@"` (which would duplicate them). POSIX-only concept; Windows always
+/// appends.
+fn references_positional(cmd: &str) -> bool {
+    let bytes = cmd.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() {
+            // Skip an optional `{` for the `${1}` / `${@}` form.
+            let j = if bytes[i + 1] == b'{' { i + 2 } else { i + 1 };
+            if let Some(&c) = bytes.get(j) {
+                if c.is_ascii_digit() || c == b'@' || c == b'*' {
+                    return true;
+                }
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Build the `Command` that runs a task's `cmd` string in a shell, wiring in
+/// any pass-through `args` safely.
+///
+/// On POSIX the args are passed as real positional parameters
+/// (`sh -c '<cmd> "$@"' fledge <args...>`) so the shell quotes them — they are
+/// never interpolated into the command string, so there is no injection
+/// surface. `"$@"` is auto-appended unless the command already references a
+/// positional. With no args, the invocation is byte-identical to before this
+/// feature existed.
+///
+/// On Windows (`cmd /C`) there is no `$@`; args are appended as separate argv
+/// entries (best-effort — complex quoting is less robust than the POSIX path).
+fn build_task_command(
+    cmd_str: &str,
+    work_dir: &Path,
+    env: &BTreeMap<String, String>,
+    args: &[String],
+) -> Command {
+    let shell = if cfg!(windows) { "cmd" } else { "sh" };
+    let flag = if cfg!(windows) { "/C" } else { "-c" };
+
+    let mut command = Command::new(shell);
+    command.arg(flag);
+
+    if cfg!(windows) {
+        command.arg(cmd_str);
+        command.args(args);
+    } else if args.is_empty() {
+        command.arg(cmd_str);
+    } else if references_positional(cmd_str) {
+        // Author placed the args themselves via $1/$@; don't double-append.
+        command.arg(cmd_str).arg("fledge").args(args);
+    } else {
+        // `$0` is set to "fledge" purely so $1.. line up with the user args.
+        command
+            .arg(format!("{cmd_str} \"$@\""))
+            .arg("fledge")
+            .args(args);
+    }
+
+    command.current_dir(work_dir);
+    command.envs(env);
+    command
 }
 
 fn list_tasks(tasks: &BTreeMap<String, TaskDef>) -> Result<()> {
@@ -205,6 +283,7 @@ fn execute_task(
     project_dir: &Path,
     visited: &mut HashSet<String>,
     json: bool,
+    args: &[String],
 ) -> Result<()> {
     if visited.contains(name) {
         bail!(
@@ -218,8 +297,9 @@ fn execute_task(
         .get(name)
         .ok_or_else(|| anyhow::anyhow!("Task '{}' not found (referenced as dependency)", name))?;
 
+    // Pass-through args apply to the named task only — dependencies run clean.
     for dep in task.deps() {
-        execute_task(dep, tasks, project_dir, visited, json)?;
+        execute_task(dep, tasks, project_dir, visited, json, &[])?;
     }
 
     let cmd_str = task.cmd();
@@ -228,19 +308,14 @@ fn execute_task(
         None => project_dir.to_path_buf(),
     };
 
-    let shell = if cfg!(windows) { "cmd" } else { "sh" };
-    let flag = if cfg!(windows) { "/C" } else { "-c" };
+    let mut command = build_task_command(cmd_str, &work_dir, task.env(), args);
 
     if json {
-        let output = Command::new(shell)
-            .arg(flag)
-            .arg(cmd_str)
-            .current_dir(&work_dir)
-            .envs(task.env())
+        let output = command
             .output()
             .with_context(|| format!("running task '{name}'"))?;
 
-        let result = serde_json::json!({
+        let mut result = serde_json::json!({
             "schema_version": RUN_TASK_SCHEMA,
             "action": "run_task",
             "task": name,
@@ -250,6 +325,11 @@ fn execute_task(
             "stdout": String::from_utf8_lossy(&output.stdout),
             "stderr": String::from_utf8_lossy(&output.stderr),
         });
+        // Only surface `args` when present, so arg-less runs keep their exact
+        // existing envelope shape.
+        if !args.is_empty() {
+            result["args"] = serde_json::json!(args);
+        }
         println!("{}", serde_json::to_string_pretty(&result)?);
 
         if !output.status.success() {
@@ -262,13 +342,6 @@ fn execute_task(
             style("▶️").cyan().bold(),
             style(format!("Running task: {name}")).bold()
         );
-
-        let mut command = Command::new(shell);
-        command.arg(flag).arg(cmd_str).current_dir(&work_dir);
-
-        for (key, value) in task.env() {
-            command.env(key, value);
-        }
 
         let status = command
             .status()
@@ -521,6 +594,104 @@ mod tests {
     use super::*;
 
     #[test]
+    fn references_positional_detects_shell_positionals() {
+        for cmd in [
+            "echo $1",
+            "deploy $@",
+            "spread $*",
+            "braced ${1}",
+            "braced ${@}",
+            "later $9 args",
+            "mid $2 of cmd",
+        ] {
+            assert!(references_positional(cmd), "expected positional in: {cmd}");
+        }
+    }
+
+    #[test]
+    fn references_positional_ignores_non_positionals() {
+        for cmd in [
+            "cargo test",
+            "echo hi",
+            "npm run build",
+            "echo $HOME",
+            "echo $FOO_BAR",
+            "make $$", // PID, not a positional
+            "trailing dollar $",
+        ] {
+            assert!(
+                !references_positional(cmd),
+                "did not expect positional in: {cmd}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn run_cmd(cmd: &str, args: &[&str]) -> String {
+        let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        let env = BTreeMap::new();
+        let out = build_task_command(cmd, &std::env::temp_dir(), &env, &owned)
+            .output()
+            .expect("spawn task command");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passthrough_appends_args_when_no_positional() {
+        // `echo` has no positional ref → fledge appends `"$@"`.
+        assert_eq!(
+            run_cmd("echo", &["hello", "world"]).trim_end(),
+            "hello world"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passthrough_forwards_a_value() {
+        // The "version bump" use case: `fledge run set-version -- 1.2.3`.
+        assert_eq!(run_cmd("echo", &["1.2.3"]).trim_end(), "1.2.3");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passthrough_no_args_is_unchanged() {
+        // Backward-compat: with no pass-through args the command runs verbatim.
+        assert_eq!(run_cmd("echo hi", &[]).trim_end(), "hi");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passthrough_respects_explicit_positional_without_doubling() {
+        // Command references $1 itself → args fill positionals, no auto-append,
+        // so the second arg is NOT echoed a second time.
+        let out = run_cmd("printf 'first=%s\\n' \"$1\"", &["A", "B"]);
+        assert_eq!(out, "first=A\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passthrough_does_not_allow_command_injection() {
+        // A value that would be catastrophic if spliced into the shell string.
+        // It must be passed as one inert literal argument instead.
+        let tmp = tempfile::tempdir().unwrap();
+        let env = BTreeMap::new();
+        let payload = "; touch PWNED".to_string();
+        let out = build_task_command("echo", tmp.path(), &env, std::slice::from_ref(&payload))
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("; touch PWNED"),
+            "literal not echoed: {stdout}"
+        );
+        assert!(
+            !tmp.path().join("PWNED").exists(),
+            "injection executed — PWNED file was created"
+        );
+    }
+
+    #[test]
     fn parse_short_tasks() {
         let toml_str = r#"
 [tasks]
@@ -587,7 +758,7 @@ deps = ["a"]
         let config: FledgeFile = toml::from_str(toml_str).unwrap();
         let project_dir = std::env::temp_dir();
         let mut visited = HashSet::new();
-        let result = execute_task("a", &config.tasks, &project_dir, &mut visited, false);
+        let result = execute_task("a", &config.tasks, &project_dir, &mut visited, false, &[]);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/snapshots/fledge__introspect__tests__introspect_schema.snap
+++ b/src/snapshots/fledge__introspect__tests__introspect_schema.snap
@@ -1,6 +1,5 @@
 ---
 source: src/introspect.rs
-assertion_line: 388
 expression: output
 ---
 {
@@ -1841,6 +1840,14 @@ expression: output
           "help": "Output results as JSON",
           "required": false,
           "takes_value": false,
+          "global": false
+        },
+        {
+          "name": "args",
+          "help": "Arguments passed through to the task's command, after a `--` separator. Example: `fledge run test -- --nocapture` or `fledge run set-version -- 1.2.3`. They are appended to the command (or fill `$1`, `$@` if it references them) and never spliced into the command string",
+          "required": false,
+          "takes_value": true,
+          "value_name": "ARGS",
           "global": false
         },
         {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -159,6 +159,7 @@ fn run_target(opts: &WatchOptions) {
             list: false,
             lang: None,
             json: false,
+            args: Vec::new(),
         })
     };
 


### PR DESCRIPTION
## Summary

Adds **argument pass-through** for tasks — the simple, additive piece we scoped out. Everything after `--` is forwarded to the target task's command:

```bash
fledge run test -- --nocapture --test-threads=1   # → cargo test --nocapture --test-threads=1
fledge run set-version -- 1.2.3                    # → ./set-version.sh 1.2.3
```

## Design

**Injection-safe by construction.** We trust the task author's `cmd` string, but never the caller's arg *values*. On POSIX the args ride as real shell positional parameters — `sh -c '<cmd> "$@"' fledge <args…>` — so the shell quotes them and they are never spliced into the command string. A value like `; touch PWNED` is passed as one inert literal argument (covered by a dedicated test).

**Smart append.** `"$@"` is auto-appended unless the command already references a positional (`$1`..`$9`, `$@`, `$*`, or `${…}` forms), in which case the args fill those positionals without being doubled — so power users can place a value mid-command (e.g. `sed -i "s/X/$1/" file`).

**Strictly additive / backward-compatible:**
- Args apply to the **named task only** — dependencies always run clean.
- With no `--` args, the shell invocation is **byte-identical** to before this change. Every existing task is untouched.
- CLI uses clap `last = true`, so args are captured **only** after `--`; existing flags like `fledge run build --json` keep working (not swallowed as pass-through).
- `run <task> --json` gains an `args` array **only when** args are supplied, preserving the prior envelope shape for arg-less runs.

**Windows:** `cmd /C` has no `$@`; args are appended as argv (best-effort, documented as less robust than the POSIX path).

## Files
- `src/cli.rs` / `src/main.rs` — new `last = true` `args` field, threaded into `RunOptions`
- `src/run.rs` — `references_positional` + `build_task_command` helpers; `execute_task` takes args (deps get `&[]`); unified command builder
- `src/watch.rs` — pass empty args (watch re-runs have none)
- `specs/run/run.spec.md` — bumped to v5 (invariants, examples, changelog)
- introspect snapshot, `README.md`, `AGENTS.md` updated

## Test Plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (856 pass) — incl. positional-detection truth table, append/value/no-op end-to-end, no-double-append, and **command-injection safety**
- [x] `cargo run -- spec check` (0 errors, 0 warnings)
- [x] Manual e2e: flags vs pass-through, deps-run-clean, JSON `args` field, injection literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
