### PR TITLE
Update: docs site for 1.5.0 AI provider changes

### DIFF
--- a/site/src/content/docs/ai.md
+++ b/site/src/content/docs/ai.md
@@ -5,20 +5,22 @@ order: 4
 ---
 
 
-The AI pillar is the daily-driver path for asking questions about your code and reviewing diffs before they land. Provider-agnostic (Claude or any Ollama-speaking endpoint), spec-aware, and capable of running multiple models in parallel against the same diff.
+The AI pillar is the daily-driver path for asking questions about your code and reviewing diffs before they land. It talks to every provider over plain HTTP through the [`corvid-ai`](https://crates.io/crates/corvid-ai) crate — no CLI to install — is spec-aware, and can run multiple models in parallel against the same diff.
+
+Providers: `ollama` (local or cloud), `anthropic`, `openai`, and the OpenAI-compatible gateways `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`. `claude` is a deprecated alias of `anthropic` (removed in 2.0).
 
 ## Pick your provider and model
 
 ```bash
 fledge ai use                                  # interactive picker
 fledge ai use ollama llama3.2:latest           # scriptable
-fledge ai use claude sonnet
+fledge ai use anthropic claude-sonnet-4-6
 fledge ai status                               # shows provider, model, host, and where each value came from
 fledge ai models --provider ollama             # live list of installed/cloud models
-fledge ai models --provider ollama --search cloud
+fledge ai models --provider anthropic          # curated model ids
 ```
 
-Per-invocation overrides via `--provider` / `--model` flags work on every AI command and take precedence over config and env vars.
+When nothing is configured, fledge **auto-detects**: the first provider with an API key (`<PROVIDER>_API_KEY`, Ollama-via-key first), falling back to a keyless local Ollama (`http://localhost:11434`) — so it works out of the box with a local daemon and no key. A set API key beats an unkeyed local Ollama (no daemon probe). Per-invocation `--provider` / `--model` flags take precedence over config and env vars.
 
 ## AI Code Review
 
@@ -41,7 +43,7 @@ Pass `--with-model <provider[:model]>` to add another slot to the panel. All slo
 fledge review --with-model ollama
 
 # Comma-separated, exclude active config
-fledge review --no-active --with-model claude:sonnet,ollama:llama3.2:latest
+fledge review --no-active --with-model anthropic:claude-sonnet-4-6,ollama:llama3.2:latest
 
 # JSON output gains a reviews[] array; legacy fields preserved when panel size is 1
 fledge review --with-model ollama --json

--- a/site/src/content/docs/pillars.md
+++ b/site/src/content/docs/pillars.md
@@ -33,7 +33,7 @@ spec-sync. Every module declares a contract (`specs/<name>/<name>.spec.md` plus 
 
 ## AI
 
-Provider-agnostic AI in the daily-driver path. Switch between Claude CLI and any Ollama-speaking endpoint in one line. Ask questions about your codebase. Review your diff with one model or a panel of them in parallel.
+Provider-agnostic AI in the daily-driver path, all over plain HTTP (no CLI). Switch between Ollama, Anthropic, OpenAI, and any OpenAI-compatible gateway in one line. Ask questions about your codebase. Review your diff with one model or a panel of them in parallel.
 
 **Commands:** `ai` (`status`, `models`, `use`), `ask`, `review`
 

--- a/site/src/content/docs/reference/agents.md
+++ b/site/src/content/docs/reference/agents.md
@@ -45,7 +45,7 @@ Every `--json` output is `{schema_version: 1, ...}`. Two patterns coexist:
 | `fledge spec show <name> --json` | `{schema_version: 1, action: "spec_show", spec: {...}}` |
 | `fledge spec check --json` | `{schema_version: 1, action: "spec_check", specs, totals, strict}` |
 | `fledge ai status --json` | `{schema_version: 1, action: "ai_status", provider, model, host, *_source}`. What's active and the source of each value |
-| `fledge ai models --provider {claude,ollama} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}` |
+| `fledge ai models --provider {ollama,anthropic,openai,...} --json` | `{schema_version: 1, action: "ai_models", provider, models: [...]}` |
 | `fledge ask "..." --json` | `{schema_version: 1, action: "ask", question, answer, provider, model}` |
 | `fledge review --json` | `{schema_version: 1, action: "review", base, file, diff_stats, spec_context, reviews: [...], review?, provider?, model?}`. Top-level `review`/`provider`/`model` only when panel size is 1 |
 | `fledge doctor --json` | `{schema_version: 1, action: "doctor", sections: [...], passed, failed}`. Four sections (`fledge`, `Git`, `AI`, `Toolchains`). `Toolchains` is informational, missing tools render dimmed and aren't counted toward `failed` |
@@ -90,12 +90,14 @@ Commands covered: `fledge templates init`, `fledge templates create`, `fledge te
 
 ### AI-powered commands
 
-`fledge ai`, `fledge ask`, and `fledge review` route through a provider abstraction. Two providers ship in core:
+`fledge ai`, `fledge ask`, and `fledge review` route through a provider abstraction — all plain HTTP via the [`corvid-ai`](https://crates.io/crates/corvid-ai) crate, no CLI. The default is auto-detect: the first provider with a key (Ollama-via-key first), falling back to keyless local Ollama. Providers:
 
 | Provider | Transport | Auth | Use case |
 |----------|-----------|------|----------|
-| `claude` (default) | `claude` CLI shell-out | Whatever `claude` is already authenticated with | Best-in-class reasoning, paid |
-| `ollama` | HTTP to `<host>/api/generate` | Optional Bearer token | Local-only, offline, cloud alternatives, self-hosted |
+| `ollama` (default fallback) | HTTP to `<host>/api/generate` | Optional Bearer token | Local-only, offline, cloud, self-hosted |
+| `anthropic` | Anthropic Messages API | `ANTHROPIC_API_KEY` | Best-in-class reasoning, paid (`claude` is a deprecated alias) |
+| `openai` | OpenAI-compatible Chat Completions | `OPENAI_API_KEY` | OpenAI or any gateway via `base_url` |
+| `openrouter` / `gemini` / `deepseek` / `groq` / `mistral` / `xai` / `together` | OpenAI-compatible / Gemini | `<PROVIDER>_API_KEY` | Named gateways (endpoint + default model from the corvid-ai registry) |
 
 Select via `fledge ai use <provider> [model]` (writes to config), `FLEDGE_AI_PROVIDER=ollama`, or `--provider ollama` per invocation. `fledge ai status` reports the active triplet and the source of each value.
 
@@ -110,7 +112,7 @@ Pass `--with-model <provider[:model]>` (repeatable, comma-separated) to run mult
 ```bash
 fledge review --json
 fledge review --with-model ollama --json
-fledge review --no-active --with-model claude:sonnet,ollama --json
+fledge review --no-active --with-model anthropic:claude-sonnet-4-6,ollama --json
 ```
 
 ## Typical agent workflow

--- a/site/src/content/docs/reference/cli-reference.md
+++ b/site/src/content/docs/reference/cli-reference.md
@@ -335,7 +335,7 @@ fledge spec show plugin --json
 
 ### fledge ai `<action>`
 
-Manage AI provider and model selection, the daily-driver way to switch between Claude and any Ollama-speaking endpoint.
+Manage AI provider and model selection, the daily-driver way to switch between Ollama, Anthropic, OpenAI, and any OpenAI-compatible gateway (all over HTTP, no CLI).
 
 ```text
 fledge ai <status|models|use> [OPTIONS]
@@ -344,7 +344,7 @@ fledge ai <status|models|use> [OPTIONS]
 **Subcommands:**
 
 - `status [--json]`: Show active provider, model, and host with a `(from env / config / default)` source tag on each value
-- `models --provider {claude,ollama} [--search <q>] [--json]`: Live list of available models (Ollama hits `/api/tags`; Claude returns curated aliases)
+- `models --provider {ollama,anthropic,openai,...} [--search <q>] [--json]`: Model list (Ollama hits `/api/tags`; Anthropic returns curated ids; OpenAI-compatible gateways aren't enumerable)
 - `use [provider] [model]`: Interactive picker (live model list for Ollama) or fully scriptable via positional args. Writes to `~/.config/fledge/config.toml`
 
 ```bash
@@ -368,7 +368,7 @@ fledge review [OPTIONS]
 - `-b, --base <BRANCH>`: Base branch [default: auto-detect]
 - `-f, --file <FILE>`: Review a single file
 - `-m, --model <MODEL>`: Override the active provider's model
-- `--provider {claude,ollama}`: Override the active provider
+- `--provider {ollama,anthropic,openai,openrouter,gemini,deepseek,groq,mistral,xai,together}`: Override the active provider
 - `-p, --prompt <TEXT>`: Append a custom focus prompt
 - `--format {summary,checklist,inline}`: Output format [default: summary]
 - `--with-specs <NAMES>`: Force-include specs (comma-separated, repeatable)
@@ -382,7 +382,7 @@ fledge review [OPTIONS]
 ```bash
 fledge review                                                 # active model
 fledge review --with-model ollama                             # active + 1 more
-fledge review --no-active --with-model claude:sonnet,ollama   # exactly two models, no active
+fledge review --no-active --with-model anthropic:claude-sonnet-4-6,ollama   # exactly two models, no active
 fledge review --json | jq '.reviews[].provider'
 ```
 
@@ -398,7 +398,7 @@ fledge ask <question> [OPTIONS]
 
 **Options:**
 - `-m, --model <MODEL>`: Override active model
-- `--provider {claude,ollama}`: Override active provider
+- `--provider {ollama,anthropic,openai,openrouter,gemini,deepseek,groq,mistral,xai,together}`: Override active provider
 - `--with-specs <NAMES>`: Include full spec + companions for these modules (comma-separated; pass `all` for everything)
 - `--no-spec-index`: Skip the spec-index injection (for off-topic questions)
 - `--json`: JSON output
@@ -442,7 +442,7 @@ fledge work <start|commit|push|status> [OPTIONS]
 - `-s, --scope <SCOPE>`: Scope for conventional commit (e.g. `work`, `cli`)
 - `-a, --all`: Stage all changes (including untracked) before committing
 - `--ai`: Generate the commit message via the configured LLM from the staged diff
-- `--provider {claude,ollama}`: Override AI provider for `--ai`
+- `--provider {ollama,anthropic,openai,openrouter,gemini,deepseek,groq,mistral,xai,together}`: Override AI provider for `--ai`
 - `--model <MODEL>`: Override AI model for `--ai`
 - `--json`: Emit `{schema_version, action, hash, message, branch}`
 
@@ -699,7 +699,9 @@ fledge config <get|set|unset|add|remove|edit|list|path|init>
 - `defaults.author`, `defaults.github_org`, `defaults.license`
 - `github.token`
 - `templates.paths`, `templates.repos`
-- `ai.provider`, `ai.claude.model`
+- `ai.provider`
+- `ai.anthropic.model`, `ai.anthropic.api_key`, `ai.anthropic.base_url`
+- `ai.openai.model`, `ai.openai.api_key`, `ai.openai.base_url`
 - `ai.ollama.host`, `ai.ollama.api_key`, `ai.ollama.model`, `ai.ollama.timeout_seconds`
 
 ```bash
@@ -717,7 +719,7 @@ Diagnose fledge's environment health. Reports four sections:
 
 - **`fledge`**: config loads cleanly
 - **`Git`**: git installed; repo initialized; remote configured; working tree clean
-- **`AI`**: Claude CLI present, Ollama reachable, the active provider's status
+- **`AI`**: active provider's readiness (API key present for `anthropic`/`openai`/gateways, or Ollama reachable)
 - **`Toolchains`** *(informational)*: probes 16 toolchains across rust (`rustc`, `cargo`), node (`node`, `npm`, `pnpm`, `bun`, `yarn`), python (`python3`, `uv`, `poetry`), `go`, `ruby`, `swift`, JVM (`java`, `gradle`, `mvn`). Missing entries render dimmed (`· tool (not installed)`) and don't pollute the pass/fail totals. A Python project shouldn't fail because Swift is absent.
 
 ```text

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -65,12 +65,21 @@ repos = ["CorvidLabs/fledge-templates", "myorg/templates"]
 
 AI provider and model settings. Written by `fledge ai use` or `fledge config set`/`edit`:
 
+All providers are reached over plain HTTP (no CLI). `provider` is one of `ollama`, `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together` (`claude` is a deprecated alias of `anthropic`). When unset, fledge auto-detects the first provider with a key, falling back to keyless local Ollama.
+
 ```toml
 [ai]
-provider = "ollama"             # "claude" or "ollama"
+provider = "anthropic"          # ollama | anthropic | openai | openrouter | gemini | deepseek | groq | mistral | xai | together
 
-[ai.claude]
-model = "sonnet"               # model name passed to claude CLI
+[ai.anthropic]
+model = "claude-sonnet-4-6"     # default if unset
+api_key = "sk-ant-..."          # or export ANTHROPIC_API_KEY
+# base_url = "..."              # optional override
+
+[ai.openai]                     # any OpenAI-compatible gateway
+base_url = "https://openrouter.ai/api/v1"
+api_key = "sk-..."              # or export OPENAI_API_KEY
+model = "anthropic/claude-sonnet-4-6"  # required (no default)
 
 [ai.ollama]
 host = "http://localhost:11434" # Ollama API endpoint (always normalized to include scheme)
@@ -79,14 +88,21 @@ api_key = "sk-..."             # for Ollama Cloud / authenticated endpoints
 timeout_seconds = 600          # request timeout (default: 600)
 ```
 
-> **Tip:** Run `fledge ai models --provider ollama` or `fledge ai models --provider claude` to see available models. Use `fledge ai use` for an interactive picker.
+> The OpenAI-compatible gateways (`openrouter`, `groq`, `deepseek`, `mistral`, `xai`, `together`, `gemini`) are key-driven: set `<PROVIDER>_API_KEY` (e.g. `GROQ_API_KEY`); their endpoint and default model come from the corvid-ai registry.
+
+> **Tip:** Run `fledge ai models --provider ollama` (live) or `--provider anthropic` (curated) to see models. Use `fledge ai use` for an interactive picker.
 
 | Key | What it does | Default |
 |-----|-------------|---------|
-| `ai.provider` | Active LLM backend | `claude` |
-| `ai.claude.model` | Model name for Claude CLI | Claude CLI default |
+| `ai.provider` | Active LLM backend | auto-detect → keyless local Ollama |
+| `ai.anthropic.model` | Anthropic model id | `claude-sonnet-4-6` |
+| `ai.anthropic.api_key` | Anthropic key (or `ANTHROPIC_API_KEY`) | (none) |
+| `ai.anthropic.base_url` | Anthropic endpoint override | `https://api.anthropic.com` |
+| `ai.openai.base_url` | OpenAI-compatible gateway URL | OpenAI |
+| `ai.openai.api_key` | OpenAI-compatible key (or `OPENAI_API_KEY`) | (none) |
+| `ai.openai.model` | Model id (required — no default) | (none) |
 | `ai.ollama.host` | Ollama API endpoint URL | `http://localhost:11434` |
-| `ai.ollama.model` | Ollama model name | first available |
+| `ai.ollama.model` | Ollama model name | `llama3.3` |
 | `ai.ollama.api_key` | Bearer token for authenticated endpoints | (none) |
 | `ai.ollama.timeout_seconds` | Request timeout in seconds | `600` |
 
@@ -159,10 +175,10 @@ users = ["corvid-agent"]
 token = "ghp_..."
 
 [ai]
-provider = "claude"
+provider = "anthropic"
 
-[ai.claude]
-model = "sonnet"
+[ai.anthropic]
+model = "claude-sonnet-4-6"
 
 [ai.ollama]
 host = "http://localhost:11434"
@@ -178,9 +194,12 @@ timeout_seconds = 600
 | `FLEDGE_TRUST_HOOKS` | Truthy authorizes `post_create` hook execution for **ad-hoc remote** templates passed to `fledge templates init`. Same as passing `--trust-hooks`. Has no effect on templates reached through `templates.paths` or `templates.repos` (those already follow the `--yes` consent path). Hooks run arbitrary shell commands; only set this for sources you trust. |
 | `FLEDGE_GITHUB_TOKEN` | GitHub token (highest priority) |
 | `GITHUB_TOKEN` | GitHub token (fallback after FLEDGE_GITHUB_TOKEN) |
-| `FLEDGE_AI_PROVIDER` | AI provider override (`claude` or `ollama`) |
+| `FLEDGE_AI_PROVIDER` | AI provider override (`ollama`, `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`) |
 | `FLEDGE_AI_MODEL` | AI model override |
-| `FLEDGE_AI_TIMEOUT` | Ollama request timeout in seconds |
+| `FLEDGE_AI_TIMEOUT` | Request timeout in seconds |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENAI_API_KEY` | OpenAI-compatible API key |
+| `<PROVIDER>_API_KEY` | Gateway key, e.g. `GROQ_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY` |
 | `OLLAMA_HOST` | Ollama API endpoint URL |
 | `OLLAMA_API_KEY` | Ollama Bearer token |
 

--- a/site/src/content/docs/reference/doctor.md
+++ b/site/src/content/docs/reference/doctor.md
@@ -31,9 +31,8 @@ Doctor reports four sections:
 
 ### `AI`
 
-- `claude` CLI is installed (powers `fledge review` and `fledge ask` when the active provider is `claude`)
 - `ollama` binary is installed (powers the `ollama` provider)
-- The active provider's reachability. When Ollama is active, doctor probes `<host>/api/tags` with a 3-second timeout to distinguish "daemon down" from "not installed"
+- The active provider's readiness. For an API provider (`anthropic` / `openai` / a gateway) doctor checks that a key is set (`<PROVIDER>_API_KEY` or config). When Ollama is active, doctor probes `<host>/api/tags` with a 3-second timeout to distinguish "daemon down" from "not installed". AI is plain HTTP — no `claude` CLI involved.
 
 ### `Toolchains` *(informational)*
 
@@ -66,7 +65,6 @@ $ fledge doctor
     ✅ working tree, clean
 
   AI
-    ✅ claude 2.1.119
     ✅ ollama 0.21.2
     ✅ Active provider: ollama (model: llama3.2:latest, host: http://localhost:11434)
 
@@ -91,7 +89,7 @@ Pass/fail totals only count the non-informational sections.
 
 - Before your first `fledge templates init`, to make sure your environment is ready
 - When `fledge run` can't find the right command for your project type. The `Toolchains` section will tell you what's missing
-- When AI commands fail. The `AI` section distinguishes "Claude not installed" from "Ollama daemon down" from "wrong provider configured"
+- When AI commands fail. The `AI` section distinguishes "API key missing" from "Ollama daemon down" from "wrong provider configured"
 - After upgrading your toolchain or switching machines
 
 If doctor finds an issue, see [Troubleshooting](./troubleshooting.md) for detailed fixes.

--- a/site/src/content/docs/resources/troubleshooting.md
+++ b/site/src/content/docs/resources/troubleshooting.md
@@ -103,13 +103,14 @@ fledge ai status
 fledge doctor        # the AI section will diagnose the issue
 ```
 
-**If using Claude (default):** Make sure the `claude` CLI is installed and authenticated:
+**If using an API provider (`anthropic` / `openai` / a gateway):** Make sure a key is set. AI is plain HTTP — there's no CLI to install.
 
 ```bash
-claude --version
+export ANTHROPIC_API_KEY=sk-ant-...        # or OPENAI_API_KEY, GROQ_API_KEY, etc.
+# or: fledge config set ai.anthropic.api_key <key>
 ```
 
-If Claude isn't installed, see [Claude CLI docs](https://docs.anthropic.com/en/docs/claude-code/overview) for setup instructions.
+A 401 from the provider means the key is wrong or missing. If no provider is configured at all, fledge falls back to a keyless local Ollama.
 
 **If using Ollama:** Make sure the Ollama daemon is running and the host is correct:
 


### PR DESCRIPTION
## Summary
- Refreshes the GitHub Pages docs site (`site/src/content/docs/`) to match the 1.5.0 AI layer, which is now plain HTTP via [`corvid-ai`](https://crates.io/crates/corvid-ai) with **no `claude` CLI**.
- Replaces all claude-CLI references across 7 doc pages with the full HTTP provider set: `ollama`, `anthropic`, `openai`, and the OpenAI-compatible gateways `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`.
- Documents the **auto-detect ladder** (first provider with a key, Ollama-via-key first, falling back to keyless local Ollama) and `flag > env > config` precedence.
- Notes the `claude` → `anthropic` deprecated alias (removed in 2.0).
- Config keys `ai.anthropic.*` / `ai.openai.*`; `<PROVIDER>_API_KEY` env vars.
- Doctor `AI` section now checks for an API key / Ollama reachability instead of a `claude` binary; troubleshooting guides API-key setup.

## Files
- `ai.md`, `pillars.md`
- `reference/{agents,cli-reference,configuration,doctor}.md`
- `resources/troubleshooting.md`

## Test Plan
- [x] Grep sweep across `site/` confirms no stale claude-CLI references remain (only legitimate model ids, the deprecated-alias notes, and "Claude Code" as an agent tool)
- [ ] Redeploys to corvidlabs.github.io/fledge/docs via `pages.yml` on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)