### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.6.0] - 2026-06-23
+
+### Changes
+
+- standardize GitHub Actions (path filters, concurrency, runners) (#423) (1295857)
+
+### Features
+
+- delegate `fledge spec check` to the real specsync binary for CI parity (#424) (9d228be)
+
+### Fixes
+
+- atomic plugins.toml writes — registry race made plugin subcommands vanish (#419) (12547a3)
+- fold handwritten Unreleased fixes into the v1.5.1 changelog section (f260171)
+
+### Other
+
+- Update redirect URLs for marketing and docs (#422) (212c591)
+- Retire: redirect the standalone fledge site to the CorvidLabs hub (#421) (28956b1)
+
+### Refactoring
+
+- unify agent docs — merge CLAUDE.md into AGENTS.md, symlink the rest (#425) (14cec6e)
+
 ## [v1.5.1] - 2026-06-11
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.5.1";
+          version = "1.6.0";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Release v1.6.0

Bumps `1.5.1 → 1.6.0` (minor — ships a new feature). Generated with the current `fledge` binary so changelog categorization is correct.

### Highlights
- **Feature (#424)** — `fledge spec check` now delegates to the real `specsync` binary when installed, matching CI's export-coverage validation (local pass ⇒ CI pass); falls back to the structural check otherwise.
- **Fix (#419)** — atomic `plugins.toml` writes; fixes the registry race that made plugin subcommands intermittently vanish.

Also folded in: CI workflow standardization (#423), agent-docs unification (#425), site retirement/redirects (#421, #422).

### What this PR changes
- `Cargo.toml`, `Cargo.lock`, `flake.nix` → `1.6.0`
- `CHANGELOG.md` → new `[v1.6.0]` section

### Release process
This PR is the **version-bump + changelog** only — **no tag**. `main` enforces branch protection (`enforce_admins: true`), so the bump lands via this PR. After it's merged, the `v1.6.0` tag is pushed to `main` as a separate step, which triggers `release.yml` (build + publish) and `post-release-formula.yml` (Homebrew). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)