### PR TITLE
Update: make wasmtime deps optional behind a `wasm` feature (on by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,14 @@ sha2 = "0.11.0"
 base64 = "0.22"
 notify = "7"
 shell-words = "1.1.1"
-wasmtime = "46.0.1"
-wasmtime-wasi = "46.0.1"
+wasmtime = { version = "46.0.1", optional = true }
+wasmtime-wasi = { version = "46.0.1", optional = true }
+
+[features]
+default = ["wasm"]
+# Sandboxed WASM plugin runtime (wasmtime + wasmtime-wasi). On by default;
+# disable with `--no-default-features` to drop the wasmtime dependency tree.
+wasm = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [build-dependencies]
 toml = "0.8"

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -646,24 +646,36 @@ pub(crate) fn install_plugin(
     }
 
     if manifest.plugin.is_wasm() {
-        for cmd in &manifest.commands {
-            let wasm_path = plugin_dir.join(&cmd.binary);
-            if wasm_path.exists() {
-                println!(
-                    "  {} Pre-compiling WASM module...",
-                    style("▶").cyan().bold()
-                );
-                super::wasm::compile_and_cache(&wasm_path)?;
-            } else {
-                remove_plugin_path(&plugin_dir).ok();
-                bail!(
-                    "WASM binary '{}' not found after build.\n  \
-                     Check that the build hook produces a .wasm file at the path declared in plugin.toml.\n  \
-                     Expected: {}",
-                    cmd.binary,
-                    wasm_path.display()
-                );
+        #[cfg(feature = "wasm")]
+        {
+            for cmd in &manifest.commands {
+                let wasm_path = plugin_dir.join(&cmd.binary);
+                if wasm_path.exists() {
+                    println!(
+                        "  {} Pre-compiling WASM module...",
+                        style("▶").cyan().bold()
+                    );
+                    super::wasm::compile_and_cache(&wasm_path)?;
+                } else {
+                    remove_plugin_path(&plugin_dir).ok();
+                    bail!(
+                        "WASM binary '{}' not found after build.\n  \
+                         Check that the build hook produces a .wasm file at the path declared in plugin.toml.\n  \
+                         Expected: {}",
+                        cmd.binary,
+                        wasm_path.display()
+                    );
+                }
             }
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            remove_plugin_path(&plugin_dir).ok();
+            bail!(
+                "Plugin '{}' requires the WASM runtime, which was not compiled in \
+                 (rebuild with --features wasm).",
+                manifest.plugin.name
+            );
         }
     }
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -17,6 +17,7 @@ mod run_plugin;
 mod search;
 mod update;
 mod validate;
+#[cfg(feature = "wasm")]
 mod wasm;
 
 #[cfg(test)]

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -57,27 +57,38 @@ pub(super) fn run_plugin_cmd(name: &str, args: &[String]) -> Result<()> {
         resolve_protocol_info(name)?
     {
         if runtime.as_deref() == Some("wasm") {
-            let manifest_path = plugin_dir.join("plugin.toml");
-            let content = std::fs::read_to_string(&manifest_path)
-                .context("reading plugin.toml for WASM plugin")?;
-            let manifest: PluginManifest =
-                toml::from_str(&content).context("parsing plugin.toml for WASM plugin")?;
-            let wasm_binary = manifest
-                .commands
-                .iter()
-                .find(|c| c.name == name)
-                .or_else(|| manifest.commands.first())
-                .map(|c| plugin_dir.join(&c.binary))
-                .ok_or_else(|| anyhow::anyhow!("WASM plugin has no commands defined"))?;
+            #[cfg(feature = "wasm")]
+            {
+                let manifest_path = plugin_dir.join("plugin.toml");
+                let content = std::fs::read_to_string(&manifest_path)
+                    .context("reading plugin.toml for WASM plugin")?;
+                let manifest: PluginManifest =
+                    toml::from_str(&content).context("parsing plugin.toml for WASM plugin")?;
+                let wasm_binary = manifest
+                    .commands
+                    .iter()
+                    .find(|c| c.name == name)
+                    .or_else(|| manifest.commands.first())
+                    .map(|c| plugin_dir.join(&c.binary))
+                    .ok_or_else(|| anyhow::anyhow!("WASM plugin has no commands defined"))?;
 
-            return super::wasm::run_wasm_plugin(
-                &wasm_binary,
-                args,
-                &plugin_name,
-                &plugin_version,
-                &plugin_dir,
-                &capabilities,
-            );
+                return super::wasm::run_wasm_plugin(
+                    &wasm_binary,
+                    args,
+                    &plugin_name,
+                    &plugin_version,
+                    &plugin_dir,
+                    &capabilities,
+                );
+            }
+            #[cfg(not(feature = "wasm"))]
+            {
+                bail!(
+                    "Plugin '{}' requires the WASM runtime, which was not compiled in \
+                     (rebuild with --features wasm).",
+                    name
+                );
+            }
         }
 
         return crate::protocol::run_protocol_plugin(

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -15,10 +15,20 @@ mod ui;
 #[cfg(test)]
 mod tests;
 
+// These re-exports exist solely for the WASM runtime's host bridge
+// (`crate::protocol::*` calls in `plugin::wasm`). Within this module the
+// handlers are reached via their submodule paths, so when the `wasm` feature
+// is disabled the re-exports would be unused — gate them to keep that build
+// warning-free.
+#[cfg(feature = "wasm")]
 pub(crate) use detect::detect_project_context;
+#[cfg(feature = "wasm")]
 pub(crate) use exec::handle_exec;
+#[cfg(feature = "wasm")]
 pub(crate) use metadata::handle_metadata;
+#[cfg(feature = "wasm")]
 pub(crate) use store::{handle_load, handle_store};
+#[cfg(feature = "wasm")]
 pub(crate) use ui::handle_log;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `wasmtime` and `wasmtime-wasi` were unconditional dependencies (~36 transitive crates) purely for the optional sandboxed WASM plugin runtime. Marked both `optional = true` and added a `[features]` block with `default = ["wasm"]` and `wasm = ["dep:wasmtime", "dep:wasmtime-wasi"]`. Default behavior is unchanged; `--no-default-features` drops the entire wasmtime dependency tree.
- Cfg-gated every wasm code path on `feature = "wasm"`:
  - `mod wasm;` in `src/plugin/mod.rs`
  - the WASM run-time dispatch in `src/plugin/run_plugin.rs`
  - the WASM pre-compile step in `src/plugin/install.rs`
- For the disabled path, both the run and install sites now `bail!` with a clear error: `"Plugin '<name>' requires the WASM runtime, which was not compiled in (rebuild with --features wasm)."`
- Gated the `protocol` re-exports (`detect_project_context`, `handle_exec`, `handle_metadata`, `handle_load`, `handle_store`, `handle_log`) that exist solely for the wasm host bridge, so the no-default-features build stays warning-free (they are the only external consumers).

## Test Plan
- [x] `cargo build` (default, wasm ON) — clean
- [x] `cargo build --no-default-features` — clean, warning-free
- [x] `cargo tree -i wasmtime`: present with default features, absent with `--no-default-features`
- [x] `cargo test --bin fledge` (default) — 897 passed, 0 failed
- [x] `cargo clippy --bin fledge -- -D warnings` — clean (also verified with `--no-default-features`)
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #445

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi