### PR TITLE
Update: make config.toml path platform-aware in docs

### DIFF
--- a/site/src/content/docs/reference/cli-reference.md
+++ b/site/src/content/docs/reference/cli-reference.md
@@ -345,7 +345,7 @@ fledge ai <status|models|use> [OPTIONS]
 
 - `status [--json]`: Show active provider, model, and host with a `(from env / config / default)` source tag on each value
 - `models --provider {ollama,anthropic,openai,...} [--search <q>] [--json]`: Model list (Ollama hits `/api/tags`; Anthropic returns curated ids; OpenAI-compatible gateways aren't enumerable)
-- `use [provider] [model]`: Interactive picker (live model list for Ollama) or fully scriptable via positional args. Writes to `~/.config/fledge/config.toml`
+- `use [provider] [model]`: Interactive picker (live model list for Ollama) or fully scriptable via positional args. Writes to the global `config.toml` (platform config dir; see [Configuration](./configuration.md))
 
 ```bash
 fledge ai status                                  # who's active and why
@@ -677,7 +677,11 @@ fledge plugins audit --json                             # machine-readable audit
 
 ### fledge config `<action>`
 
-Manage `~/.config/fledge/config.toml`.
+Manage the global `config.toml`. Its location follows the platform config
+directory (`dirs::config_dir()`): `~/Library/Application Support/fledge/config.toml`
+on macOS, `~/.config/fledge/config.toml` on Linux, `%APPDATA%\fledge\config.toml`
+on Windows. Run `fledge config path` to print the resolved location, or see
+[Configuration](./configuration.md).
 
 ```text
 fledge config <get|set|unset|add|remove|edit|list|path|init>

--- a/site/src/content/docs/reference/doctor.md
+++ b/site/src/content/docs/reference/doctor.md
@@ -20,7 +20,7 @@ Doctor reports four sections:
 
 ### `fledge`
 
-- `fledge config`. Does `~/.config/fledge/config.toml` parse cleanly?
+- `fledge config`. Does the global `config.toml` parse cleanly? (Its path follows the platform config dir; see [Configuration](./configuration.md).)
 
 ### `Git`
 


### PR DESCRIPTION
## Summary

Docs hardcoded the Linux `~/.config/fledge/config.toml` path, but the code resolves the config file via `dirs::config_dir()` (macOS `~/Library/Application Support/fledge/`, Windows `%APPDATA%\fledge\`, Linux `~/.config/fledge/`). This adds brief platform-aware clarity at the most prominent occurrences, reusing SECURITY.md's "File Locations" table wording.

Changes:
- `site/src/content/docs/reference/cli-reference.md`
  - `fledge config <action>` section: replaced the single hardcoded Linux path with the full platform mapping (macOS/Linux/Windows) plus a pointer to `fledge config path` (a real subcommand) and the Configuration page.
  - `fledge ai use`: no longer hardcodes the Linux path; now says "the global `config.toml` (platform config dir; see Configuration)".
- `site/src/content/docs/reference/doctor.md`
  - `fledge config` check bullet: brief platform-aware note linking to Configuration.

Deliberately left as-is (already correct or intentionally minimal per issue's "don't rewrite everything"):
- `configuration.md` and `plugins.md` already carry the full platform table.
- `fledge-toml.md` mentions are cross-reference links to the canonical Configuration page.
- `template-authoring.md` occurrence is an illustrative code-block comment.

## Test Plan
- [x] Docs-only change; no build required.
- [x] Grepped `site/src/content/docs`, `docs/`, and `README.md` for `.config/fledge` to locate all occurrences (README/docs had none).
- [x] Verified `fledge config path` exists (src/config_cmds.rs:262, `ConfigAction::Path`).
- [x] Confirmed both edited files link to `./configuration.md`, which resides in the same `reference/` directory.
- [x] Platform-mapping wording matches the existing SECURITY.md / configuration.md tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #449

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi