### PR TITLE
Refactor: action-dialect envelope builder; adopt in work commands (#444)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -16,9 +16,8 @@
 //! helpers centralize the outer envelope so `schema_version` is never mistyped
 //! and the dialect is chosen explicitly rather than copy-pasted.
 //!
-//! This module currently provides the resource-dialect builder ([`resource`]),
-//! adopted by the `*/search` commands. An action-dialect builder lands
-//! alongside the first cross-cutting commands migrated to it.
+//! Provides both dialect builders: [`resource`] (pillar list/query commands)
+//! and [`action`] (cross-cutting commands).
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -38,6 +37,33 @@ pub fn resource(schema_version: u32, resource_key: &str, items: impl Serialize) 
         resource_key.to_string(),
         serde_json::to_value(items).unwrap_or(Value::Null),
     );
+    Value::Object(map)
+}
+
+/// Build an **action-dialect** envelope: `{schema_version, action, ...fields}`.
+///
+/// `schema_version` and `action` are inserted first; the keys of `fields` are
+/// merged in. `fields` must be a JSON object — any other `Value` contributes no
+/// extra keys (the envelope still carries `schema_version` and `action`).
+///
+/// The serialized output is identical to a hand-rolled `json!({"schema_version":
+/// …, "action": …, …fields})`: serde_json orders object keys the same way
+/// regardless of insertion order, so migrating a call site to this helper is a
+/// byte-for-byte-compatible refactor.
+///
+/// ```ignore
+/// let out = envelope::action(WORK_START_SCHEMA, "work_start", serde_json::json!({
+///     "branch": branch_name,
+///     "base": base_branch,
+/// }));
+/// ```
+pub fn action(schema_version: u32, action: &str, fields: Value) -> Value {
+    let mut map = Map::new();
+    map.insert("schema_version".to_string(), Value::from(schema_version));
+    map.insert("action".to_string(), Value::from(action));
+    if let Value::Object(obj) = fields {
+        map.extend(obj);
+    }
     Value::Object(map)
 }
 
@@ -61,5 +87,56 @@ mod tests {
         // A typed slice serializes the same as hand-rolled Values.
         let typed = resource(1, "results", ["x", "y"]);
         assert_eq!(typed["results"], serde_json::json!(["x", "y"]));
+    }
+
+    #[test]
+    fn action_leads_with_schema_version_and_action_then_merges_fields() {
+        let out = action(
+            2,
+            "release",
+            serde_json::json!({ "dry_run": true, "version": "1.2.3" }),
+        );
+        assert_eq!(out["schema_version"], 2);
+        assert_eq!(out["action"], "release");
+        assert_eq!(out["dry_run"], true);
+        assert_eq!(out["version"], "1.2.3");
+    }
+
+    #[test]
+    fn action_is_byte_identical_to_hand_rolled_json() {
+        // The migration guarantee: swapping a hand-rolled envelope for action()
+        // must not change a single byte of serialized output.
+        let built = action(
+            1,
+            "work_start",
+            serde_json::json!({
+                "branch": "t/feat/demo",
+                "base": "main",
+                "type": "feat",
+                "prefix": Value::Null,
+                "issue": Value::Null,
+            }),
+        );
+        let hand = serde_json::json!({
+            "schema_version": 1,
+            "action": "work_start",
+            "branch": "t/feat/demo",
+            "base": "main",
+            "type": "feat",
+            "prefix": Value::Null,
+            "issue": Value::Null,
+        });
+        assert_eq!(
+            serde_json::to_string_pretty(&built).unwrap(),
+            serde_json::to_string_pretty(&hand).unwrap()
+        );
+    }
+
+    #[test]
+    fn action_survives_non_object_fields() {
+        let out = action(1, "noop", Value::Null);
+        assert_eq!(out["schema_version"], 1);
+        assert_eq!(out["action"], "noop");
+        assert_eq!(out.as_object().unwrap().len(), 2);
     }
 }

--- a/src/work.rs
+++ b/src/work.rs
@@ -293,15 +293,17 @@ fn start(
     crate::plugin::run_lifecycle_hook("post_work_start").ok();
 
     if json {
-        let payload = serde_json::json!({
-            "schema_version": WORK_START_SCHEMA,
-            "action": "work_start",
-            "branch": branch_name,
-            "base": base_branch,
-            "type": btype,
-            "prefix": prefix,
-            "issue": issue,
-        });
+        let payload = crate::envelope::action(
+            WORK_START_SCHEMA,
+            "work_start",
+            serde_json::json!({
+                "branch": branch_name,
+                "base": base_branch,
+                "type": btype,
+                "prefix": prefix,
+                "issue": issue,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
         println!(
@@ -396,13 +398,15 @@ fn commit(
     let hash = git_output(&["rev-parse", "--short", "HEAD"])?;
 
     if json {
-        let payload = serde_json::json!({
-            "schema_version": WORK_COMMIT_SCHEMA,
-            "action": "work_commit",
-            "hash": hash,
-            "message": commit_msg,
-            "branch": branch,
-        });
+        let payload = crate::envelope::action(
+            WORK_COMMIT_SCHEMA,
+            "work_commit",
+            serde_json::json!({
+                "hash": hash,
+                "message": commit_msg,
+                "branch": branch,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
         println!(
@@ -540,13 +544,15 @@ fn push(force: bool, json: bool) -> Result<()> {
     }
 
     if json {
-        let payload = serde_json::json!({
-            "schema_version": WORK_PUSH_SCHEMA,
-            "action": "work_push",
-            "branch": branch,
-            "remote": "origin",
-            "force": force,
-        });
+        let payload = crate::envelope::action(
+            WORK_PUSH_SCHEMA,
+            "work_push",
+            serde_json::json!({
+                "branch": branch,
+                "remote": "origin",
+                "force": force,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
         println!(
@@ -574,15 +580,17 @@ fn status(json: bool) -> Result<()> {
         .count();
 
     if json {
-        let payload = serde_json::json!({
-            "schema_version": WORK_STATUS_SCHEMA,
-            "action": "work_status",
-            "branch": branch,
-            "default": default,
-            "ahead": ahead,
-            "behind": behind,
-            "dirty": dirty_count,
-        });
+        let payload = crate::envelope::action(
+            WORK_STATUS_SCHEMA,
+            "work_status",
+            serde_json::json!({
+                "branch": branch,
+                "default": default,
+                "ahead": ahead,
+                "behind": behind,
+                "dirty": dirty_count,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
         let behind_display = match behind {


### PR DESCRIPTION
## Summary

Second slice of #444. Adds the **action-dialect** builder `envelope::action(schema_version, action, fields)` — the counterpart to `envelope::resource` from #471 — and migrates all four `work.rs` `--json` sites (`work_start`/`work_commit`/`work_push`/`work_status`) to it.

This is a **pure internal refactor with zero output change.** `serde_json` orders object keys identically regardless of insertion order, so `action(…)` serializes byte-for-byte the same as the hand-rolled `json!({"schema_version": …, "action": …, …})` it replaces.

## Verification (byte-identical is the bar)
- [x] New unit test `action_is_byte_identical_to_hand_rolled_json` asserts `action()` == hand-rolled `json!` output exactly
- [x] Live `work start --json`: **byte-identical** to the pre-change (main) binary
- [x] Live `work status --json`: **identical** in a controlled clean repo (the earlier one-line delta was an environmental `dirty` count, reproduced as clean-vs-clean identical)
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] Full suite **904 passing** (+3 envelope tests); `fledge spec check` **0/0** (no export moved)
- [x] No AGENTS.md / spec change — no documented shape changed

## Progress on #444
Migrated so far: 3 search commands (resource, #471) + 4 work commands (action, this PR). Remaining `serde_json::json!` envelope sites continue in follow-up slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi