### PR TITLE
Add corvid-stack template: CorvidLabs trust toolchain setup (language-agnostic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ See the [WASM plugin guide](https://corvidlabs.github.io/fledge/docs/reference/w
 
 ## Built-in templates
 
-`rust-cli`, `ts-bun`, `python-cli`, `go-cli`, `ts-node`, `static-site`, `kotlin-kmp`, `kotlin-ktor-api`
+Language starters: `rust-cli`, `ts-bun`, `python-cli`, `go-cli`, `ts-node`, `static-site`, `kotlin-kmp`, `kotlin-ktor-api`
+
+Setup-only: `corvid-stack` (CorvidLabs trust toolchain — fledge + spec-sync + augur + attest, no language scaffolding), `fledge-plugin` (plugin scaffold)
 
 Browse community templates: `fledge templates search <keyword>`
 

--- a/specs/templates/context.md
+++ b/specs/templates/context.md
@@ -19,7 +19,7 @@ spec: templates.spec.md
 
 ## Current Status
 
-- 8 built-in starter templates embedded in the binary via `include_dir!`: `go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`. Additional community templates discoverable via `fledge templates search` (filters on the `fledge-template` GitHub topic).
+- 8 built-in language starter templates embedded in the binary via `include_dir!`: `go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`. Plus two setup-only (no language scaffolding) templates: `fledge-plugin` (plugin scaffold) and `corvid-stack` (CorvidLabs trust toolchain: fledge + spec-sync + augur + attest config). Additional community templates discoverable via `fledge templates search` (filters on the `fledge-template` GitHub topic).
 - Template discovery from built-in, local, and remote sources all working
 - Full rendering pipeline: glob matching, Tera rendering, .tera extension stripping, path variable rendering
 - Embedded template extraction with version-stamped caching

--- a/specs/templates/requirements.md
+++ b/specs/templates/requirements.md
@@ -13,7 +13,7 @@ spec: templates.spec.md
 
 ## Acceptance Criteria
 
-- `discover_templates()` finds all built-in templates (8 starters: `go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`)
+- `discover_templates()` finds all built-in templates (8 language starters: `go-cli`, `kotlin-kmp`, `kotlin-ktor-api`, `python-cli`, `rust-cli`, `static-site`, `ts-bun`, `ts-node`; plus setup-only `fledge-plugin` and `corvid-stack`)
 - Extra paths from config are searched for template directories
 - Remote repos from config are fetched and searched for templates
 - Templates are returned sorted alphabetically by name

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1009,7 +1009,8 @@ ignore = ["template.toml"]
             "missing kotlin-ktor-api"
         );
         assert!(names.contains(&"fledge-plugin"), "missing fledge-plugin");
-        assert_eq!(names.len(), 9, "expected exactly 9 built-in templates");
+        assert!(names.contains(&"corvid-stack"), "missing corvid-stack");
+        assert_eq!(names.len(), 10, "expected exactly 10 built-in templates");
     }
 
     #[test]

--- a/templates/corvid-stack/.attest.json
+++ b/templates/corvid-stack/.attest.json
@@ -1,0 +1,6 @@
+{
+  "requireAttestation": false,
+  "requireTestsPassed": false,
+  "requireSignature": false,
+  "requireHumanApprovalWhenVerdictAtLeast": "block"
+}

--- a/templates/corvid-stack/.github/workflows/trust.yml
+++ b/templates/corvid-stack/.github/workflows/trust.yml
@@ -1,8 +1,14 @@
 name: Trust
 
