### PR TITLE
Fix: make post-release formula sync recoverable and self-verifying (C-1)

### DIFF
--- a/.github/workflows/post-release-formula.yml
+++ b/.github/workflows/post-release-formula.yml
@@ -18,10 +18,20 @@ on:
   workflow_run:
     workflows: ["Release"]
     types: [completed]
+  # Manual recovery lever: re-sync the formula for a given tag without
+  # re-triggering the whole Release workflow (e.g. after rotating an expired
+  # TAP_GITHUB_TOKEN). The workflow_run-only trigger previously left no way to
+  # recover a failed formula update except re-running a past workflow_run.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync (e.g. v1.6.0)"
+        required: true
+        type: string
 
 jobs:
   update-formula:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +41,8 @@ jobs:
       - name: Resolve release tag
         id: tag
         env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # workflow_run supplies the tag via head_branch; manual dispatch via input.
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag }}
         run: |
           set -euo pipefail
           if ! [[ "$HEAD_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
@@ -120,3 +131,27 @@ jobs:
           git add Formula/fledge.rb
           git commit -m "chore: update formula to v$NEW_VERSION"
           git push origin main
+
+      - name: Verify channels converged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Read the just-pushed formula via the Contents API (not the CDN, which
+          # can lag) and assert the version actually took effect. This turns a
+          # silent no-op push into a red run instead of leaving brew users stale.
+          formula="$(gh api repos/CorvidLabs/homebrew-tap/contents/Formula/fledge.rb --jq '.content' | base64 --decode)"
+          tap_version="$(printf '%s' "$formula" | sed -n 's/^[[:space:]]*version[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+          if [ "$tap_version" != "$NEW_VERSION" ]; then
+            echo "::error::homebrew-tap Formula/fledge.rb reports '$tap_version', expected '$NEW_VERSION' — formula sync did not take effect."
+            exit 1
+          fi
+          echo "Verified homebrew-tap Formula/fledge.rb at v$NEW_VERSION."
+          # crates.io is published out of band; warn (don't fail) if it lags so
+          # channel drift is at least visible in the run log.
+          crate_version="$(curl -fsSL -A 'fledge-ci' https://crates.io/api/v1/crates/fledge \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["crate"]["max_version"])' 2>/dev/null || echo "")"
+          if [ -n "$crate_version" ] && [ "$crate_version" != "$NEW_VERSION" ]; then
+            echo "::warning::crates.io max_version '$crate_version' != release '$NEW_VERSION' — crates.io publish may be pending or missing."
+          fi


### PR DESCRIPTION
## Summary

`post-release-formula.yml` triggered only on `workflow_run`, so a failed formula update (the expired `TAP_GITHUB_TOKEN` that left the Homebrew tap at 1.4.3 across three releases) had **no recovery lever** and failed silently beside a green Release run.

- Add a `workflow_dispatch` trigger with a `tag` input so the sync can be re-run for any release after fixing the cause, without re-triggering the whole Release workflow. Recover with `gh workflow run "Post-Release Formula Update" -f tag=v1.6.0`.
- Add a **Verify channels converged** step that reads the just-pushed formula via the Contents API (not the CDN) and fails the run if the version didn't take effect; warns when crates.io lags the release.

Addresses review finding **C-1** (code-side hardening). Rotating `TAP_GITHUB_TOKEN` and re-running remain manual operator steps.

## Test Plan

- [ ] Workflow YAML validated locally (parses cleanly)
- [ ] Operator: rotate `TAP_GITHUB_TOKEN`, then `gh workflow run "Post-Release Formula Update" -f tag=v1.6.0` and confirm the run's verify step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
