### PR TITLE
Add: trailing success confirmation with elapsed time to `fledge run` (human output)

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -343,14 +343,23 @@ fn execute_task(
             style(format!("Running task: {name}")).bold()
         );
 
+        let started = std::time::Instant::now();
         let status = command
             .status()
             .with_context(|| format!("running task '{name}'"))?;
+        let elapsed = started.elapsed();
 
         if !status.success() {
             let code = status.code().unwrap_or(1);
             bail!("Task '{}' failed with exit code {}", name, code);
         }
+
+        println!(
+            "{} {} ({:.1}s)",
+            style("✅").green().bold(),
+            style(name).bold(),
+            elapsed.as_secs_f64()
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- The human (non-JSON) path of `fledge run <task>` previously printed only `▶️ Running task: <name>` with no completion signal.
- Adds a trailing `✅ <task> (0.Ns)` line, timed with `std::time::Instant` around the command's `.status()` call, printed only on success (a failing task still bails before the line, as before).
- Only the human path in `execute_task` (src/run.rs) changes. The `--json` `run_task` envelope is untouched and stays byte-identical, so its tests/snapshots remain green.

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin fledge -- -D warnings` clean
- [x] `cargo test --bin fledge run` (72 passed)
- [x] `cargo test --test run` (20 passed, incl. `cli_run_task_json_emits_envelope`)
- [x] Manual smoke test: human output shows the new `✅ hello (0.0s)` line; `--json` output shows the unchanged 8-key envelope with no extra line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #455

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi