### PR TITLE
Fix: pluralize doctor working-tree file count correctly

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -375,11 +375,13 @@ fn check_git(dir: &Path) -> Section {
                 fix: None,
             });
         } else {
+            let count = changed.len();
+            let noun = if count == 1 { "file" } else { "files" };
             checks.push(CheckResult {
                 name: "working tree".to_string(),
                 status: CheckStatus::Error,
                 version: None,
-                detail: Some(format!("uncommitted changes ({} files)", changed.len())),
+                detail: Some(format!("uncommitted changes ({count} {noun})")),
                 fix: Some("git add . && git commit".to_string()),
             });
         }


### PR DESCRIPTION
## Summary
- `fledge doctor` previously always printed "uncommitted changes (N files)", so a single change read as "(1 files)".
- The working-tree check now selects the singular noun ("file") when exactly one file changed and the plural ("files") otherwise.

## Test Plan
- [x] `cargo fmt`
- [x] `cargo build`
- [x] `cargo clippy --bin fledge -- -D warnings` (clean)
- [x] `cargo test --bin fledge doctor` (9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #453

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi