### PR TITLE
Refactor: migrate all lanes/ --json sites to the envelope builder (#444)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -67,6 +67,24 @@ pub fn action(schema_version: u32, action: &str, fields: Value) -> Value {
     Value::Object(map)
 }
 
+/// Build a **flat versioned** envelope: `{schema_version, ...fields}` — for the
+/// handful of commands whose `--json` shape is neither the resource nor the
+/// action dialect (e.g. `lanes run`/`lanes validate`, which carry named fields
+/// but no `action` key or single resource array).
+///
+/// Like [`action`] minus the `action` key: `fields` must be a JSON object; any
+/// other `Value` contributes no extra keys. Serialization is byte-for-byte
+/// identical to a hand-rolled `json!` with the same fields (or to inserting
+/// `schema_version` into an already-serialized struct).
+pub fn versioned(schema_version: u32, fields: Value) -> Value {
+    let mut map = Map::new();
+    map.insert("schema_version".to_string(), Value::from(schema_version));
+    if let Value::Object(obj) = fields {
+        map.extend(obj);
+    }
+    Value::Object(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,5 +156,31 @@ mod tests {
         assert_eq!(out["schema_version"], 1);
         assert_eq!(out["action"], "noop");
         assert_eq!(out.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn versioned_prepends_schema_version_without_action() {
+        let out = versioned(1, serde_json::json!({ "lane": "ci", "success": true }));
+        assert_eq!(out["schema_version"], 1);
+        assert!(out.get("action").is_none());
+        assert_eq!(out["lane"], "ci");
+        assert_eq!(out["success"], true);
+    }
+
+    #[test]
+    fn versioned_is_byte_identical_to_hand_rolled_json() {
+        let built = versioned(
+            1,
+            serde_json::json!({ "path": ".fledge/lanes/x.toml", "lane_count": 2 }),
+        );
+        let hand = serde_json::json!({
+            "schema_version": 1,
+            "path": ".fledge/lanes/x.toml",
+            "lane_count": 2,
+        });
+        assert_eq!(
+            serde_json::to_string_pretty(&built).unwrap(),
+            serde_json::to_string_pretty(&hand).unwrap()
+        );
     }
 }

--- a/src/lanes/community.rs
+++ b/src/lanes/community.rs
@@ -242,16 +242,18 @@ pub(crate) fn import_lanes(source: &str, yes: bool, json: bool) -> Result<()> {
 
     if imported_lanes.is_empty() {
         if json {
-            let result = serde_json::json!({
-                "schema_version": LANES_IMPORT_SCHEMA,
-                "action": "import",
-                "source": display_source,
-                "trust_tier": tier.label(),
-                "imported": [],
-                "skipped": skipped,
-                "file": relative_file,
-                "written": false,
-            });
+            let result = crate::envelope::action(
+                LANES_IMPORT_SCHEMA,
+                "import",
+                serde_json::json!({
+                    "source": display_source,
+                    "trust_tier": tier.label(),
+                    "imported": [],
+                    "skipped": skipped,
+                    "file": relative_file,
+                    "written": false,
+                }),
+            );
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
             println!(
@@ -271,16 +273,18 @@ pub(crate) fn import_lanes(source: &str, yes: bool, json: bool) -> Result<()> {
     std::fs::write(&import_path, import_content.trim_start()).context("writing imported lanes")?;
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": LANES_IMPORT_SCHEMA,
-            "action": "import",
-            "source": display_source,
-            "trust_tier": tier.label(),
-            "imported": imported_lanes,
-            "skipped": skipped,
-            "file": relative_file,
-            "written": true,
-        });
+        let result = crate::envelope::action(
+            LANES_IMPORT_SCHEMA,
+            "import",
+            serde_json::json!({
+                "source": display_source,
+                "trust_tier": tier.label(),
+                "imported": imported_lanes,
+                "skipped": skipped,
+                "file": relative_file,
+                "written": true,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/lanes/create.rs
+++ b/src/lanes/create.rs
@@ -99,14 +99,16 @@ See [fledge docs](https://github.com/CorvidLabs/fledge) for lane syntax.
     ];
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": LANES_CREATE_SCHEMA,
-            "action": "create",
-            "path": target.display().to_string(),
-            "name": name,
-            "description": desc,
-            "files_created": files_created,
-        });
+        let result = crate::envelope::action(
+            LANES_CREATE_SCHEMA,
+            "create",
+            serde_json::json!({
+                "path": target.display().to_string(),
+                "name": name,
+                "description": desc,
+                "files_created": files_created,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/lanes/defaults.rs
+++ b/src/lanes/defaults.rs
@@ -109,13 +109,15 @@ pub(crate) fn init_lanes(json: bool) -> Result<()> {
         .unwrap_or_default();
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": LANES_INIT_SCHEMA,
-            "action": "init",
-            "file": "fledge.toml",
-            "project_type": project_type,
-            "lanes_added": lanes_added,
-        });
+        let result = crate::envelope::action(
+            LANES_INIT_SCHEMA,
+            "init",
+            serde_json::json!({
+                "file": "fledge.toml",
+                "project_type": project_type,
+                "lanes_added": lanes_added,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/lanes/execute.rs
+++ b/src/lanes/execute.rs
@@ -247,17 +247,19 @@ fn execute_lane_json(
     let total_elapsed = lane_start.elapsed();
     let success = failures.is_empty();
 
-    let mut output = serde_json::json!({
-        "schema_version": LANES_RUN_SCHEMA,
-        "lane": lane_name,
-        "description": lane.description.as_deref().unwrap_or(""),
-        "total_steps": total_steps,
-        "success": success,
-        "duration_ms": total_elapsed.as_millis() as u64,
-        "fail_fast": lane.fail_fast,
-        "steps": step_results,
-        "failures": failures,
-    });
+    let mut output = crate::envelope::versioned(
+        LANES_RUN_SCHEMA,
+        serde_json::json!({
+            "lane": lane_name,
+            "description": lane.description.as_deref().unwrap_or(""),
+            "total_steps": total_steps,
+            "success": success,
+            "duration_ms": total_elapsed.as_millis() as u64,
+            "fail_fast": lane.fail_fast,
+            "steps": step_results,
+            "failures": failures,
+        }),
+    );
     if let Some(fi) = from_index {
         output["from_step"] = serde_json::json!(fi + 1);
     }

--- a/src/lanes/mod.rs
+++ b/src/lanes/mod.rs
@@ -433,10 +433,7 @@ pub(super) fn list_lanes(lanes: &BTreeMap<String, LaneDef>, json: bool) -> Resul
                 entry
             })
             .collect();
-        let result = serde_json::json!({
-            "schema_version": LANES_LIST_SCHEMA,
-            "lanes": entries,
-        });
+        let result = crate::envelope::resource(LANES_LIST_SCHEMA, "lanes", entries);
         println!("{}", serde_json::to_string_pretty(&result)?);
         return Ok(());
     }
@@ -593,15 +590,17 @@ pub(super) fn dry_run_lane(
             })
             .collect();
 
-        let mut output = serde_json::json!({
-            "schema_version": LANES_DRY_RUN_SCHEMA,
-            "lane": lane_name,
-            "description": lane.description.as_deref().unwrap_or(""),
-            "total_steps": lane.steps.len(),
-            "fail_fast": lane.fail_fast,
-            "dry_run": true,
-            "steps": steps,
-        });
+        let mut output = crate::envelope::versioned(
+            LANES_DRY_RUN_SCHEMA,
+            serde_json::json!({
+                "lane": lane_name,
+                "description": lane.description.as_deref().unwrap_or(""),
+                "total_steps": lane.steps.len(),
+                "fail_fast": lane.fail_fast,
+                "dry_run": true,
+                "steps": steps,
+            }),
+        );
         if let Some(fi) = from_index {
             output["from_step"] = serde_json::json!(fi + 1);
         }

--- a/src/lanes/publish.rs
+++ b/src/lanes/publish.rs
@@ -87,21 +87,23 @@ pub(crate) fn publish_lanes(
 
             if !confirm {
                 if json {
-                    let result = serde_json::json!({
-                        "schema_version": LANES_PUBLISH_SCHEMA,
-                        "action": "publish",
-                        "cancelled": true,
-                        "repo": {
-                            "owner": owner,
-                            "name": repo_name,
-                            "url": format!("https://github.com/{owner}/{repo_name}"),
-                            "created": false,
-                            "private": private,
-                        },
-                        "lanes_published": lane_names,
-                        "topic": "fledge-lane",
-                        "import_hint": format!("fledge lanes import {owner}/{repo_name}"),
-                    });
+                    let result = crate::envelope::action(
+                        LANES_PUBLISH_SCHEMA,
+                        "publish",
+                        serde_json::json!({
+                            "cancelled": true,
+                            "repo": {
+                                "owner": owner,
+                                "name": repo_name,
+                                "url": format!("https://github.com/{owner}/{repo_name}"),
+                                "created": false,
+                                "private": private,
+                            },
+                            "lanes_published": lane_names,
+                            "topic": "fledge-lane",
+                            "import_hint": format!("fledge lanes import {owner}/{repo_name}"),
+                        }),
+                    );
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 } else {
                     println!("{} Cancelled.", style("*").cyan().bold());
@@ -158,21 +160,23 @@ pub(crate) fn publish_lanes(
     }
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": LANES_PUBLISH_SCHEMA,
-            "action": "publish",
-            "cancelled": false,
-            "repo": {
-                "owner": owner,
-                "name": repo_name,
-                "url": format!("https://github.com/{owner}/{repo_name}"),
-                "created": created_repo,
-                "private": private,
-            },
-            "lanes_published": lane_names,
-            "topic": "fledge-lane",
-            "import_hint": format!("fledge lanes import {owner}/{repo_name}"),
-        });
+        let result = crate::envelope::action(
+            LANES_PUBLISH_SCHEMA,
+            "publish",
+            serde_json::json!({
+                "cancelled": false,
+                "repo": {
+                    "owner": owner,
+                    "name": repo_name,
+                    "url": format!("https://github.com/{owner}/{repo_name}"),
+                    "created": created_repo,
+                    "private": private,
+                },
+                "lanes_published": lane_names,
+                "topic": "fledge-lane",
+                "import_hint": format!("fledge lanes import {owner}/{repo_name}"),
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!("  {} Pushed lane files", style("✅").green().bold());

--- a/src/lanes/validate.rs
+++ b/src/lanes/validate.rs
@@ -174,13 +174,7 @@ pub(crate) fn print_lane_report(
 ) -> Result<()> {
     if json {
         // Wrap with schema_version envelope (matches lanes list/run/search shape).
-        let mut value = serde_json::to_value(report)?;
-        if let Some(obj) = value.as_object_mut() {
-            obj.insert(
-                "schema_version".to_string(),
-                serde_json::Value::Number(serde_json::Number::from(1)),
-            );
-        }
+        let value = crate::envelope::versioned(1, serde_json::to_value(report)?);
         println!("{}", serde_json::to_string_pretty(&value)?);
     } else if report.errors.is_empty() && report.warnings.is_empty() {
         println!(


### PR DESCRIPTION
## Summary

Third slice of #444 (**batch: `lanes` module**). Adds the flat builder `envelope::versioned(schema_version, fields)` — the counterpart to `resource`/`action` for commands whose `--json` shape has named fields but no `action` key or single resource array — and migrates **all 10** `lanes/` envelope sites:

| Dialect | Commands |
|---|---|
| resource | `lanes list` |
| action | `lanes import` (×2), `publish` (×2), `create`, `init` |
| versioned (flat) | `lanes run`, `dry-run`, `validate` |

**Pure internal refactor, zero output change.** `serde_json` key ordering is insertion-order-independent, so every site serializes byte-for-byte identically.

## Verification
- [x] New `versioned` unit tests incl. `versioned_is_byte_identical_to_hand_rolled_json`
- [x] Live `lanes list --json` and `lanes run pre-commit --dry-run --json`: **byte-identical** to the pre-change binary
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] Full suite **906 passing** (97 lanes tests); `fledge spec check` **0/0**
- [x] No AGENTS.md / spec change — no documented shape or export moved

## Progress on #444
search (resource, #471) → work (action, #472) → **lanes (all three dialects, this PR)**. Remaining modules: `plugin/`, `spec/`+`release/`, top-level misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi