### PR TITLE
Fix: isolate cli_config_init_default via FLEDGE_CONFIG_DIR (#447 HOME-isolation)

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -613,9 +613,35 @@ fn cli_config_add_remove_list_key() {
 
 #[test]
 fn cli_config_init_default() {
-    let output = run_fledge(&["config", "init"]);
-    // Should succeed (creates default config if none exists, or reports it already exists)
-    let _ = output.status;
+    // Isolate to a fresh tempdir via FLEDGE_CONFIG_DIR so the test never
+    // touches the developer's real ~/.config/fledge/config.toml. Setting the
+    // env var on the child process (not the test process) keeps this safe
+    // under parallel test execution.
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("fledge-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let output = Command::new(cargo_bin())
+        .args(["config", "init"])
+        .env("FLEDGE_CONFIG_DIR", &config_dir)
+        .output()
+        .unwrap();
+
+    // A fresh dir has no config yet, so init creates the default and succeeds.
+    assert!(
+        output.status.success(),
+        "config init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("Created"),
+        "expected creation message, got: {stdout}"
+    );
+    assert!(
+        config_dir.join("config.toml").exists(),
+        "config init did not write config.toml into the isolated dir"
+    );
 }
 
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `cli_config_init_default` (tests/main.rs) previously ran `fledge config init` against the developer's real config path — it could write a real `~/.config/fledge/config.toml` (or fail if one already existed) and asserted nothing (`let _ = output.status;`).
- Rewrote it to be hermetic: point the child process at a fresh `TempDir` via the `FLEDGE_CONFIG_DIR` env var (honored by `Config::config_path()` in src/config.rs), then add real assertions — the command succeeds, prints a "Created" message, and actually writes `config.toml` into the isolated dir.
- Setting the env var on the spawned child (not the test process) keeps this safe under parallel test execution; no serial guard needed.

## Scope notes
- This is the config-writing / HOME-isolation facet of #447 only. The other config-writing integration tests (`cli_config_set_and_get_roundtrip`, `cli_config_add_remove_list_key`) already isolate via `FLEDGE_CONFIG_DIR`; the unknown-key tests fail before saving so they never write. The `src/config.rs` unit tests use in-memory TOML or explicit `save_to(tempdir)`, so none touch the real path.
- No production code changed.

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin fledge --tests -- -D warnings` clean
- [x] `cargo test --lib` / `--bin fledge` (897 pass) and all integration binaries except spec pass; `cli_config_init_default` passes
- [x] Verified the two `tests/spec.rs` spec-check failures are pre-existing and environmental (installed `specsync` v4.6.0 emits a different `spec check --json` envelope) — they reproduce on the base branch via `git stash` and are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi

Closes #447