### PR TITLE
Update: enforce Cargo.lock in CI with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --verbose
+      - run: cargo test --verbose --locked
 
   lint:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build fledge
-        run: cargo build --release
+        run: cargo build --release --locked
       - name: Add fledge to PATH (unix)
         if: runner.os != 'Windows'
         run: echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
-      - run: cargo test --verbose
+      - run: cargo test --verbose --locked
 
   build:
     needs: [test]
@@ -66,10 +66,10 @@ jobs:
         if: matrix.cross == true
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --locked
       - name: Build (native)
         if: matrix.cross != true
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --locked
       - name: Rename binary
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- Now that `Cargo.lock` is committed (#436), make CI enforce it by adding `--locked` to the cargo build/test invocations.
- `.github/workflows/ci.yml`: `cargo test --verbose --locked` (test job) and `cargo build --release --locked` (integration job).
- `.github/workflows/release.yml`: `cargo test --verbose --locked` (test gate) and `cargo build --release --target ... --locked` (both cross and native build steps).
- Deliberately left untouched: the `audit` job (rustsec/audit-check manages its own lockfile via `cargo generate-lockfile`) and `cargo fmt`/`cargo clippy` steps.

Closes #450

## Test Plan
- [x] YAML validated as well-formed (`yaml.safe_load` on both files).
- [x] Diff is minimal: 5 insertions, 5 deletions across the two workflow files.
- [ ] CI runs `--locked` on the PR; a stale `Cargo.lock` would now fail the build/test steps.

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi