### PR TITLE
Fix: reject dot-dot path segments in plugin sources — trust-tier spoof (H-2)

### DIFF
--- a/specs/trust/trust.spec.md
+++ b/specs/trust/trust.spec.md
@@ -1,6 +1,6 @@
 ---
 module: trust
-version: 4
+version: 5
 status: active
 files:
   - src/trust.rs
@@ -28,6 +28,7 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 | `determine_trust_tier` | Classify a source string into a trust tier by parsing the GitHub org/owner |
 | `determine_trust_tier_from_owner` | Classify by GitHub owner string directly |
 | `parse_source_ref` | Split a source string into base URL and optional git ref (e.g., `@v1.0.0`) |
+| `source_has_path_traversal` | Detect a `.` or `..` segment in a source's owner/repo path (used to reject trust-tier spoofing via clone-URL collapse) |
 
 ### Structs & Enums
 
@@ -44,6 +45,7 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 | `determine_trust_tier` | `(&str) -> TrustTier` | Parse source URL/shorthand, extract org/owner, classify tier |
 | `determine_trust_tier_from_owner` | `(&str) -> TrustTier` | Classify by owner name directly (no URL parsing) |
 | `parse_source_ref` | `(&str) -> (&str, Option<&str>)` | Split `source@ref` into base and optional ref; handles SSH URLs |
+| `source_has_path_traversal` | `(&str) -> bool` | True if the source's owner/repo path contains a `.` or `..` segment; callers reject such sources because git/curl collapse them client-side to a different repo than the one classified |
 
 ## Invariants
 
@@ -57,6 +59,7 @@ Shared trust-tier classification for all extension types (plugins, templates, la
 8. `OFFICIAL_ORGS` and `TEAM_MEMBERS` are `&[&str]` constants providing the baseline trust lists. Users can extend the team tier at runtime via `trust.orgs` and `trust.users` in `config.toml` — these config entries grant **Team** tier only, never Official
 9. Config-based orgs and users are compared case-insensitively, matching the behavior of hardcoded `TEAM_MEMBERS`
 10. When config cannot be loaded (missing or malformed `config.toml`), the system falls back to an empty `TrustConfig` — only the hardcoded constants apply
+11. A source whose owner/repo path contains a `.` or `..` segment (e.g. `CorvidLabs/../attacker/evil`) classifies as `Unverified`, never Official or Team. git/curl collapse such segments client-side (RFC 3986 dot-segment removal), so the fetched repo would differ from the one classified — a trust-tier spoof. `source_has_path_traversal` exposes the same check so install/fetch paths can reject these sources outright
 
 ## Behavioral Examples
 
@@ -96,6 +99,14 @@ determine_trust_tier("My-Company/fledge-plugin-foo")    -> Team  (case-insensiti
 determine_trust_tier("CorvidLabs/fledge-plugin-deploy") -> Official  (hardcoded takes precedence)
 ```
 
+### determine_trust_tier — dot-dot spoof rejected
+```
+determine_trust_tier("CorvidLabs/../attacker/evil")                        -> Unverified
+determine_trust_tier("https://github.com/CorvidLabs/../attacker/evil.git") -> Unverified
+source_has_path_traversal("CorvidLabs/../attacker/evil")                   -> true
+source_has_path_traversal("CorvidLabs/fledge-plugin-deploy")               -> false
+```
+
 ### parse_source_ref
 ```
 parse_source_ref("someone/fledge-deploy@v1.2.0") -> ("someone/fledge-deploy", Some("v1.2.0"))
@@ -119,6 +130,7 @@ parse_source_ref("https://user:token@github.com/owner/repo.git") -> ("https://us
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 5 | 2026-07-02 | Add `source_has_path_traversal` export and invariant 11: sources with `.`/`..` path segments classify as `Unverified` and are rejected at install time, closing a trust-tier spoof where a collapsed clone URL fetches a different repo than the one classified |
 | 4 | 2026-06-03 | Add `Local` trust tier for filesystem path plugin installs. Labels and styled labels include `"local"`; GitHub owner-based classification remains unchanged for search/discovery |
 | 3 | 2026-05-03 | Configurable trust: `trust.orgs` and `trust.users` config keys extend the team tier at runtime. Invariant 8 rewritten, invariants 9-10 added. Behavioral examples added for config-driven classification. Depends on `config` module |
 | 2 | 2026-04-25 | Rename `Community` → `Team`; add `TEAM_MEMBERS` allowlist of CorvidLabs members (`["0xGaspar", "0xLeif", "Kyntrin", "tofu-ux"]`) classifying their personal repos as `Team`. Drops the unused-variant `#[allow(dead_code)]` since all three tiers now have construction sites |

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -38,6 +38,14 @@ impl InstallSource {
             bail!("--copy is only valid when installing from a local path.");
         }
 
+        // Reject "." / ".." path segments in a remote source. git/curl collapse
+        // them client-side (RFC 3986), so "CorvidLabs/../attacker/evil" would be
+        // fetched as "attacker/evil" while trust classification keys on the
+        // official "CorvidLabs" org — a trust-tier spoof (review finding H-2).
+        if crate::trust::source_has_path_traversal(source) {
+            bail!("Invalid plugin source '{source}': '.' and '..' path segments are not allowed.");
+        }
+
         let (base, git_ref) = parse_source_ref(source);
         let clone_url = if Self::is_git_url(base) {
             base.to_string()
@@ -735,4 +743,26 @@ pub(crate) fn install_plugin(
         "pinned_ref": entry.pinned_ref,
         "capabilities": entry.capabilities,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rejects_dotdot_source() {
+        // Trust-tier spoof sources must be rejected before classification or
+        // clone, whether shorthand or full URL (review finding H-2).
+        assert!(InstallSource::parse("CorvidLabs/../attacker/evil", false).is_err());
+        assert!(
+            InstallSource::parse("https://github.com/CorvidLabs/../attacker/evil.git", false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn parse_accepts_normal_shorthand() {
+        // A legitimate owner/repo shorthand still parses (no network in parse).
+        assert!(InstallSource::parse("CorvidLabs/fledge-plugin-deploy", false).is_ok());
+    }
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -156,7 +156,7 @@ fn path_has_traversal_segment(path: &str) -> bool {
 /// these outright. Local "./"/"../" paths are handled by `determine_trust_tier`
 /// before classification, so in practice this only inspects remote-style
 /// sources (shorthand `owner/repo` or clone URLs).
-pub(crate) fn source_has_path_traversal(source: &str) -> bool {
+pub fn source_has_path_traversal(source: &str) -> bool {
     let (base, _) = parse_source_ref(source);
     let normalized = base
         .strip_prefix("https://github.com/")

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -156,7 +156,7 @@ fn path_has_traversal_segment(path: &str) -> bool {
 /// these outright. Local "./"/"../" paths are handled by `determine_trust_tier`
 /// before classification, so in practice this only inspects remote-style
 /// sources (shorthand `owner/repo` or clone URLs).
-pub fn source_has_path_traversal(source: &str) -> bool {
+pub(crate) fn source_has_path_traversal(source: &str) -> bool {
     let (base, _) = parse_source_ref(source);
     let normalized = base
         .strip_prefix("https://github.com/")

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -124,6 +124,15 @@ fn classify_source(source: &str, config: &TrustConfig) -> TrustTier {
         base
     };
 
+    // A legitimate owner/repo never contains "." or ".." path segments. Such a
+    // segment lets git/curl collapse the clone URL client-side (RFC 3986
+    // dot-segment removal), so "CorvidLabs/../attacker/evil" would classify on
+    // the official "CorvidLabs" org yet actually fetch "attacker/evil" — a
+    // trust-tier spoof. Never grant such a source any trust.
+    if path_has_traversal_segment(normalized) {
+        return TrustTier::Unverified;
+    }
+
     if let Some((org, _)) = normalized.split_once('/') {
         if OFFICIAL_ORGS.contains(&org) {
             return TrustTier::Official;
@@ -134,6 +143,28 @@ fn classify_source(source: &str, config: &TrustConfig) -> TrustTier {
     }
 
     TrustTier::Unverified
+}
+
+/// True if any "/"- or "\\"-separated segment of `path` is "." or "..".
+fn path_has_traversal_segment(path: &str) -> bool {
+    path.split(['/', '\\']).any(|seg| seg == "." || seg == "..")
+}
+
+/// True if a plugin/template source contains a "." or ".." segment in its
+/// owner/repo path. git/curl collapse such segments client-side so the fetched
+/// repo differs from the one classified for trust; the install path rejects
+/// these outright. Local "./"/"../" paths are handled by `determine_trust_tier`
+/// before classification, so in practice this only inspects remote-style
+/// sources (shorthand `owner/repo` or clone URLs).
+pub fn source_has_path_traversal(source: &str) -> bool {
+    let (base, _) = parse_source_ref(source);
+    let normalized = base
+        .strip_prefix("https://github.com/")
+        .or_else(|| base.strip_prefix("http://github.com/"))
+        .or_else(|| base.strip_prefix("git@github.com:"))
+        .unwrap_or(base)
+        .trim_end_matches(".git");
+    path_has_traversal_segment(normalized)
 }
 
 fn classify_owner(owner: &str, config: &TrustConfig) -> TrustTier {
@@ -189,6 +220,40 @@ mod tests {
             determine_trust_tier("corvidlabs/fledge-plugin-deploy"),
             TrustTier::Official
         );
+    }
+
+    #[test]
+    fn dotdot_source_never_official() {
+        // Trust-tier spoof: first segment is an official org, but git/curl
+        // collapse the URL to a different repo. Must NOT be classified Official.
+        assert_eq!(
+            determine_trust_tier("CorvidLabs/../attacker/evil"),
+            TrustTier::Unverified
+        );
+        assert_eq!(
+            determine_trust_tier("https://github.com/CorvidLabs/../attacker/evil.git"),
+            TrustTier::Unverified
+        );
+        assert_eq!(
+            determine_trust_tier("git@github.com:CorvidLabs/../attacker/evil.git"),
+            TrustTier::Unverified
+        );
+    }
+
+    #[test]
+    fn source_traversal_detection() {
+        assert!(source_has_path_traversal("CorvidLabs/../attacker/evil"));
+        assert!(source_has_path_traversal(
+            "https://github.com/CorvidLabs/../attacker/evil.git"
+        ));
+        // Legitimate sources must not be flagged.
+        assert!(!source_has_path_traversal(
+            "CorvidLabs/fledge-plugin-deploy"
+        ));
+        assert!(!source_has_path_traversal("owner/repo@v1.0.0"));
+        assert!(!source_has_path_traversal(
+            "https://github.com/CorvidLabs/fledge.git"
+        ));
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -145,9 +145,41 @@ fn classify_source(source: &str, config: &TrustConfig) -> TrustTier {
     TrustTier::Unverified
 }
 
-/// True if any "/"- or "\\"-separated segment of `path` is "." or "..".
+/// True if any "/"- or "\\"-separated segment of `path` is "." or "..",
+/// checked against both the raw string and a percent-decoded copy. git and
+/// curl percent-decode a URL before resolving it, so `%2e%2e` / `%2f` / `%5c`
+/// collapse to `..` / `/` / `\` client-side just like literal segments — we
+/// must decode too or the check is trivially bypassed.
 fn path_has_traversal_segment(path: &str) -> bool {
-    path.split(['/', '\\']).any(|seg| seg == "." || seg == "..")
+    fn has_dot_segment(path: &str) -> bool {
+        path.split(['/', '\\']).any(|seg| seg == "." || seg == "..")
+    }
+    has_dot_segment(path) || has_dot_segment(&percent_decode(path))
+}
+
+/// Decode `%XX` percent-escapes (case-insensitive hex) to their bytes and
+/// render the result lossily as UTF-8. Incomplete or non-hex `%` sequences are
+/// left verbatim. A single pass — matching what git/curl's transport does —
+/// not a general-purpose URL decoder. Used only to normalize a source before
+/// the traversal check.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// True if a plugin/template source contains a "." or ".." segment in its
@@ -254,6 +286,22 @@ mod tests {
         assert!(!source_has_path_traversal(
             "https://github.com/CorvidLabs/fledge.git"
         ));
+    }
+
+    #[test]
+    fn percent_encoded_traversal_rejected() {
+        // git/curl decode %2e/%2f/%5c before resolving, so a percent-encoded
+        // spoof must be caught just like a literal `..` (Gemini review, #434).
+        assert!(source_has_path_traversal("CorvidLabs/%2e%2e/attacker/evil"));
+        assert!(source_has_path_traversal("CorvidLabs/%2E%2E/attacker/evil")); // uppercase hex
+        assert!(source_has_path_traversal("CorvidLabs%2f..%2fattacker")); // encoded slash
+        assert!(source_has_path_traversal("CorvidLabs%5c..%5cattacker")); // encoded backslash
+        assert_eq!(
+            determine_trust_tier("https://github.com/CorvidLabs/%2e%2e/attacker/evil"),
+            TrustTier::Unverified
+        );
+        // A literal percent that is not a traversal escape must not false-positive.
+        assert!(!source_has_path_traversal("CorvidLabs/fledge-%25-plugin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The trust classifier keyed on the **first** path segment of a source, so `CorvidLabs/../attacker/evil` classified as the official CorvidLabs org (green "official CorvidLabs plugin" banner) — while git/curl collapse the clone URL client-side (RFC 3986 dot-segment removal) to `attacker/evil`. Since only the Unverified tier is capability-blocked, the attacker repo's `exec`/`network` capabilities were allowed (auto-granted under `--force` / non-interactive). Verified live: `git ls-remote` of `.../CorvidLabs/../attacker/evil.git` fetches `attacker/evil`.

- `trust.rs`: `classify_source` returns `Unverified` for any source with a `.`/`..` segment; adds `source_has_path_traversal()`.
- `install.rs`: `InstallSource::parse` rejects such sources outright (before classification or clone), shorthand and full-URL forms alike.
- Tests: `dotdot_source_never_official`, `source_traversal_detection`, `parse_rejects_dotdot_source`, `parse_accepts_normal_shorthand`.

Addresses review finding **H-2**.

## Test Plan

- [ ] New tests pass; `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [ ] Full unit suite green (876 passed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
