### PR TITLE
Update: fix stale provider --help text + SECURITY.md accuracy (Medium)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.0.x   | Yes              |
-| 0.17.x  | Best effort      |
-| < 0.17  | No               |
+| 1.6.x   | Yes              |
+| < 1.6   | Best effort      |
 
-Once 1.0 ships, only 1.0.x receives security fixes. Until then, the latest
-0.x release is the supported line.
+The latest 1.x release is the supported line; earlier releases receive
+best-effort fixes only.
 
 ## Reporting a Vulnerability
 
@@ -73,7 +72,8 @@ We aim to acknowledge reports within 48 hours and provide a fix or mitigation pl
   paths, and `cd /` all work. Treat granting `exec` the same as granting
   the plugin full access to your system as your user
 - Stdout/stderr from `exec` are each capped at 10 MB; plugin state at 1 MB
-  total / 64 KB per value / 256 keys; prompt/cancel timeouts at 5 minutes
+  total / 64 KB per value / 256 keys; `exec` commands default to a 30-second
+  timeout, capped at 5 minutes (300s)
 
 ### WASM Plugins
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,12 +40,12 @@ pub enum Commands {
         /// Omit the compact spec index from the prompt (saves tokens)
         #[arg(long)]
         no_spec_index: bool,
-        /// LLM provider: claude (default) or ollama. Overrides
+        /// LLM provider (default: auto-detected). Overrides
         /// FLEDGE_AI_PROVIDER and ai.provider in config.
         #[arg(long, value_name = "NAME", value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Model name. Overrides FLEDGE_AI_MODEL and
-        /// ai.{claude,ollama}.model in config.
+        /// ai.<provider>.model in config.
         #[arg(long, value_name = "MODEL")]
         model: Option<String>,
     },
@@ -148,7 +148,7 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
         /// Model name for the active provider (overrides FLEDGE_AI_MODEL
-        /// and ai.{claude,ollama}.model in config)
+        /// and ai.<provider>.model in config)
         #[arg(short, long)]
         model: Option<String>,
         /// Custom review focus prompt (appended to default instructions)
