### PR TITLE
Update: correct stale Claude-CLI references in review/ask/doctor specs (H-5)

### DIFF
--- a/specs/ask/ask.spec.md
+++ b/specs/ask/ask.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ask
-version: 6
+version: 7
 status: active
 files:
   - src/ask.rs
@@ -16,7 +16,7 @@ depends_on:
 
 ## Purpose
 
-Ask questions about your codebase using AI. Builds a spec-augmented prompt (compact index of every module plus optional full bundles for named modules) and sends it to the active LLM provider — Claude CLI or any Ollama-speaking endpoint. The question composition is provider-agnostic; the provider is resolved from CLI override > `FLEDGE_AI_PROVIDER` env > `ai.provider` config > default `"claude"`.
+Ask questions about your codebase using AI. Builds a spec-augmented prompt (compact index of every module plus optional full bundles for named modules) and sends it to the active LLM provider over HTTP — `anthropic`, any OpenAI-compatible endpoint (`openai` and the gateways), or an Ollama-speaking endpoint. As of 1.5.0 there is no CLI shell-out: every provider except Ollama is served by the [`corvid-ai`](https://crates.io/crates/corvid-ai) crate, and Ollama keeps fledge's native HTTP client. The question composition is provider-agnostic; the provider is resolved from CLI override > `FLEDGE_AI_PROVIDER` env > `ai.provider` config > **auto-detect** (the first configured provider with a key, falling back to keyless local Ollama). When several providers are configured and the session is interactive (and `--json` is not set), `ask` prompts the user to pick a provider + model; non-TTY / CI / `--json` fall through to the deterministic auto-detect.
 
 ## Public API
 
@@ -44,10 +44,10 @@ Ask questions about your codebase using AI. Builds a spec-augmented prompt (comp
 
 ## Invariants
 
-1. Requires the active provider's dependency to be installed and reachable (Claude CLI for `provider = claude`; an Ollama-speaking endpoint for `provider = ollama`). `fledge doctor` reports which is active and whether it's available.
+1. Requires the active provider to be reachable over HTTP — no CLI is shelled out. `anthropic` and the OpenAI-compatible providers need an API key (`<PROVIDER>_API_KEY` env or `ai.<provider>.api_key`); `ollama` needs a reachable Ollama-speaking endpoint (local daemon, or an API key for cloud). `fledge ai status` / `fledge doctor` report which provider is active and whether it's configured.
 2. Question is joined from multiple args (no quotes required)
 3. `--json` outputs `{question, answer, provider, model}` structured response
-4. `--provider {claude,ollama}` overrides env and config; validated at parse time (typos rejected with a clap error)
+4. `--provider <name>` overrides env and config; validated at parse time by a clap `value_parser` (accepted: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, `ollama`, and the deprecated `claude` alias of `anthropic`; typos rejected with a clap error)
 5. `--model <name>` overrides env and config
 6. Prompt composition is provider-agnostic: the exact same text flows to whichever provider is active
 7. By default, a compact spec index is always prepended to the prompt (one line per module: name, version, status, files, first-paragraph purpose). Skipped only when `--no-spec-index` is passed.
@@ -61,17 +61,17 @@ Ask questions about your codebase using AI. Builds a spec-augmented prompt (comp
 ### ask — default (index auto-included)
 ```
 $ fledge ask "how does the work module build branch names?"
-● Thinking...
+● Thinking [ollama (llama3.3)]:
 
-[Claude reads the index, knows there's a `work` module, cites specs/work/work.spec.md in its answer]
+[the model reads the index, knows there's a `work` module, cites specs/work/work.spec.md in its answer]
 ```
 
 ### ask — with full spec + companions for a module
 ```
 $ fledge ask --with-specs work "why does the work module sanitize branch names this way?"
-● Thinking...
+● Thinking [anthropic (claude-sonnet-4-6)]:
 
-[Claude has the full spec, context.md design decisions, and requirements.md in its prompt]
+[the model has the full spec, context.md design decisions, and requirements.md in its prompt]
 ```
 
 ### ask — multiple specs, comma or repeated
@@ -113,22 +113,25 @@ error: Please provide a question. Usage: fledge ask <question>
 
 | Error | When | Behavior |
 |-------|------|----------|
-| Claude CLI not installed | `claude --version` fails | Bail with install instructions |
+| Missing API key | Active provider (`anthropic` or an OpenAI-compatible provider) has no key in env/config | Bail with API-key setup guidance (surfaced from `llm` / `corvid-ai`) |
+| Ollama endpoint unreachable | Active provider `ollama` and the POST to `<host>/api/generate` fails | Bail with the full URL and a "(is the Ollama server running?)" hint |
+| Unknown provider | `--provider` value outside the accepted set | clap rejects at parse time with a "possible values" hint |
 | No question provided | Empty args | Bail with usage hint |
 | `--with-specs <name>` where `specs/<name>/` does not exist | Unknown module | Bail with the looked-at path |
-| Claude CLI error | Non-zero exit | Bail with stderr |
 
 ## Dependencies
 
-- Active LLM provider — either Claude CLI or an Ollama-speaking endpoint (see `llm` spec)
+- Active LLM provider over HTTP — `anthropic`, an OpenAI-compatible endpoint, or an Ollama-speaking endpoint (see `llm` spec); no CLI dependency
 - `spec` module — `collect_index`, `render_index_markdown`, `load_module_bundle`, `all_module_names`
 - `llm` module — `build_provider`, `ProviderOverride`, `describe`
+- `ai` module — `pick_when_multiple` for the interactive provider+model pick when several are configured
 - `config` module — `ai.*` section for provider + model resolution
 
 ## Change Log
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 7 | 2026-07-02 | Correct stale Claude-CLI references left over from before the 1.5.0 HTTP-provider migration. Purpose, invariants, error cases, and dependencies now describe the `corvid-ai`-backed HTTP providers (`anthropic` / OpenAI-compatible / `ollama`) with **auto-detect** as the default and an interactive pick when several are configured — no CLI shell-out and no `claude --version` check. Invariant 4 lists the real clap `value_parser` provider set; behavioral examples use the actual `● Thinking [<provider (model)>]:` spinner. No code change |
 | 6 | 2026-04-26 | Doc sync, behavioral example updated to show the post-tier-D envelope shape with `schema_version`/`action`/`provider`/`model`. No code change |
 | 5 | 2026-04-26 | Tier-D 1.0 envelope: `ask --json` now wraps output as `{schema_version: 1, action: "ask", question, answer, provider, model}`. Previously emitted bare `{question, answer, provider, model}`. Closes a gap where tier C (#274) only migrated plugins/lanes/templates |
 | 4 | 2026-04-23 | Provider abstraction: Claude CLI is no longer hardcoded. New `--provider` and `--model` flags. JSON output gains `provider` and `model` fields. Runs through `llm::build_provider` with config / env / override precedence. |

--- a/specs/doctor/doctor.spec.md
+++ b/specs/doctor/doctor.spec.md
@@ -1,6 +1,6 @@
 ---
 module: doctor
-version: 8
+version: 9
 status: active
 files:
   - src/doctor.rs
@@ -50,14 +50,14 @@ The report has four sections, in this order:
 |---------|---------------|---------------|
 | `fledge` | no | `fledge config` loads cleanly |
 | `Git` | no | `git` installed; repository initialized; remote configured; working tree clean |
-| `AI` | no | Claude CLI present; Ollama binary present; the active provider's reachability (probes Ollama's `/api/tags` when active) |
+| `AI` | no | Ollama binary present; the active provider's readiness — API providers (anthropic / openai / gateways) verify a configured API key, Ollama probes its `/api/tags` endpoint |
 | `Toolchains` | **yes** | Probes for rust (rustc/cargo), node (node/npm/pnpm/bun/yarn), python (python3/uv/poetry), go, ruby, swift, and JVM (java/gradle/mvn) |
 
 ## Invariants
 
 1. The `fledge`, `Git`, and `AI` sections contribute to the passed/failed totals; the `Toolchains` section does not (`section.informational == true` excludes it from counting and renders missing tools dimmed rather than as failures, since not every project uses every language).
 2. Toolchain probes capture the tool's version string when present; missing tools render as `· <name> (not installed)` and carry no fix hint (environmental, not project errors).
-3. AI checks verify Claude CLI is installed and Ollama (when configured as active) is reachable; when Ollama is the active provider the displayed `model` honors the `FLEDGE_AI_MODEL` env override so doctor's report matches what `ask` / `review` will actually send.
+3. The AI section probes the Ollama binary (the only provider with a local binary worth checking) and reports the active provider's readiness: API providers (`anthropic`, `openai`, and the gateways) pass when an API key is configured and fail with a `<PROVIDER>_API_KEY` fix hint otherwise; `ollama` probes its `/api/tags` endpoint. When Ollama is the active provider the displayed `model` honors the `FLEDGE_AI_MODEL` env override so doctor's report matches what `ask` / `review` will actually send. There is no `claude` CLI check — since 1.5.0 the AI commands are plain HTTP through the `corvid-ai` crate and need an API key, not a local binary.
 4. Each failing check in a non-informational section includes an actionable fix command.
 5. `--json` outputs a structured `DoctorReport` with all sections (informational sections still appear in the JSON, with `informational: true`).
 6. Exit summary shows count of passed checks and issues found, computed only over non-informational sections.
@@ -79,7 +79,6 @@ $ fledge doctor
     ✅ working tree — clean
 
   AI
-    ✅ claude 2.1.119
     ✅ ollama 0.21.2
     ✅ Active provider: ollama — ollama is the active provider (model: gpt-oss:120b-cloud, host: http://localhost:11434)
 
@@ -95,7 +94,28 @@ $ fledge doctor
     · go (not installed)
 
   7 checks passed, 0 issues found
+```
 
+When an API provider is active, the AI section reports the key state instead of an endpoint probe:
+
+```
+$ ANTHROPIC_API_KEY=sk-ant-... fledge doctor
+
+  AI
+    ✅ ollama 0.21.2
+    ✅ Active provider: anthropic — anthropic is the active provider and an API key is configured
+```
+
+If that provider has no key, the check fails with a fix hint naming the env var:
+
+```
+  AI
+    ✅ ollama 0.21.2
+    ❌ Active provider: anthropic — anthropic is the active provider but no API key is set
+      ➡️ Set ANTHROPIC_API_KEY or configure a key for anthropic
+```
+
+```
 $ fledge doctor --json
 { "schema_version": 1, "action": "doctor", "sections": [...], "passed": 7, "failed": 0 }
 ```
@@ -106,12 +126,13 @@ $ fledge doctor --json
 |-------|------|----------|
 | Cannot detect cwd | Current dir inaccessible | anyhow error |
 | Tool probe times out | `<tool> --version` hangs more than 10s | Killed; reported as `Error` with `timed out after 10s` |
+| Invalid active provider | `ai.provider` / `FLEDGE_AI_PROVIDER` is an unknown value | AI section emits an `Error` check with a fix hint to set a valid provider (`anthropic`, `openai`, or `ollama`) |
 
 ## Dependencies
 
 - `std::process::Command` for running tool version checks
-- `config` module — reads `ai.provider` and `ai.ollama.host` to determine the active LLM provider
-- `llm` module — `resolve_provider_kind` for active-provider selection, `ProviderKind` for display
+- `config` module — reads the `ai.*` section (provider, per-provider keys, `ai.ollama.host` / `model`) to resolve the active LLM provider
+- `llm` module — `resolve_provider_kind` for active-provider selection, `provider_has_key` to check API-provider keys, `normalize_ollama_host` for the Ollama endpoint, and `ProviderKind` (`as_str` / `env_var`) for display and fix hints
 - `ureq` — probes the Ollama endpoint's `/api/tags` to check reachability
 - `console` for styled output
 - `serde` + `serde_json` for JSON output
@@ -120,6 +141,7 @@ $ fledge doctor --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 9 | 2026-07-02 | Doc correction for the 1.5.0 HTTP-provider move: removed the stale `claude` CLI check from the AI section (fledge no longer shells out to a `claude` binary). The AI section now probes the Ollama binary and the active provider — API providers (anthropic / openai / gateways) verify a configured API key with a `<PROVIDER>_API_KEY` fix hint; Ollama probes `/api/tags`. Dropped the `✅ claude` line from the behavioral example and expanded the `llm` dependency list to match actual usage. Prose-only; no code change |
 | 8 | 2026-04-26 | Doc sync, `doctor --json` behavioral example updated to show the post-tier-D envelope shape. No code change |
 | 7 | 2026-04-26 | Tier-D 1.0 envelope: `doctor --json` now wraps output as `{schema_version: 1, action: "doctor", sections, passed, failed}`. Previously emitted bare `{sections, passed, failed}`, a 1.0 contract violation per the AGENTS.md rule that every `--json` output is enveloped. Inner `DoctorReport` struct unchanged so the unit test still validates section serialization. New integration assertion in `cli_doctor_json_valid` |
 | 6 | 2026-04-25 | Re-absorbed `fledge-plugin-doctor` toolchain probes into core as a new informational `Toolchains` section. Missing toolchain entries render dimmed and don't pollute the pass/fail totals because environmental availability isn't a project error. Plugin dropped from `DEFAULT_PLUGINS`. |

--- a/specs/review/review.spec.md
+++ b/specs/review/review.spec.md
@@ -1,6 +1,6 @@
 ---
 module: review
-version: 10
+version: 11
 status: active
 files:
   - src/review.rs
@@ -16,7 +16,7 @@ depends_on:
 
 ## Purpose
 
-AI-powered code review of current branch changes. Gets the git diff against a base branch and sends it to the Claude CLI for review, displaying actionable feedback inline. When the repo is spec-tracked, `review` automatically detects which modules the diff touches (via each spec's `files:` frontmatter and any edits under `specs/<name>/`) and includes their full spec + companion files as *context* for the review. The review target is always the diff itself — specs are reference material.
+AI-powered code review of current branch changes. Gets the git diff against a base branch and sends it to the active LLM provider — resolved through the `llm` module's provider abstraction and reached over plain HTTP (Anthropic Messages API, any OpenAI-compatible endpoint, or an Ollama-speaking endpoint; no CLI binary required) — displaying actionable feedback inline. When the repo is spec-tracked, `review` automatically detects which modules the diff touches (via each spec's `files:` frontmatter and any edits under `specs/<name>/`) and includes their full spec + companion files as *context* for the review. The review target is always the diff itself — specs are reference material.
 
 ## Public API
 
@@ -49,25 +49,25 @@ AI-powered code review of current branch changes. Gets the git diff against a ba
 
 ## Invariants
 
-1. Requires Claude CLI (`claude`) to be installed and authenticated
+1. Requires an active LLM provider (see `llm` spec). No CLI binary is installed or shelled out to — every provider is reached over HTTP. When nothing is explicitly selected the provider is **auto-detected** (the first configured provider by API key, falling back to keyless local Ollama); it can be pinned via `ai.provider` config, `FLEDGE_AI_PROVIDER` env, or the `--provider` flag
 2. Base branch defaults to auto-detected default: tries `git symbolic-ref refs/remotes/origin/HEAD`, then checks `main` and `master` via `git rev-parse --verify`, falls back to `main`
 3. Empty diffs bail with a clear message
 4. Shows diff stats before the AI review output
 5. `--file` flag restricts review to a single file's changes
 6. `--json` outputs structured JSON review results (including the list of specs included in context)
-7. `--model` overrides the Claude model used for review
+7. `--model` overrides the model used for review (applied to the active provider's selection)
 8. `--prompt` appends a custom focus prompt to the default review instructions
 9. `--format` controls output style: `summary` (default), `checklist`, or `inline`
 10. When the repo has specs, `review` auto-detects relevant modules by intersecting the diff's changed-file list with each spec's frontmatter `files:` field and with the spec file's actual parent directory (respects the `specs_dir` key from `.specsync/config.toml`, defaulting to `specs/`). Sub-specs that share a directory with another module (e.g. `specs/plugin/plugin-protocol.spec.md` declaring `module: plugin-protocol`) resolve via their real on-disk parent, not via an assumed `<specs_dir>/<name>/`
 11. `--with-specs <names>` (comma-separated, repeatable) appends named modules to the auto-detected set and dedupes
 12. `--no-auto-specs` skips the auto-detection step (but still honors `--with-specs`)
-13. The review target is always the diff; the prompt explicitly instructs Claude that specs are context-only and that changes outside the diff must not be suggested
+13. The review target is always the diff; the prompt explicitly instructs the model that specs are context-only and that changes outside the diff must not be suggested
 14. A broken or missing `.specsync/` never blocks a review — spec auto-detection silently falls back to empty
 15. An explicit `--with-specs <name>` that doesn't resolve bails with a clear error naming the missing module
 16. `--file <path>` narrows both the diff AND the auto-detection input — only specs whose `files:` or directory intersects that single path will be auto-included. Use `--with-specs` alongside `--file` if you want additional context
-17. `--provider {claude,ollama}` overrides env and config for this invocation; `--model` does the same for model selection. The provider chain is identical to `fledge ask`'s (see `llm` spec)
+17. `--provider <name>` overrides env and config for this invocation (`anthropic`, `openai`, `ollama`, or an OpenAI-compatible gateway; `claude` is a deprecated alias of `anthropic`); `--model` does the same for model selection. The provider chain is identical to `fledge ask`'s (see `llm` spec)
 18. JSON output gains `provider` and `model` fields alongside the existing `spec_context` array
-19. `--with-model <ref>` (repeatable, also comma-separated) adds slots to a review **panel**. Refs parse as `provider[:model]` — bare provider names (`claude`, `ollama`) use that provider's active config; specific models (`ollama:gpt-oss:120b-cloud`) override per-slot. The active config (honoring `--provider`/`--model`) is included as the first slot unless `--no-active` is set
+19. `--with-model <ref>` (repeatable, also comma-separated) adds slots to a review **panel**. Refs parse as `provider[:model]` — bare provider names (`anthropic`, `ollama`) use that provider's active config; specific models (`ollama:gpt-oss:120b-cloud`, `anthropic:claude-opus-4-8`) override per-slot. The active config (honoring `--provider`/`--model`) is included as the first slot unless `--no-active` is set
 20. A panel of N slots runs in parallel via `std::thread::spawn`; the diff and spec context are built **once** and shared across all slots so every model sees the same input. Output ordering matches input order — never finish-order — so runs are deterministic
 21. A failed slot (timeout, HTTP error, etc.) is captured as an `error` entry in that slot's result and does **not** abort the panel; remaining slots still produce reviews. The text output prints `error: <message>` in red where the review would have been; JSON gets an `error` field instead of `review`. Exit code is still 0 if at least one slot succeeded
 22. JSON output always includes a `reviews` array (one entry per slot, in input order) with `provider`, `model`, `elapsed_seconds`, and either `review` or `error`. When the panel has exactly one slot, the legacy top-level `review` / `provider` / `model` fields are also emitted so existing scripts don't break
@@ -86,7 +86,7 @@ Spec context: trust
 
 ● Reviewing changes against main ...
 
-[Claude reviews the diff with specs/trust/*.md loaded as context]
+[The active provider reviews the diff with specs/trust/*.md loaded as context]
 ```
 
 ### review — opt out of auto-detection
@@ -120,10 +120,10 @@ $ fledge review --json
   "file": null,
   "diff_stats": "...",
   "spec_context": ["trust"],
-  "reviews": [{"provider": "claude", "model": "opus-4.7", "elapsed_seconds": 5.2, "review": "..."}],
+  "reviews": [{"provider": "anthropic", "model": "claude-opus-4-8", "elapsed_seconds": 5.2, "review": "..."}],
   "review": "...",
-  "provider": "claude",
-  "model": "opus-4.7"
+  "provider": "anthropic",
+  "model": "claude-opus-4-8"
 }
 ```
 
@@ -144,10 +144,10 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --with-model ollama:qwen3
  1 file changed, 12 insertions(+), 2 deletions(-)
 Spec context: work
 
-✓ Reviewing changes against main across 3 models [claude (opus-4.7), ollama (gpt-oss:120b-cloud), ollama (qwen3-coder:480b-cloud)]: 18.4s
+✓ Reviewing changes against main across 3 models [anthropic (claude-opus-4-8), ollama (gpt-oss:120b-cloud), ollama (qwen3-coder:480b-cloud)]: 18.4s
 
 ═════════════════════════════════════════════════════════════
- claude (opus-4.7) — 5.2s
+ anthropic (claude-opus-4-8) — 5.2s
 ═════════════════════════════════════════════════════════════
 
 <review markdown>
@@ -167,7 +167,7 @@ Spec context: work
 
 ### review — panel comma-separated, exclude active
 ```
-$ fledge review --no-active --with-model claude:opus-4.7,ollama:gpt-oss:120b-cloud
+$ fledge review --no-active --with-model anthropic:claude-opus-4-8,ollama:gpt-oss:120b-cloud
 ```
 
 ### review — panel JSON
@@ -180,7 +180,7 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
   "diff_stats": "...",
   "spec_context": ["work"],
   "reviews": [
-    {"provider": "claude", "model": "opus-4.7", "elapsed_seconds": 5.2, "review": "..."},
+    {"provider": "anthropic", "model": "claude-opus-4-8", "elapsed_seconds": 5.2, "review": "..."},
     {"provider": "ollama", "model": "gpt-oss:120b-cloud", "elapsed_seconds": 12.1, "review": "..."}
   ]
 }
@@ -191,10 +191,10 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 
 | Error | When | Behavior |
 |-------|------|----------|
-| Claude CLI not installed | `claude --version` fails | Bail with install instructions |
+| Provider not configured / missing key | Active provider needs an API key that isn't set (e.g. `anthropic` with no `ANTHROPIC_API_KEY`, or an Ollama `-cloud` model with no key) | `build_provider` bails before any thread spawns, with API-key setup guidance (see `llm` spec) |
 | Not a git repo | Outside a git repository | Bail with message |
 | No changes | Empty diff against base | Bail with message |
-| Claude CLI error | Non-zero exit from claude | Bail with error |
+| Provider request fails | HTTP error, timeout, or bad response from the model | A 1-slot panel bails with the error; a multi-slot panel captures it per slot without aborting (see the last row) |
 | Invalid format | Unknown `--format` value | Bail with error listing valid formats |
 | `--with-specs <name>` not found | Named module has no spec | Bail with "loading spec bundle for '<name>'" context |
 | Invalid `--with-model` ref | Unknown provider, missing provider half, or empty entry | Bail at parse time before any LLM call (e.g. `--with-model gpt:4` → unknown provider) |
@@ -203,10 +203,10 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 
 ## Dependencies
 
-- Active LLM provider — Claude CLI or an Ollama-speaking endpoint (see `llm` spec)
+- Active LLM provider — reached over HTTP via the `llm` module (Anthropic, any OpenAI-compatible endpoint, or Ollama; no CLI binary required)
 - Git CLI — diff generation, `--name-only` for changed-file detection
 - `spec` module — `specs_for_changed_files` (auto-detect), `load_module_bundle` (full spec+companions)
-- `llm` module — provider dispatch and construction
+- `llm` module — provider dispatch and construction (`build_provider`, `ProviderKind`, `ProviderOverride`, `describe`)
 - `config` module — `ai.*` section
 - `std::thread`, `std::sync::Arc` — parallel panel execution (no new crate dependencies)
 
@@ -214,6 +214,7 @@ $ fledge review --with-model ollama:gpt-oss:120b-cloud --json
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 11 | 2026-07-02 | Correct stale Claude-CLI references left over from the 1.5.0 HTTP-provider migration (review finding H-5). Purpose, invariants (1, 7, 13, 17, 19), behavioral examples, error cases, and dependencies no longer describe a required `claude` CLI: reviews route through the `llm` provider abstraction over HTTP (Anthropic / OpenAI-compatible / Ollama), the provider is auto-detected by default, and `claude` is a deprecated alias of `anthropic`. Panel/JSON examples now show `anthropic (claude-opus-4-8)` instead of `claude (opus-4.7)`. Prose/doc-only; no code or export change |
 | 10 | 2026-04-27 | Fix nested-spec auto-detection (#291). Invariant 10 now describes resolution via each spec's actual parent directory rather than the assumed `<specs_dir>/<name>/`. Sub-specs sharing a directory (e.g. `specs/plugin/plugin-protocol.spec.md`) resolve correctly. Behavior change lives in the `spec` module; `review` only inherits |
 | 9 | 2026-04-26 | Doc sync, `review --json` (single + panel) behavioral examples updated to show the post-tier-D envelope shape. Single-vs-panel field-presence rule explicitly documented. No code change |
 | 8 | 2026-04-26 | Tier-D 1.0 envelope: `review --json` adds `schema_version: 1` and `action: "review"` at the top level. Existing fields (`base`, `file`, `diff_stats`, `spec_context`, `reviews`, single-model `provider`/`model`/`review`) all preserved (purely additive). Closes the gap where tier C (#274) only migrated plugins/lanes/templates |


### PR DESCRIPTION
## Summary

The 1.5.0 release (commit 9c39222) removed the Claude CLI and moved all AI commands to HTTP providers via the `corvid-ai` crate. The `ai`, `config`, and `llm` specs were updated then — but `review`, `ask`, and `doctor` still documented the **Claude CLI as a hard requirement**: `claude --version` install checks, default provider `"claude"`, "Claude reads the index", `--provider {claude,ollama}`. An agent (or human) reading these specs as the source of truth would be misled about how the AI commands actually work. Review finding **H-5**.

Prose-only correction to match the shipped reality:

- **review** (v10→11), **ask** (v6→7), **doctor** (v8→9)
- Purpose / Invariants / Error Cases / Behavioral Examples / Dependencies now describe the `llm` provider abstraction over HTTP (`anthropic` / OpenAI-compatible / `ollama`), **auto-detect** as the default, and `claude` as a deprecated alias of `anthropic` — no CLI binary, no shell-out.
- `doctor`'s AI section no longer claims a `claude --version` check; it probes the Ollama binary and the active provider's readiness (API-key check for anthropic/openai/gateways, `/api/tags` for Ollama).
- Panel/JSON examples use `anthropic (claude-opus-4-8)` instead of `claude (opus-4.7)`.

## Test Plan

- [x] `fledge spec check` clean (ask v7, doctor v9, review v11 — 0 errors, 0 warnings)
- [x] No `Exported Functions` / `Functions` / `Structs & Enums` rows changed — export-coverage is unaffected (verified against the removed-line diff); section structure and frontmatter keys preserved
- [x] Residual `claude` mentions are all legitimate: real model IDs (`claude-opus-4-8`), the deprecated-alias note, and preserved historical changelog rows

## Note

No code change — these three specs simply drifted from the code at the 1.5.0 migration. Each gains a v-bump Change Log row dated 2026-07-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
