### PR TITLE
Fix: stop swallowing git errors in templates init + publish push (Medium)

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -145,9 +145,11 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
     )?;
 
     // Git init
-    if !opts.no_git {
-        init_git(&target_dir)?;
-    }
+    let git_initialized = if opts.no_git {
+        false
+    } else {
+        init_git(&target_dir)?
+    };
 
     let hooks_run = !opts.no_install && reqs_ok && !template.manifest.hooks.post_create.is_empty();
     // Post-create hooks for **local** templates: `--yes` is sufficient consent
@@ -172,7 +174,7 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
             None,
             &variables,
             &created_files,
-            !opts.no_git,
+            git_initialized,
             hooks_run,
         )?;
     } else {
@@ -359,9 +361,11 @@ fn run_remote(
         &created_files,
     )?;
 
-    if !opts.no_git {
-        init_git(&target_dir)?;
-    }
+    let git_initialized = if opts.no_git {
+        false
+    } else {
+        init_git(&target_dir)?
+    };
 
     // Remote templates: `--yes` alone is **not** consent for arbitrary shell
     // execution from a third-party source. Require `--trust-hooks` (or
@@ -387,7 +391,7 @@ fn run_remote(
             Some(remote_ref),
             &variables,
             &created_files,
-            !opts.no_git,
+            git_initialized,
             hooks_run,
         )?;
     } else {
@@ -673,7 +677,7 @@ fn resolve_template<'a>(
     }
 }
 