-# The single CorvidLabs trust gate: fledge (quality) → spec-sync (contract) →
-# augur (risk) → attest (provenance), plus a check that the managed AGENTS.md
-# rules block is present. Tools: https://corvidlabs.xyz/integrate/
+# The CorvidLabs trust gate as parallel checks: fledge (quality), spec-sync
+# (contract), augur (risk), attest (provenance), and the AGENTS.md rules marker.
+# Each job is an independent PR check, so a failure points straight at the tool.
+# Tools: https://corvidlabs.xyz/integrate/
+#
+# These run in parallel because, in verify form, they are independent. If you
+# later switch attest to `sign --from-augur augur.json --tests-passed`, attest
+# depends on augur + tests — add `needs: [augur, fledge]` and pass augur.json
+# between the jobs with upload-artifact / download-artifact.
 on:
   push:
     branches: [main]
@@ -12,48 +18,65 @@ permissions:
   contents: read
 
 jobs:
-  trust:
+  # 1) fledge — the quality gate (the `verify` lane: fmt + lint + test + build).
+  fledge:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # augur/attest ranges need full git history
-
-      # 1) fledge — the single quality gate (the `verify` lane: fmt+lint+test+build).
-      #    Swap brew for `cargo install fledge --locked` if you prefer.
+          fetch-depth: 0
+      # fledge has no setup action; install the CLI. Swap brew for
+      # `cargo install fledge --locked` if you prefer.
       - name: Install fledge
         run: brew install corvidlabs/tap/fledge
       - name: Verify (fledge lane)
         run: fledge lanes run verify
 
-      # 2) spec-sync — spec-as-contract validation.
-      #    Soft until specs land; drop continue-on-error once you have specs.
-      - name: Spec-sync
-        uses: CorvidLabs/spec-sync@v4
+  # 2) spec-sync — spec-as-contract validation.
+  #    Soft until specs land; drop continue-on-error once you have specs.
+  spec-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v4
         continue-on-error: true
         with:
           strict: true
           comment: false
 
-      # 3) augur — deterministic diff-risk gate. Fails at/above `threshold`.
-      - name: Augur risk gate
-        uses: CorvidLabs/augur@v0
+  # 3) augur — deterministic diff-risk gate. Fails at/above `threshold`.
+  augur:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # range needs full git history
+      - uses: CorvidLabs/augur@v0
         with:
           range: origin/main..HEAD
           threshold: block
 
-      # 4) attest — signed provenance verification against .attest.json.
-      #    The shipped policy is permissive; soft until you tighten it.
+  # 4) attest — signed provenance verification against .attest.json.
+  #    The shipped policy is permissive; soft until you tighten it.
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Fetch provenance notes
         run: git fetch origin "+refs/notes/*:refs/notes/*" 2>/dev/null || true
-      - name: Attest verify
-        uses: CorvidLabs/attest@v0
+      - uses: CorvidLabs/attest@v0
         continue-on-error: true
         with:
           range: origin/main..HEAD
           policy: .attest.json
 
-      # 5) The managed agent-rules block must be present and intact.
+  # 5) The managed agent-rules block must be present and intact.
+  rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Check AGENTS.md trust marker
         run: |
           grep -q "CorvidLabs trust toolchain: BEGIN" AGENTS.md \

--- a/templates/corvid-stack/.github/workflows/trust.yml
+++ b/templates/corvid-stack/.github/workflows/trust.yml
@@ -1,0 +1,60 @@
+name: Trust
+
+# The single CorvidLabs trust gate: fledge (quality) → spec-sync (contract) →
+# augur (risk) → attest (provenance), plus a check that the managed AGENTS.md
+# rules block is present. Tools: https://corvidlabs.xyz/integrate/
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  trust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # augur/attest ranges need full git history
+
+      # 1) fledge — the single quality gate (the `verify` lane: fmt+lint+test+build).
+      #    Swap brew for `cargo install fledge --locked` if you prefer.
+      - name: Install fledge
+        run: brew install corvidlabs/tap/fledge
+      - name: Verify (fledge lane)
+        run: fledge lanes run verify
+
+      # 2) spec-sync — spec-as-contract validation.
+      #    Soft until specs land; drop continue-on-error once you have specs.
+      - name: Spec-sync
+        uses: CorvidLabs/spec-sync@v4
+        continue-on-error: true
+        with:
+          strict: true
+          comment: false
+
+      # 3) augur — deterministic diff-risk gate. Fails at/above `threshold`.
+      - name: Augur risk gate
+        uses: CorvidLabs/augur@v0
+        with:
+          range: origin/main..HEAD
+          threshold: block
+
+      # 4) attest — signed provenance verification against .attest.json.
+      #    The shipped policy is permissive; soft until you tighten it.
+      - name: Fetch provenance notes
+        run: git fetch origin "+refs/notes/*:refs/notes/*" 2>/dev/null || true
+      - name: Attest verify
+        uses: CorvidLabs/attest@v0
+        continue-on-error: true
+        with:
+          range: origin/main..HEAD
+          policy: .attest.json
+
+      # 5) The managed agent-rules block must be present and intact.
+      - name: Check AGENTS.md trust marker
+        run: |
+          grep -q "CorvidLabs trust toolchain: BEGIN" AGENTS.md \
+            || { echo "::error::AGENTS.md is missing the managed CorvidLabs trust toolchain block"; exit 1; }

--- a/templates/corvid-stack/.github/workflows/trust.yml
+++ b/templates/corvid-stack/.github/workflows/trust.yml
@@ -7,7 +7,7 @@ name: Trust
 #
 # These run in parallel because, in verify form, they are independent. If you
 # later switch attest to `sign --from-augur augur.json --tests-passed`, attest
-# depends on augur + tests — add `needs: [augur, fledge]` and pass augur.json
+# depends on augur + tests: add `needs: [augur, fledge]` and pass augur.json
 # between the jobs with upload-artifact / download-artifact.
 on:
   push:
@@ -18,21 +18,22 @@ permissions:
   contents: read
 
 jobs:
-  # 1) fledge — the quality gate (the `verify` lane: fmt + lint + test + build).
+  # 1) fledge: the quality gate (the `verify` lane: fmt + lint + test + build).
   fledge:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # fledge has no setup action; install the CLI. Swap brew for
-      # `cargo install fledge --locked` if you prefer.
+      # fledge has no setup action; install the prebuilt binary (fast). Swap for
+      # `cargo install fledge --locked` or `brew install corvidlabs/tap/fledge`
+      # if you prefer.
       - name: Install fledge
-        run: brew install corvidlabs/tap/fledge
+        run: curl -fsSL https://raw.githubusercontent.com/CorvidLabs/fledge/main/install.sh | sh
       - name: Verify (fledge lane)
         run: fledge lanes run verify
 
-  # 2) spec-sync — spec-as-contract validation.
+  # 2) spec-sync: spec-as-contract validation.
   #    Soft until specs land; drop continue-on-error once you have specs.
   spec-sync:
     runs-on: ubuntu-latest
@@ -44,7 +45,7 @@ jobs:
           strict: true
           comment: false
 
-  # 3) augur — deterministic diff-risk gate. Fails at/above `threshold`.
+  # 3) augur: deterministic diff-risk gate. Fails at/above `threshold`.
   augur:
     runs-on: ubuntu-latest
     steps:
@@ -53,10 +54,12 @@ jobs:
           fetch-depth: 0          # range needs full git history
       - uses: CorvidLabs/augur@v0
         with:
-          range: origin/main..HEAD
+          # PR: base..head. Push: the single pushed commit. Avoids the empty
+          # range that a hardcoded origin/main..HEAD gives on push to main.
+          range: ${{ github.event_name == 'pull_request' && format('origin/{0}..HEAD', github.base_ref) || format('{0}~1..{0}', github.sha) }}
           threshold: block
 
-  # 4) attest — signed provenance verification against .attest.json.
+  # 4) attest: signed provenance verification against .attest.json.
   #    The shipped policy is permissive; soft until you tighten it.
   attest:
     runs-on: ubuntu-latest
@@ -69,7 +72,7 @@ jobs:
       - uses: CorvidLabs/attest@v0
         continue-on-error: true
         with:
-          range: origin/main..HEAD
+          range: ${{ github.event_name == 'pull_request' && format('origin/{0}..HEAD', github.base_ref) || format('{0}~1..{0}', github.sha) }}
           policy: .attest.json
 
   # 5) The managed agent-rules block must be present and intact.

--- a/templates/corvid-stack/.gitignore
+++ b/templates/corvid-stack/.gitignore
@@ -1,0 +1,6 @@
+# CorvidLabs trust toolchain
+augur.json          # per-run augur artifact — never commit
+
+# OS / editor noise
+.DS_Store
+*.swp

--- a/templates/corvid-stack/.gitignore
+++ b/templates/corvid-stack/.gitignore
@@ -1,5 +1,5 @@
 # CorvidLabs trust toolchain
-augur.json          # per-run augur artifact — never commit
+augur.json          # per-run augur artifact: never commit
 
 # OS / editor noise
 .DS_Store

--- a/templates/corvid-stack/.specsync/.gitignore
+++ b/templates/corvid-stack/.specsync/.gitignore
@@ -1,0 +1,3 @@
+backup-3x/
+config.local.toml
+hashes.json

--- a/templates/corvid-stack/.specsync/config.toml
+++ b/templates/corvid-stack/.specsync/config.toml
@@ -1,6 +1,8 @@
 # spec-sync v4 configuration
 # Docs: https://github.com/CorvidLabs/spec-sync
 specs_dir = "specs"
+# Set this to match your project's source layout, e.g. ["lib"], ["app"],
+# ["pkg"], or ["."] for a root-level layout.
 source_dirs = ["src"]
 exclude_dirs = []
 exclude_patterns = []

--- a/templates/corvid-stack/.specsync/config.toml
+++ b/templates/corvid-stack/.specsync/config.toml
@@ -1,0 +1,11 @@
+# spec-sync v4 configuration
+# Docs: https://github.com/CorvidLabs/spec-sync
+specs_dir = "specs"
+source_dirs = ["src"]
+exclude_dirs = []
+exclude_patterns = []
+required_sections = ["Purpose", "Public API", "Invariants", "Behavioral Examples", "Error Cases", "Dependencies", "Change Log"]
+enforcement = "strict"
+
+[lifecycle]
+track_history = false

--- a/templates/corvid-stack/.specsync/registry.toml.tera
+++ b/templates/corvid-stack/.specsync/registry.toml.tera
@@ -1,0 +1,6 @@
+[registry]
+name = "{{ project_name }}"
+
+[specs]
+# One entry per module spec, e.g.:
+#   auth = "specs/auth/auth.spec.md"

--- a/templates/corvid-stack/AGENTS.md.tera
+++ b/templates/corvid-stack/AGENTS.md.tera
@@ -1,0 +1,34 @@
+# {{ project_name }}
+
+{{ description }}
+
+This repository runs the **CorvidLabs trust toolchain**. Project-specific notes
+for humans and agents go above the managed block; the block below is owned by the
+toolchain — keep it intact.
+
+<!-- CorvidLabs trust toolchain: BEGIN (managed, do not edit inside) -->
+## CorvidLabs trust toolchain (standing rules)
+
+This repo is gated by four tools, run in order by `.github/workflows/trust.yml`:
+
+1. **fledge** — the single quality gate. `fledge lanes run verify` runs
+   fmt + lint + test + build. Prefer fledge wrappers over raw tools.
+2. **spec-sync** — specs are contracts. Each module API has a `*.spec.md`;
+   `specsync check` must pass. Skipping spec-sync for a repo needs an explicit
+   one-line reason.
+3. **augur** — deterministic diff-risk scoring. A **block** verdict halts the
+   merge. `augur.json` is a per-run artifact and is gitignored; never commit it.
+4. **attest** — signed provenance. CI records an attestation and verifies the
+   range against `.attest.json`. Provenance lives in `refs/notes/attest`.
+
+Standing rules for anyone (human or agent) changing this repo:
+
+- Run `fledge lanes run verify` before pushing; do not bypass the gate.
+- Keep specs in lockstep with code — update the `*.spec.md` in the same change.
+- A block verdict from augur means stop and escalate, not merge.
+- Do not commit `augur.json`.
+- Do not use em-dash characters in authored content.
+- Runner-specific rule files (`CLAUDE.md`, `.cursor/rules/*.mdc`,
+  `.github/copilot-instructions.md`) are one-line pointers to this file — do not
+  duplicate these rules into them.
+<!-- CorvidLabs trust toolchain: END -->

