### PR TITLE
Fix: retry formula-convergence check for Contents API propagation lag

### DIFF
--- a/.github/workflows/post-release-formula.yml
+++ b/.github/workflows/post-release-formula.yml
@@ -138,13 +138,22 @@ jobs:
           NEW_VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          # Read the just-pushed formula via the Contents API (not the CDN, which
-          # can lag) and assert the version actually took effect. This turns a
-          # silent no-op push into a red run instead of leaving brew users stale.
-          formula="$(gh api repos/CorvidLabs/homebrew-tap/contents/Formula/fledge.rb --jq '.content' | base64 --decode)"
-          tap_version="$(printf '%s' "$formula" | sed -n 's/^[[:space:]]*version[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+          # Assert the pushed formula version actually took effect. GitHub's
+          # Contents API can serve a cached blob for several seconds after a
+          # push, so poll with a short backoff before declaring failure —
+          # otherwise a sync that DID land false-fails as "did not take effect"
+          # (observed on the v1.6.0 backfill). This still turns a genuine no-op
+          # push into a red run, just without the propagation race.
+          tap_version=""
+          for attempt in 1 2 3 4 5 6; do
+            formula="$(gh api repos/CorvidLabs/homebrew-tap/contents/Formula/fledge.rb --jq '.content' | base64 --decode)"
+            tap_version="$(printf '%s' "$formula" | sed -n 's/^[[:space:]]*version[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+            [ "$tap_version" = "$NEW_VERSION" ] && break
+            echo "Formula still reports '$tap_version' (attempt $attempt/6); waiting for Contents API to propagate..."
+            sleep 10
+          done
           if [ "$tap_version" != "$NEW_VERSION" ]; then
-            echo "::error::homebrew-tap Formula/fledge.rb reports '$tap_version', expected '$NEW_VERSION' — formula sync did not take effect."
+            echo "::error::homebrew-tap Formula/fledge.rb reports '$tap_version', expected '$NEW_VERSION' after retries — formula sync did not take effect."
             exit 1
           fi
           echo "Verified homebrew-tap Formula/fledge.rb at v$NEW_VERSION."


### PR DESCRIPTION
## Summary

The "Verify channels converged" step (added in #435) read the just-pushed Homebrew-tap formula via the GitHub **Contents API** and asserted the version immediately. That API serves a **cached blob for several seconds** after a push, so a sync that *actually landed* false-failed as "formula sync did not take effect".

Observed live on the **v1.6.0 backfill**: the sync step pushed `chore: update formula to v1.6.0` and the tap formula is now `1.6.0`, yet the verify step read a stale `1.4.3` and exited 1 — a red run for a successful sync.

Fix: poll the Contents API up to **6× with a 10s backoff** before declaring failure. A genuine no-op push still goes red; only the propagation race is removed.

## Test Plan

- [x] YAML validates (`yaml.safe_load`)
- [x] Verified against the real failure: the tap **did** converge to 1.6.0 (commit `chore: update formula to v1.6.0`, 14:33); only the eager read failed
- [ ] Confirmed green on the next release / `workflow_dispatch` backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi