### PR TITLE
Fix: route plugin lifecycle-hook progress to stderr so --json stays clean

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -336,7 +336,9 @@ pub fn run_lifecycle_hook(event: &str) -> Result<()> {
             _ => &None,
         };
         if let Some(hook_cmd) = hook {
-            println!(
+            // Progress goes to stderr so it never corrupts a `--json` stdout
+            // envelope (lifecycle hooks fire mid-command, e.g. `work start --json`).
+            eprintln!(
                 "  {} {} ({})",
                 style("▶️").cyan().bold(),
                 style(format!("Plugin hook: {event}")).dim(),

--- a/src/plugin/run_plugin.rs
+++ b/src/plugin/run_plugin.rs
@@ -135,7 +135,9 @@ pub(super) fn resolve_plugin_source_dir(bin_path: &Path) -> Option<PathBuf> {
 }
 
 pub(super) fn run_hook(plugin_dir: &Path, hook: &str, event: &str) -> Result<()> {
-    println!(
+    // Progress to stderr — hooks run during `--json` commands (e.g. work start),
+    // where stdout must stay a clean JSON envelope.
+    eprintln!(
         "  {} Running {} hook...",
         style("▶️").cyan().bold(),
         style(event).dim()


### PR DESCRIPTION
## Summary

Plugin lifecycle hooks fire mid-command (`work start`, `work push`, `init`) — including in `--json` mode. Two progress banners were printed to **stdout**:
- `run_lifecycle_hook` → `"  ▶️ Plugin hook: <event> (<plugin>)"` (src/plugin/mod.rs)
- `run_hook` → `"  ▶️ Running <event> hook..."` (src/plugin/run_plugin.rs)

So when a hook fired during `work start --json`, those lines **prepended non-JSON to the envelope**, breaking `jq`/serde parsing. Found by a dogfooding sweep.

Both are progress messages → moved to **stderr**, matching every other status line. `--json` stdout now carries only the envelope; humans still see the progress on stderr.

## Test Plan
- [x] `cargo build` / `cargo clippy --bin fledge -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --bin fledge plugin` — 178 passed
- [x] `work start --json` in a temp repo emits valid JSON with the documented keys (`schema_version, action, branch, base, type, prefix, issue`)
- [x] No test asserted the banners on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi