### PR TITLE
Fix: enforce CI gates so untested code cannot ship (H-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'specs/**'
       - 'tests/**'
       - 'templates/**'
       - 'build.rs'
@@ -21,6 +22,7 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'specs/**'
       - 'tests/**'
       - 'templates/**'
       - 'build.rs'
@@ -32,7 +34,10 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel in-progress runs on main: every merged commit must get a
+  # completed CI verdict (for bisection and post-merge signal). PR branches
+  # keep fast-cancel on new pushes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test:
+    name: Test gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test --verbose
+
   build:
+    needs: [test]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- `release.yml`: add a **Test gate** job (fmt + clippy + `cargo test`) that the build matrix `needs`, so 5-platform release binaries can no longer be published from a commit that fails tests.
- `ci.yml`: stop cancelling in-progress runs on `main` — `cancel-in-progress` now excludes `refs/heads/main`, so every merged commit gets a completed CI verdict.
- `ci.yml`: add `specs/**` to the push and pull_request path filters so spec-only PRs trigger the strict spec-check job instead of running no CI at all.

Addresses review finding **H-4** (no release test gate / cancelled main runs) and the `specs/**` CI-coverage gap. Enabling branch-protection required status checks is a repo-settings change and is intentionally left out of this PR.

## Test Plan

- [ ] Workflow YAML validated locally (parses cleanly)
- [ ] CI runs green on this PR
- [ ] Follow-up: enable required status checks on `main` (`lint`, `audit`, `spec-check`, `test (ubuntu-latest)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
