### PR TITLE
Fix: two Medium panics — UTF-8 search truncation + broken pipe on --json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,16 @@ mod test_support;
 use cli::*;
 
 fn main() {
+    // Restore the default SIGPIPE disposition so fledge dies quietly when its
+    // stdout is closed early (e.g. `fledge introspect --json | head`), like a
+    // normal Unix tool. Rust ignores SIGPIPE by default, which otherwise turns a
+    // broken pipe into a panic ("failed printing to stdout: Broken pipe") and
+    // exit code 101.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     if let Err(e) = run() {
         eprintln!("{} {:#}", style("error:").red().bold(), e);
         std::process::exit(1);

--- a/src/plugin/search.rs
+++ b/src/plugin/search.rs
@@ -188,13 +188,16 @@ fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
 /// Unicode scalar count), appending an ellipsis when it overflows. Char-based
 /// so it never panics on a multi-byte UTF-8 boundary, unlike a byte slice, and
 /// uses `saturating_sub` so a zero width cannot underflow.
-fn truncate_display(line: String, max_width: usize) -> String {
+fn truncate_display(mut line: String, max_width: usize) -> String {
     if line.chars().count() > max_width {
-        let truncated: String = line.chars().take(max_width.saturating_sub(1)).collect();
-        format!("{truncated}…")
-    } else {
-        line
+        // Truncate in place at the char boundary and append the ellipsis,
+        // avoiding the extra String allocation of collect() + format!.
+        let keep = max_width.saturating_sub(1);
+        let end = line.char_indices().nth(keep).map_or(line.len(), |(i, _)| i);
+        line.truncate(end);
+        line.push('…');
     }
+    line
 }
 
 #[cfg(test)]

--- a/src/plugin/search.rs
+++ b/src/plugin/search.rs
@@ -158,11 +158,7 @@ fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
                 tier.label(),
                 r.description
             );
-            if line.len() > max_item_width {
-                format!("{}…", &line[..max_item_width - 1])
-            } else {
-                line
-            }
+            truncate_display(line, max_item_width)
         })
         .collect();
 
@@ -186,4 +182,45 @@ fn interactive_search(results: &[crate::search::SearchResult]) -> Result<()> {
     );
 
     super::install::install_action(Some(&chosen.full_name()), false, false, false, false)
+}
+
+/// Truncate a display line to at most `max_width` columns (approximated by
+/// Unicode scalar count), appending an ellipsis when it overflows. Char-based
+/// so it never panics on a multi-byte UTF-8 boundary, unlike a byte slice, and
+/// uses `saturating_sub` so a zero width cannot underflow.
+fn truncate_display(line: String, max_width: usize) -> String {
+    if line.chars().count() > max_width {
+        let truncated: String = line.chars().take(max_width.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    } else {
+        line
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_display;
+
+    #[test]
+    fn truncate_display_leaves_short_lines() {
+        let line = "short line".to_string();
+        assert_eq!(truncate_display(line.clone(), 40), line);
+    }
+
+    #[test]
+    fn truncate_display_does_not_panic_on_multibyte_boundary() {
+        // A run of 3-byte chars where the old byte cutoff `&line[..max-1]`
+        // landed mid-char and panicked with "not a char boundary".
+        let line = "日本語テストの説明文です".to_string();
+        let out = truncate_display(line, 5);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 5);
+    }
+
+    #[test]
+    fn truncate_display_zero_width_does_not_underflow() {
+        // max_item_width becomes 0 when the terminal is narrower than 5 cols;
+        // the old `max_item_width - 1` underflowed here.
+        assert_eq!(truncate_display("anything".to_string(), 0), "…");
+    }
 }


### PR DESCRIPTION
## Summary

Two Medium review findings, both "fledge should never panic":

- **UTF-8 search panic** — `fledge plugins search --interactive` truncated each select item with a byte-index slice `&line[..max_item_width - 1]`, which panics on a multi-byte UTF-8 boundary (e.g. a CJK description) and underflows when the terminal is < 5 columns. The sibling `templates`/`lanes` search already truncate by chars. Extracted a char-based `truncate_display` helper (`saturating_sub`, ellipsis) matching them.
- **Broken pipe on `--json`** — `main()` never reset SIGPIPE, so piping any `--json` output to an early-exit consumer (`fledge introspect --json | head`) panicked with `failed printing to stdout: Broken pipe` and exit 101. Now resets SIGPIPE to `SIG_DFL` at startup (unix-gated; `libc` is already a `cfg(unix)` dep) so fledge dies quietly like a normal Unix tool.

## Test Plan

- [x] 3 new unit tests: short-line passthrough, no panic on a CJK multi-byte boundary at width 5, no underflow at width 0
- [x] `clippy -D warnings` clean; `fmt --check` clean
- [x] Manual: `fledge introspect --json | head -1` no longer panics (exit via SIGPIPE, not 101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
