### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,31 @@ permissions:
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'templates/**'
+      - 'build.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'fledge.toml'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'templates/**'
+      - 'build.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'fledge.toml'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,19 +40,21 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --verbose
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -40,8 +64,9 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo generate-lockfile
       - uses: rustsec/audit-check@v2.0.0
@@ -51,13 +76,14 @@ jobs:
   integration:
     name: Integration (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: [test]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build fledge
@@ -89,10 +115,11 @@ jobs:
 
   spec-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       body: ${{ steps.specsync.outputs.body }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run spec-sync
         id: specsync
         uses: CorvidLabs/spec-sync@v4.3.2
@@ -104,10 +131,11 @@ jobs:
 
   corvid-pet:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request' && always()
     needs: [test, lint, audit, spec-check, integration]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine combined status
         id: status


### PR DESCRIPTION
Standardizes `.github/workflows/ci.yml` to match the CorvidLabs/merlin CI standard.

## Changes (ci.yml only)
- Add `paths:` filters to `push` and `pull_request` (single-crate Rust set): `src/**`, `tests/**`, `templates/**`, `build.rs`, `Cargo.toml`, `Cargo.lock`, `fledge.toml`, plus `.github/workflows/ci.yml`. Docs/LICENSE-only changes no longer trigger the full matrix.
- Add `concurrency:` group `ci-${{ github.ref }}` with `cancel-in-progress: true` to cancel superseded runs.
- Bump `actions/checkout@v4` -> `@v5` across all jobs.
- Add `timeout-minutes` to every job.

## Not changed (already compliant for a PUBLIC repo)
- Runners: all jobs already use GitHub-hosted runners (correct for PUBLIC; never self-hosted).
- `pages.yml`: already has a site-scoped `paths:` filter + `concurrency:`, `ubuntu-latest`.
- `release.yml` (tag-push) and `post-release-formula.yml` (workflow_run): not branch CI, so no `paths:` added; runners already correct.

Note: `Cargo.lock` is not currently committed; it is included in the path set as a harmless future-proofing entry (path filters match only if a file is present).

Mirrors the CorvidLabs/merlin CI standard.