@@ -165,14 +165,14 @@ pub enum Commands {
         /// Disable auto-detection of specs based on files in the diff
         #[arg(long)]
         no_auto_specs: bool,
-        /// LLM provider: claude (default) or ollama. Overrides
+        /// LLM provider (default: auto-detected). Overrides
         /// FLEDGE_AI_PROVIDER and ai.provider in config.
         #[arg(long, value_name = "NAME", value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Add another model to the review panel — runs in parallel against
         /// the same diff + spec context. Format: `provider[:model]`, e.g.
-        /// `ollama:gpt-oss:120b-cloud` or just `claude` to use the active
-        /// claude config. Repeatable and comma-separated.
+        /// `ollama:gpt-oss:120b-cloud` or just `anthropic` to use the active
+        /// provider config. Repeatable and comma-separated.
         #[arg(long, value_name = "REF")]
         with_model: Vec<String>,
         /// Drop the active config (--provider/--model or
@@ -447,7 +447,7 @@ pub enum WorkSubcommand {
         /// Generate commit message via AI from the staged diff
         #[arg(long)]
         ai: bool,
-        /// Override AI provider for --ai (claude or ollama)
+        /// Override AI provider for --ai (default: auto-detected)
         #[arg(long, value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Override AI model for --ai
@@ -490,7 +490,7 @@ pub enum AiSubcommand {
     },
     /// List available models for the active (or specified) provider
     Models {
-        /// Provider: claude or ollama (default: active provider)
+        /// Provider (default: active/auto-detected provider)
         #[arg(long, value_name = "NAME", value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Filter models by substring (case-insensitive)
@@ -504,7 +504,7 @@ pub enum AiSubcommand {
     /// are omitted
     #[command(name = "use")]
     Use {
-        /// Provider: claude or ollama
+        /// Provider (default: active provider)
         #[arg(value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Model name (e.g. qwen3-coder:480b-cloud)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,7 +172,7 @@ pub enum Commands {
         /// Add another model to the review panel — runs in parallel against
         /// the same diff + spec context. Format: `provider[:model]`, e.g.
         /// `ollama:gpt-oss:120b-cloud` or just `anthropic` to use the active
-        /// provider config. Repeatable and comma-separated.
+        /// anthropic config. Repeatable and comma-separated.
         #[arg(long, value_name = "REF")]
         with_model: Vec<String>,
         /// Drop the active config (--provider/--model or
@@ -504,7 +504,7 @@ pub enum AiSubcommand {
     /// are omitted
     #[command(name = "use")]
     Use {
-        /// Provider (default: active provider)
+        /// Provider (interactive prompt if omitted)
         #[arg(value_parser = ["anthropic", "openai", "openrouter", "gemini", "deepseek", "groq", "mistral", "xai", "together", "ollama", "claude"])]
         provider: Option<String>,
         /// Model name (e.g. qwen3-coder:480b-cloud)

--- a/src/snapshots/fledge__introspect__tests__introspect_schema.snap
+++ b/src/snapshots/fledge__introspect__tests__introspect_schema.snap
@@ -74,7 +74,7 @@ expression: output
             {
               "name": "provider",
               "long": "provider",
-              "help": "Provider: claude or ollama (default: active provider)",
+              "help": "Provider (default: active/auto-detected provider)",
               "required": false,
               "takes_value": true,
               "value_name": "NAME",
@@ -118,7 +118,7 @@ expression: output
           "args": [
             {
               "name": "provider",
-              "help": "Provider: claude or ollama",
+              "help": "Provider (default: active provider)",
               "required": false,
               "takes_value": true,
               "value_name": "PROVIDER",
@@ -189,7 +189,7 @@ expression: output
         {
           "name": "provider",
           "long": "provider",
-          "help": "LLM provider: claude (default) or ollama. Overrides FLEDGE_AI_PROVIDER and ai.provider in config",
+          "help": "LLM provider (default: auto-detected). Overrides FLEDGE_AI_PROVIDER and ai.provider in config",
           "required": false,
           "takes_value": true,
           "value_name": "NAME",
@@ -198,7 +198,7 @@ expression: output
         {
           "name": "model",
           "long": "model",
-          "help": "Model name. Overrides FLEDGE_AI_MODEL and ai.{claude,ollama}.model in config",
+          "help": "Model name. Overrides FLEDGE_AI_MODEL and ai.<provider>.model in config",
           "required": false,
           "takes_value": true,
           "value_name": "MODEL",
@@ -1713,7 +1713,7 @@ expression: output
           "name": "model",
           "long": "model",
           "short": "m",
-          "help": "Model name for the active provider (overrides FLEDGE_AI_MODEL and ai.{claude,ollama}.model in config)",
+          "help": "Model name for the active provider (overrides FLEDGE_AI_MODEL and ai.<provider>.model in config)",
           "required": false,
           "takes_value": true,
           "value_name": "MODEL",
@@ -1758,7 +1758,7 @@ expression: output
         {
           "name": "provider",
           "long": "provider",
-          "help": "LLM provider: claude (default) or ollama. Overrides FLEDGE_AI_PROVIDER and ai.provider in config",
+          "help": "LLM provider (default: auto-detected). Overrides FLEDGE_AI_PROVIDER and ai.provider in config",
           "required": false,
           "takes_value": true,
           "value_name": "NAME",
@@ -1767,7 +1767,7 @@ expression: output
         {
           "name": "with_model",
           "long": "with-model",
-          "help": "Add another model to the review panel — runs in parallel against the same diff + spec context. Format: `provider[:model]`, e.g. `ollama:gpt-oss:120b-cloud` or just `claude` to use the active claude config. Repeatable and comma-separated",
+          "help": "Add another model to the review panel — runs in parallel against the same diff + spec context. Format: `provider[:model]`, e.g. `ollama:gpt-oss:120b-cloud` or just `anthropic` to use the active provider config. Repeatable and comma-separated",
           "required": false,
           "takes_value": true,
           "value_name": "REF",
@@ -2674,7 +2674,7 @@ expression: output
             {
               "name": "provider",
               "long": "provider",
-              "help": "Override AI provider for --ai (claude or ollama)",
+              "help": "Override AI provider for --ai (default: auto-detected)",
               "required": false,
               "takes_value": true,
               "value_name": "PROVIDER",

--- a/src/snapshots/fledge__introspect__tests__introspect_schema.snap
+++ b/src/snapshots/fledge__introspect__tests__introspect_schema.snap
@@ -118,7 +118,7 @@ expression: output
           "args": [
             {
               "name": "provider",
-              "help": "Provider (default: active provider)",
+              "help": "Provider (interactive prompt if omitted)",
               "required": false,
               "takes_value": true,
               "value_name": "PROVIDER",
@@ -1767,7 +1767,7 @@ expression: output
         {
           "name": "with_model",
           "long": "with-model",
-          "help": "Add another model to the review panel — runs in parallel against the same diff + spec context. Format: `provider[:model]`, e.g. `ollama:gpt-oss:120b-cloud` or just `anthropic` to use the active provider config. Repeatable and comma-separated",
+          "help": "Add another model to the review panel — runs in parallel against the same diff + spec context. Format: `provider[:model]`, e.g. `ollama:gpt-oss:120b-cloud` or just `anthropic` to use the active anthropic config. Repeatable and comma-separated",
           "required": false,
           "takes_value": true,
           "value_name": "REF",


### PR DESCRIPTION
## Summary

Doc-accuracy drift caught by the review (companion to the H-5 spec fixes):

- **`src/cli.rs` help text** — 8 `--help` doc comments still described the pre-1.5.0 model: "LLM provider: claude (default) or ollama" and "ai.{claude,ollama}.model". The default is now **auto-detect** and the provider set is broader. Reworded to match. The `value_parser` arrays are unchanged — `claude` is still accepted as a **deprecated alias**, so it stays in the list.
- **SECURITY.md** — Supported Versions was stuck at `1.0.x` with "Once 1.0 ships…" prose while the project is at **1.6.0** (updated to `1.6.x`). Separately, the "prompt/cancel timeouts at 5 minutes" line was inaccurate — there is no prompt/cancel timeout in the code; the real 5-minute limit is `MAX_EXEC_TIMEOUT` on **exec** commands (default 30s, capped at 300s), so I restated it accurately (verified against `src/protocol/exec.rs`).

## Test Plan

- [x] `introspect` JSON snapshot updated — diff is exactly the 8 help-text edits, no structural change
- [x] Full unit suite green (890 passed); `clippy -D warnings` + `fmt --check` clean

## Follow-up (not in this PR)

Docs hardcode `~/.config/fledge/config.toml` in ~8 places; on macOS/Windows the code uses the platform config dir. That needs per-OS wording across the docs site and is better as its own change — filing as an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