-fn init_git(dir: &Path) -> Result<()> {
+fn init_git(dir: &Path) -> Result<bool> {
     let output = std::process::Command::new("git")
         .args(["init"])
         .current_dir(dir)
@@ -713,24 +717,50 @@ fn init_git(dir: &Path) -> Result<()> {
     }
 
     // Stage all files
-    std::process::Command::new("git")
+    let add = std::process::Command::new("git")
         .args(["add", "."])
         .current_dir(dir)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .stderr(std::process::Stdio::piped())
+        .output()
         .context("running git add")?;
+    if !add.status.success() {
+        let stderr = String::from_utf8_lossy(&add.stderr);
+        eprintln!(
+            "{} git add failed, skipping initial commit: {}",
+            style("!").yellow().bold(),
+            stderr.trim()
+        );
+        return Ok(false);
+    }
 
     // Initial commit
-    std::process::Command::new("git")
+    let commit = std::process::Command::new("git")
         .args(["commit", "-m", "Initial commit from fledge"])
         .current_dir(dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
         .context("running git commit")?;
+    if !commit.status.success() {
+        // "nothing to commit" is benign: `git init` succeeded and the working
+        // tree is simply empty. Any other non-zero exit (failing hook,
+        // misconfigured identity, ...) is a real failure worth surfacing.
+        let stderr = String::from_utf8_lossy(&commit.stderr);
+        let stdout = String::from_utf8_lossy(&commit.stdout);
+        let nothing_to_commit =
+            stdout.contains("nothing to commit") || stderr.contains("nothing to commit");
+        if !nothing_to_commit {
+            eprintln!(
+                "{} git commit failed: {}",
+                style("!").yellow().bold(),
+                stderr.trim()
+            );
+            return Ok(false);
+        }
+    }
 
-    Ok(())
+    Ok(true)
 }
 
 fn generate_fledge_toml_if_missing(
@@ -854,6 +884,35 @@ ignore = ["template.toml"]
             .unwrap();
         let log = String::from_utf8(output.stdout).unwrap();
         assert!(log.contains("Initial commit from fledge"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_git_reports_false_when_commit_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("my-project");
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "hello").unwrap();
+
+        // Pre-create the repo with a pre-commit hook that always fails.
+        // git init is idempotent, so init_git re-inits and keeps the hook.
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&dir)
+            .output()
+            .unwrap();
+        let hooks = dir.join(".git/hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        let hook = hooks.join("pre-commit");
+        fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let initialized = init_git(&dir).unwrap();
+        assert!(
+            !initialized,
+            "a failed commit must report git_initialized = false"
+        );
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -178,7 +178,7 @@ pub fn run(mut opts: InitOptions) -> Result<()> {
             hooks_run,
         )?;
     } else {
-        print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+        print_summary(&opts.name, &target_dir, &created_files, git_initialized);
     }
 
     Ok(())
@@ -395,13 +395,13 @@ fn run_remote(
             hooks_run,
         )?;
     } else {
-        print_summary(&opts.name, &target_dir, &created_files, opts.no_git);
+        print_summary(&opts.name, &target_dir, &created_files, git_initialized);
     }
 
     Ok(())
 }
 
-fn print_summary(name: &str, target_dir: &Path, created_files: &[PathBuf], no_git: bool) {
+fn print_summary(name: &str, target_dir: &Path, created_files: &[PathBuf], git_initialized: bool) {
     println!();
     println!(
         "{} Created {} in {}",
@@ -415,7 +415,7 @@ fn print_summary(name: &str, target_dir: &Path, created_files: &[PathBuf], no_gi
     }
     println!();
     println!("  {} files created", created_files.len());
-    if !no_git {
+    if git_initialized {
         println!("  git repo initialized with initial commit");
     }
     println!();
@@ -734,30 +734,37 @@ fn init_git(dir: &Path) -> Result<bool> {
         return Ok(false);
     }
 
-    // Initial commit
+    // Only commit if something is staged. `git diff --cached --quiet` exits 0
+    // when the index is empty (benign — e.g. a template with no files) and
+    // non-zero when there are staged changes. This is locale-independent,
+    // unlike parsing git's "nothing to commit" message.
+    let staged = std::process::Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .current_dir(dir)
+        .status()
+        .context("checking for staged changes")?;
+    if staged.success() {
+        // Nothing staged; `git init` succeeded, so report success without a commit.
+        return Ok(true);
+    }
+
+    // Initial commit — any failure here (failing hook, missing identity, ...)
+    // is real, since we already confirmed there are staged changes.
     let commit = std::process::Command::new("git")
         .args(["commit", "-m", "Initial commit from fledge"])
         .current_dir(dir)
-        .stdout(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .output()
         .context("running git commit")?;
     if !commit.status.success() {
-        // "nothing to commit" is benign: `git init` succeeded and the working
-        // tree is simply empty. Any other non-zero exit (failing hook,
-        // misconfigured identity, ...) is a real failure worth surfacing.
         let stderr = String::from_utf8_lossy(&commit.stderr);
-        let stdout = String::from_utf8_lossy(&commit.stdout);
-        let nothing_to_commit =
-            stdout.contains("nothing to commit") || stderr.contains("nothing to commit");
-        if !nothing_to_commit {
-            eprintln!(
-                "{} git commit failed: {}",
-                style("!").yellow().bold(),
-                stderr.trim()
-            );
-            return Ok(false);
-        }
+        eprintln!(
+            "{} git commit failed: {}",
+            style("!").yellow().bold(),
+            stderr.trim()
+        );
+        return Ok(false);
     }
 
     Ok(true)

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -197,7 +197,7 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
         owner,
         repo
     );
-    let status = std::process::Command::new("git")
+    let output = std::process::Command::new("git")
         .args(["push", "-u", "origin", "main", "--force"])
         .current_dir(path)
         .env("GIT_CONFIG_COUNT", (existing + 1).to_string())
@@ -205,15 +205,26 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
         .env(format!("GIT_CONFIG_VALUE_{existing}"), &header_value)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
-        .status()
+        .output()
         .context("running git push")?;
 
-    if !status.success() {
-        bail!(
-            "Failed to push to {}/{}. Check your token has 'repo' scope.",
-            owner,
-            repo
-        );
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim();
+        if detail.is_empty() {
+            bail!(
+                "Failed to push to {}/{}. Check your token has 'repo' scope.",
+                owner,
+                repo
+            );
+        } else {
+            bail!(
+                "Failed to push to {}/{}. Check your token has 'repo' scope.\ngit error: {}",
+                owner,
+                repo,
+                detail
+            );
+        }
     }
 
     if needs_init {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -209,7 +209,10 @@ pub fn push_directory(path: &Path, owner: &str, repo: &str, token: &str) -> Resu
         .context("running git push")?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Redact the injected token before surfacing git's stderr — the push
+        // passes the GitHub token via http.extraheader, which git can echo back
+        // in error output (matches the redaction boundary used in remote.rs).
+        let stderr = crate::utils::redact_secrets(&String::from_utf8_lossy(&output.stderr));
         let detail = stderr.trim();
         if detail.is_empty() {
             bail!(


### PR DESCRIPTION
## Summary

Two error-swallowing bugs from the review:

- **`templates init` git status** — `init_git` ran `git add`/`git commit` with `.status()` and stderr nulled, and both call sites hardcoded `git_initialized: !opts.no_git`. So a failed `add`/`commit` (failing hook, missing identity, …) still reported `git_initialized: true` at exit 0. `init_git` now returns whether the commit actually succeeded — treating `"nothing to commit"` as benign so an empty tree isn't a false failure — warns to stderr on real failures, and the JSON envelope reports the true state.
- **publish push stderr** — the git push piped stderr but called `.status()`, never reading it: git's error detail was lost and a full stderr buffer could deadlock the child. Now uses `.output()` and surfaces the error on failure.

## Test Plan

- [x] New regression test: a failing `pre-commit` hook makes `init_git` return `false` (unix-gated); existing success-path tests still green (now `Ok(true)`)
- [x] Full unit suite green (891 passed); `clippy -D warnings` + `fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