--- a/templates/corvid-stack/AGENTS.md.tera
+++ b/templates/corvid-stack/AGENTS.md.tera
@@ -4,31 +4,31 @@
 
 This repository runs the **CorvidLabs trust toolchain**. Project-specific notes
 for humans and agents go above the managed block; the block below is owned by the
-toolchain — keep it intact.
+toolchain, so keep it intact.
 
 <!-- CorvidLabs trust toolchain: BEGIN (managed, do not edit inside) -->
 ## CorvidLabs trust toolchain (standing rules)
 
-This repo is gated by four tools, run in order by `.github/workflows/trust.yml`:
+This repo is gated by four tools, run in parallel by `.github/workflows/trust.yml`:
 
-1. **fledge** — the single quality gate. `fledge lanes run verify` runs
+1. **fledge**: the quality gate. `fledge lanes run verify` runs
    fmt + lint + test + build. Prefer fledge wrappers over raw tools.
-2. **spec-sync** — specs are contracts. Each module API has a `*.spec.md`;
+2. **spec-sync**: specs are contracts. Each module API has a `*.spec.md`, and
    `specsync check` must pass. Skipping spec-sync for a repo needs an explicit
    one-line reason.
-3. **augur** — deterministic diff-risk scoring. A **block** verdict halts the
+3. **augur**: deterministic diff-risk scoring. A `block` verdict halts the
    merge. `augur.json` is a per-run artifact and is gitignored; never commit it.
-4. **attest** — signed provenance. CI records an attestation and verifies the
+4. **attest**: signed provenance. CI records an attestation and verifies the
    range against `.attest.json`. Provenance lives in `refs/notes/attest`.
 
 Standing rules for anyone (human or agent) changing this repo:
 
 - Run `fledge lanes run verify` before pushing; do not bypass the gate.
-- Keep specs in lockstep with code — update the `*.spec.md` in the same change.
-- A block verdict from augur means stop and escalate, not merge.
+- Keep specs in lockstep with code: update the `*.spec.md` in the same change.
+- A `block` verdict from augur means stop and escalate, not merge.
 - Do not commit `augur.json`.
-- Do not use em-dash characters in authored content.
+- Do not use em-dash characters in authored content; use hyphens or colons.
 - Runner-specific rule files (`CLAUDE.md`, `.cursor/rules/*.mdc`,
-  `.github/copilot-instructions.md`) are one-line pointers to this file — do not
+  `.github/copilot-instructions.md`) are one-line pointers to this file; do not
   duplicate these rules into them.
 <!-- CorvidLabs trust toolchain: END -->

--- a/templates/corvid-stack/CLAUDE.md
+++ b/templates/corvid-stack/CLAUDE.md
@@ -1,0 +1,1 @@
+See AGENTS.md for the project rules, including the managed CorvidLabs trust toolchain block.

--- a/templates/corvid-stack/README.md.tera
+++ b/templates/corvid-stack/README.md.tera
@@ -2,18 +2,22 @@
 
 {{ description }}
 
-Scaffolded with the **CorvidLabs trust toolchain** — a language-agnostic setup
+Scaffolded with the **CorvidLabs trust toolchain**, a language-agnostic setup
 that gates every change through four tools. See https://corvidlabs.xyz/integrate/.
 
 ## What's here
 
 | File | Purpose |
 |------|---------|
-| `fledge.toml` | Tasks + the `verify` lane (the single CI gate) |
+| `fledge.toml` | Tasks plus the `verify` lane (the single quality gate) |
 | `.specsync/config.toml` | spec-sync configuration (spec-as-contract validation) |
 | `.attest.json` | attestation policy (provenance verification) |
-| `.github/workflows/trust.yml` | CI: fledge → spec-sync → augur → attest |
+| `.github/workflows/trust.yml` | CI: fledge, spec-sync, augur, attest |
 | `AGENTS.md` | Agent/human rules, incl. the managed trust-toolchain block |
+
+> Dropping this onto an existing repo? Merge the `.gitignore` and `AGENTS.md`
+> entries into your files rather than replacing them. (Via `fledge templates
+> init` the project dir is created fresh, so there is nothing to overwrite.)
 
 ## Setup
 
@@ -30,7 +34,8 @@ fledge run --init
 fledge lanes run verify
 ```
 
-Then fill in the `[tasks]` in `fledge.toml`, add a `*.spec.md` per module under
+Then fill in the `[tasks]` in `fledge.toml`, set `source_dirs` in
+`.specsync/config.toml` to match your layout, add a `*.spec.md` per module under
 `specs/`, and register it in `.specsync/registry.toml`.
 
 ## The gate
@@ -38,11 +43,11 @@ Then fill in the `[tasks]` in `fledge.toml`, add a `*.spec.md` per module under
 Every push and PR runs `.github/workflows/trust.yml` as **five parallel checks**,
 so a failure points straight at the tool:
 
-- **fledge** `lanes run verify` — fmt + lint + test + build
-- **spec-sync** — specs match code (soft until specs land)
-- **augur** — diff-risk verdict; a `block` halts the merge
-- **attest** — provenance verified against `.attest.json`
-- **rules** — the managed `AGENTS.md` trust block must be present
+- **fledge** `lanes run verify`: fmt + lint + test + build
+- **spec-sync**: specs match code (soft until specs land)
+- **augur**: diff-risk verdict; a `block` halts the merge
+- **attest**: provenance verified against `.attest.json`
+- **rules**: the managed `AGENTS.md` trust block must be present
 
 They run independently because, in verify form, none consumes another's output.
 If you later switch attest to `sign --from-augur` (which needs augur's verdict

--- a/templates/corvid-stack/README.md.tera
+++ b/templates/corvid-stack/README.md.tera
@@ -35,10 +35,15 @@ Then fill in the `[tasks]` in `fledge.toml`, add a `*.spec.md` per module under
 
 ## The gate
 
-Every push and PR runs `.github/workflows/trust.yml`:
+Every push and PR runs `.github/workflows/trust.yml` as **five parallel checks**,
+so a failure points straight at the tool:
 
-1. **fledge** `lanes run verify` — fmt + lint + test + build
-2. **spec-sync** — specs match code (soft until specs land)
-3. **augur** — diff-risk verdict; a `block` halts the merge
-4. **attest** — provenance verified against `.attest.json`
-5. The managed `AGENTS.md` rules block must be present
+- **fledge** `lanes run verify` — fmt + lint + test + build
+- **spec-sync** — specs match code (soft until specs land)
+- **augur** — diff-risk verdict; a `block` halts the merge
+- **attest** — provenance verified against `.attest.json`
+- **rules** — the managed `AGENTS.md` trust block must be present
+
+They run independently because, in verify form, none consumes another's output.
+If you later switch attest to `sign --from-augur` (which needs augur's verdict
+and the test result), make the attest job `needs: [augur, fledge]`.

--- a/templates/corvid-stack/README.md.tera
+++ b/templates/corvid-stack/README.md.tera
@@ -1,0 +1,44 @@
+# {{ project_name }}
+
+{{ description }}
+
+Scaffolded with the **CorvidLabs trust toolchain** — a language-agnostic setup
+that gates every change through four tools. See https://corvidlabs.xyz/integrate/.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `fledge.toml` | Tasks + the `verify` lane (the single CI gate) |
+| `.specsync/config.toml` | spec-sync configuration (spec-as-contract validation) |
+| `.attest.json` | attestation policy (provenance verification) |
+| `.github/workflows/trust.yml` | CI: fledge → spec-sync → augur → attest |
+| `AGENTS.md` | Agent/human rules, incl. the managed trust-toolchain block |
+
+## Setup
+
+```bash
+# Install the toolchain (macOS shown; see the guide for Linux/cargo)
+brew install CorvidLabs/tap/fledge
+cargo install specsync
+# augur + attest run as GitHub Actions in trust.yml
+
+# Wire up your stack's tasks (auto-detects Rust, Node, Go, Python, Ruby, Java, Swift)
+fledge run --init
+
+# Run the gate locally
+fledge lanes run verify
+```
+
+Then fill in the `[tasks]` in `fledge.toml`, add a `*.spec.md` per module under
+`specs/`, and register it in `.specsync/registry.toml`.
+
+## The gate
+
+Every push and PR runs `.github/workflows/trust.yml`:
+
+1. **fledge** `lanes run verify` — fmt + lint + test + build
+2. **spec-sync** — specs match code (soft until specs land)
+3. **augur** — diff-risk verdict; a `block` halts the merge
+4. **attest** — provenance verified against `.attest.json`
+5. The managed `AGENTS.md` rules block must be present

--- a/templates/corvid-stack/fledge.toml
+++ b/templates/corvid-stack/fledge.toml
@@ -1,0 +1,15 @@
+# fledge.toml — tasks and lanes for the CorvidLabs trust toolchain.
+# Docs: https://github.com/CorvidLabs/fledge
+
+# Fill these in for your stack. `fledge run --init` auto-detects Rust, Node, Go,
+# Python, Ruby, Java, or Swift and can populate them for you.
+[tasks]
+fmt = "echo 'TODO: format-check command (e.g. cargo fmt --check)'"
+lint = "echo 'TODO: lint command (e.g. cargo clippy -- -D warnings)'"
+test = "echo 'TODO: test command (e.g. cargo test)'"
+build = "echo 'TODO: build command (e.g. cargo build)'"
+
+# The single CI gate. `.github/workflows/trust.yml` runs `fledge lanes run verify`.
+[lanes.verify]
+description = "The single CI gate"
+steps = ["fmt", "lint", "test", "build"]

--- a/templates/corvid-stack/fledge.toml
+++ b/templates/corvid-stack/fledge.toml
@@ -1,4 +1,4 @@
-# fledge.toml — tasks and lanes for the CorvidLabs trust toolchain.
+# fledge.toml: tasks and lanes for the CorvidLabs trust toolchain.
 # Docs: https://github.com/CorvidLabs/fledge
 
 # Fill these in for your stack. `fledge run --init` auto-detects Rust, Node, Go,
@@ -9,7 +9,7 @@ lint = "echo 'TODO: lint command (e.g. cargo clippy -- -D warnings)'"
 test = "echo 'TODO: test command (e.g. cargo test)'"
 build = "echo 'TODO: build command (e.g. cargo build)'"
 
-# The single CI gate. `.github/workflows/trust.yml` runs `fledge lanes run verify`.
+# The single quality gate. `.github/workflows/trust.yml` runs `fledge lanes run verify`.
 [lanes.verify]
-description = "The single CI gate"
+description = "The single quality gate"
 steps = ["fmt", "lint", "test", "build"]

--- a/templates/corvid-stack/template.toml
+++ b/templates/corvid-stack/template.toml
@@ -1,12 +1,12 @@
 [template]
 name = "corvid-stack"
-description = "CorvidLabs trust toolchain (fledge + spec-sync + augur + attest) — language-agnostic stack setup, config only"
+description = "CorvidLabs trust toolchain (fledge + spec-sync + augur + attest): language-agnostic stack setup, config only"
 min_fledge_version = "1.0.0"
 
 [prompts]
 description = { message = "Project description", default = "A {{ project_name }} project" }
 
-# This template scaffolds setup/config only — no source code. Files that need
+# This template scaffolds setup/config only, no source code. Files that need
 # project variables carry a `.tera` extension and are rendered; everything else
 # (notably the workflow YAML with its ${{ }} expressions and .attest.json) is
 # copied verbatim.

--- a/templates/corvid-stack/template.toml
+++ b/templates/corvid-stack/template.toml
@@ -1,0 +1,16 @@
+[template]
+name = "corvid-stack"
+description = "CorvidLabs trust toolchain (fledge + spec-sync + augur + attest) — language-agnostic stack setup, config only"
+min_fledge_version = "1.0.0"
+
+[prompts]
+description = { message = "Project description", default = "A {{ project_name }} project" }
+
+# This template scaffolds setup/config only — no source code. Files that need
+# project variables carry a `.tera` extension and are rendered; everything else
+# (notably the workflow YAML with its ${{ }} expressions and .attest.json) is
+# copied verbatim.
+[files]
+render = []
+copy = []
+ignore = ["template.toml"]


### PR DESCRIPTION
## Summary

Adds a built-in **`corvid-stack`** template that scaffolds the [CorvidLabs trust toolchain](https://corvidlabs.xyz/integrate/) — **fledge + spec-sync + augur + attest** — as pure config. No language scaffolding: it's the "stack setup" layer you drop onto any repo.

Until now, wiring those four tools together meant hand-copying config from the integration guide. `fledge templates init <name> -t corvid-stack` does it in one shot.

## What it scaffolds

| File | Purpose |
|------|---------|
| `fledge.toml` | Tasks + the `verify` lane (the single CI gate) |
| `.specsync/{config.toml, registry.toml, .gitignore}` | spec-as-contract setup |
| `.attest.json` | Attestation policy (canonical permissive shape from `CorvidLabs/attest`) |
| `.github/workflows/trust.yml` | CI gate: fledge → spec-sync → augur → attest → AGENTS.md marker check |
| `AGENTS.md` | Managed trust-toolchain rules block (the `BEGIN` marker `trust.yml` greps for); `CLAUDE.md` is a one-line pointer |
| `README.md` | Setup + gate overview |

## Faithfulness

Rather than guess, the config is grounded in the real upstream sources:
- `trust.yml` uses the actual composite actions — `CorvidLabs/spec-sync@v4`, `CorvidLabs/augur@v0`, `CorvidLabs/attest@v0` — with their documented inputs (`fetch-depth: 0`, notes fetch, `threshold: block`, `policy: .attest.json`).
- `.attest.json` matches the canonical schema dogfooded in `CorvidLabs/attest`.

## Rendering

Files needing project variables carry a `.tera` extension (`AGENTS.md.tera`, `README.md.tera`, `.specsync/registry.toml.tera`). The workflow YAML and `.attest.json` are copied **verbatim**, so their literal `${{ }}` / JSON survive Tera untouched (`render = []`).

## Test Plan

- [x] Scaffolded a project (`fledge templates init acme-svc -t corvid-stack`): all 10 files render, `.tera` stripped, `{{ project_name }}` substituted, `${{ }}` preserved, marker present, no leftovers
- [x] Scaffolded project runs `fledge spec check` (exit 0) and `fledge lanes run verify` (all 4 steps)
- [x] Updated built-in template count test (9 → 10) + templates spec/README catalog
- [x] `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)