### PR TITLE
CI: run the gate on every PR so required checks always report (#451 step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,31 +5,17 @@ permissions:
   pull-requests: write
   checks: write
 
+# NOTE: intentionally no `paths:` filter. These jobs (test/lint/audit/spec-check)
+# are the branch-protection required status checks — a required check that is
+# skipped by a path filter never reports, which blocks the PR forever (e.g. a
+# docs-only PR). Running the gate on every PR/push is the cost of enforcing it.
+# See issue #451. Do not re-add path filters here without also removing these
+# jobs from the required-checks list.
 on:
   push:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'specs/**'
-      - 'tests/**'
-      - 'templates/**'
-      - 'build.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'fledge.toml'
-      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'specs/**'
-      - 'tests/**'
-      - 'templates/**'
-      - 'build.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'fledge.toml'
-      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Removes the `paths:` filters from `ci.yml`'s `push` and `pull_request` triggers, so `test`/`lint`/`audit`/`spec-check` run on **every** PR and push to main.

This is **Step 1 of #451** — the prerequisite for enforcing branch-protection required status checks. Today the config has `required_status_checks: []` (a red `test`/`audit` can't block a merge) plus `required_approving_review_count: 1` + `enforce_admins: true` (so every merge needs `--admin`). The fix is to require the checks — but a required check that a path filter *skips* never reports, which would **deadlock** any docs-only PR (as #470 showed: it ran only CodeQL). Running the gate unconditionally removes that trap.

**Trade-off:** docs/CI-only PRs now run the full matrix (cache-warm, a few minutes). That's the accepted cost of being able to enforce CI.

## Step 2 (maintainer, after this merges)

Set protection so CI gates everyone and clean PRs merge without `--admin` or an approval:

```bash
gh api -X PUT /repos/CorvidLabs/fledge/branches/main/protection --input - <<'JSON'
{
  "required_status_checks": {
    "strict": false,
    "contexts": ["test (ubuntu-latest)", "test (macos-latest)", "test (windows-latest)", "lint", "audit", "spec-check"]
  },
  "enforce_admins": true,
  "required_pull_request_reviews": null,
  "restrictions": null
}
JSON
```

## Test Plan
- [x] `ci.yml` YAML validates; triggers now carry no `paths:`; all 6 jobs intact
- [x] This PR itself exercises the change (touching `.github/workflows/ci.yml` triggers the full gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi