### PR TITLE
Fix: ai use error names positional args; ai status Host-line spacing

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -176,9 +176,9 @@ fn status(json: bool) -> Result<()> {
     }
     if let (Some(h), Some(src)) = (&report.host, &report.host_source) {
         let cloud_note = if report.cloud_routed == Some(true) {
-            " (auto-routed to cloud)".to_string()
+            "(auto-routed to cloud)".to_string()
         } else {
-            format!(" (from {})", src.label())
+            format!("(from {})", src.label())
         };
         println!(
             "      {} {} {}",
@@ -554,7 +554,10 @@ fn use_provider(provider: Option<String>, model: Option<String>) -> Result<()> {
     let kind = match provider {
         Some(p) => ProviderKind::parse(&p)?,
         None => {
-            utils::require_interactive("provider")?;
+            utils::require_interactive_hint(
+                "pass a provider and model, e.g. `fledge ai use ollama qwen3-coder:480b-cloud` \
+                 or `fledge ai use anthropic claude-sonnet-4-6`",
+            )?;
             // Ollama first (the default), then the API providers in AUTO_ORDER.
             let items: Vec<&str> = crate::llm::AUTO_ORDER.iter().map(|k| k.as_str()).collect();
             let selection = Select::with_theme(&ColorfulTheme::default())

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -555,7 +555,7 @@ fn use_provider(provider: Option<String>, model: Option<String>) -> Result<()> {
         Some(p) => ProviderKind::parse(&p)?,
         None => {
             utils::require_interactive_hint(
-                "pass a provider and model, e.g. `fledge ai use ollama qwen3-coder:480b-cloud` \
+                "Pass a provider and model, e.g. `fledge ai use ollama qwen3-coder:480b-cloud` \
                  or `fledge ai use anthropic claude-sonnet-4-6`",
             )?;
             // Ollama first (the default), then the API providers in AUTO_ORDER.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,13 +80,14 @@ pub fn require_interactive_hint(how_to_provide: &str) -> anyhow::Result<()> {
     if is_non_interactive() {
         anyhow::bail!(
             "This command requires interactive input but --non-interactive (or FLEDGE_NON_INTERACTIVE) is set.\n  \
-             {how_to_provide}, or unset FLEDGE_NON_INTERACTIVE / omit --non-interactive to run interactively."
+             Hint: {how_to_provide}.\n  \
+             Or unset FLEDGE_NON_INTERACTIVE / omit --non-interactive to run interactively."
         );
     }
     if !is_interactive() {
         anyhow::bail!(
             "This command requires interactive input but stdin is not a TTY.\n  \
-             {how_to_provide}."
+             Hint: {how_to_provide}."
         );
     }
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,6 +71,27 @@ pub fn require_interactive(flag_name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Like [`require_interactive`], but for commands whose required input is a
+/// positional argument rather than a `--flag`. `how_to_provide` is spliced into
+/// the error verbatim (e.g. "pass a provider and model, e.g. `fledge ai use
+/// ollama <model>`"), so the message names the real arguments instead of a
+/// `--flag` that may not exist.
+pub fn require_interactive_hint(how_to_provide: &str) -> anyhow::Result<()> {
+    if is_non_interactive() {
+        anyhow::bail!(
+            "This command requires interactive input but --non-interactive (or FLEDGE_NON_INTERACTIVE) is set.\n  \
+             {how_to_provide}, or unset FLEDGE_NON_INTERACTIVE / omit --non-interactive to run interactively."
+        );
+    }
+    if !is_interactive() {
+        anyhow::bail!(
+            "This command requires interactive input but stdin is not a TTY.\n  \
+             {how_to_provide}."
+        );
+    }
+    Ok(())
+}
+
 pub fn to_kebab_case(s: &str) -> String {
     s.chars()
         .map(|c| {


### PR DESCRIPTION
## Summary

Two `ai` UX bugs found by a dogfooding sweep:

1. **`ai use` no-args error advised a nonexistent flag.** Under `FLEDGE_NON_INTERACTIVE`, `fledge ai use` errored with *"Use `--provider` to skip prompts"* — but `provider` is a **positional** argument, so `fledge ai use --provider anthropic` fails with exit 2. Added `utils::require_interactive_hint(how_to_provide)` (a positional-arg-aware sibling of `require_interactive`); `ai use` now says *"pass a provider and model, e.g. `fledge ai use ollama qwen3-coder:480b-cloud`"*, matching the documented "pass provider+model" intent.
2. **`ai status` double space.** The Host line printed `Host: <url>  (from default)` (two spaces) because `cloud_note` carried a leading space that doubled with the format separator — the Provider/Model/API-Key lines don't. Dropped the leading space.

## Test Plan
- [x] `cargo clippy --bin fledge -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --bin fledge ai` — 33 passed
- [x] `ai use` (no args, non-interactive) error now names the positional args, no `--provider`
- [x] `ai status` Host line: single space before `(from default)`, matching the other lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi