### PR TITLE
Refactor: migrate all plugin/ --json sites to the envelope builder (#444)

### DIFF
--- a/src/plugin/create.rs
+++ b/src/plugin/create.rs
@@ -139,14 +139,16 @@ See [fledge plugin docs](https://github.com/CorvidLabs/fledge) for the full plug
     ];
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_CREATE_SCHEMA,
-            "action": "create",
-            "path": target.display().to_string(),
-            "name": name,
-            "description": desc,
-            "files_created": files_created,
-        });
+        let result = crate::envelope::action(
+            PLUGINS_CREATE_SCHEMA,
+            "create",
+            serde_json::json!({
+                "path": target.display().to_string(),
+                "name": name,
+                "description": desc,
+                "files_created": files_created,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(
@@ -289,15 +291,17 @@ fledge plugins install ./{name}
     ];
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": super::PLUGINS_CREATE_SCHEMA,
-            "action": "create",
-            "path": target.display().to_string(),
-            "name": name,
-            "description": desc,
-            "runtime": "wasm",
-            "files_created": files_created,
-        });
+        let result = crate::envelope::action(
+            super::PLUGINS_CREATE_SCHEMA,
+            "create",
+            serde_json::json!({
+                "path": target.display().to_string(),
+                "name": name,
+                "description": desc,
+                "runtime": "wasm",
+                "files_created": files_created,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -320,14 +320,16 @@ pub(crate) fn install_action(
     })?;
     let report = install_plugin(source, force, copy, json)?;
     if json {
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_INSTALL_SCHEMA,
-            "action": "install",
-            "scope": "single",
-            "installed": [report],
-            "failed": [],
-            "summary": { "total": 1, "installed": 1, "failed": 0 },
-        });
+        let result = crate::envelope::action(
+            PLUGINS_INSTALL_SCHEMA,
+            "install",
+            serde_json::json!({
+                "scope": "single",
+                "installed": [report],
+                "failed": [],
+                "summary": { "total": 1, "installed": 1, "failed": 0 },
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     }
     Ok(())
@@ -393,18 +395,20 @@ pub(crate) fn install_defaults(force: bool, json: bool) -> Result<()> {
             .iter()
             .map(|(source, err)| serde_json::json!({ "source": source, "error": err }))
             .collect();
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_INSTALL_SCHEMA,
-            "action": "install",
-            "scope": "defaults",
-            "installed": installed,
-            "failed": failed_json,
-            "summary": {
-                "total": DEFAULT_PLUGINS.len(),
-                "installed": installed_sources.len(),
-                "failed": failed.len(),
-            },
-        });
+        let result = crate::envelope::action(
+            PLUGINS_INSTALL_SCHEMA,
+            "install",
+            serde_json::json!({
+                "scope": "defaults",
+                "installed": installed,
+                "failed": failed_json,
+                "summary": {
+                    "total": DEFAULT_PLUGINS.len(),
+                    "installed": installed_sources.len(),
+                    "failed": failed.len(),
+                },
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     }
 

--- a/src/plugin/list.rs
+++ b/src/plugin/list.rs
@@ -13,10 +13,11 @@ pub(crate) fn list_plugins(json: bool) -> Result<()> {
 
     if registry.plugins.is_empty() {
         if json {
-            let result = serde_json::json!({
-                "schema_version": PLUGINS_LIST_SCHEMA,
-                "plugins": [],
-            });
+            let result = crate::envelope::resource(
+                PLUGINS_LIST_SCHEMA,
+                "plugins",
+                Vec::<serde_json::Value>::new(),
+            );
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
             println!(
@@ -46,10 +47,7 @@ pub(crate) fn list_plugins(json: bool) -> Result<()> {
                 })
             })
             .collect();
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_LIST_SCHEMA,
-            "plugins": entries,
-        });
+        let result = crate::envelope::resource(PLUGINS_LIST_SCHEMA, "plugins", entries);
         println!("{}", serde_json::to_string_pretty(&result)?);
         return Ok(());
     }
@@ -102,10 +100,11 @@ pub(crate) fn audit_plugins(json: bool) -> Result<()> {
 
     if registry.plugins.is_empty() {
         if json {
-            let result = serde_json::json!({
-                "schema_version": PLUGINS_AUDIT_SCHEMA,
-                "audit": [],
-            });
+            let result = crate::envelope::resource(
+                PLUGINS_AUDIT_SCHEMA,
+                "audit",
+                Vec::<serde_json::Value>::new(),
+            );
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
             println!("{} No plugins installed.", style("*").cyan().bold());
@@ -140,10 +139,7 @@ pub(crate) fn audit_plugins(json: bool) -> Result<()> {
                 })
             })
             .collect();
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_AUDIT_SCHEMA,
-            "audit": entries,
-        });
+        let result = crate::envelope::resource(PLUGINS_AUDIT_SCHEMA, "audit", entries);
         println!("{}", serde_json::to_string_pretty(&result)?);
         return Ok(());
     }

--- a/src/plugin/publish.rs
+++ b/src/plugin/publish.rs
@@ -76,25 +76,27 @@ pub(crate) fn publish_plugin(
 
             if !confirm {
                 if json {
-                    let result = serde_json::json!({
-                        "schema_version": PLUGINS_PUBLISH_SCHEMA,
-                        "action": "publish",
-                        "cancelled": true,
-                        "repo": {
-                            "owner": owner,
-                            "name": repo_name,
-                            "url": format!("https://github.com/{owner}/{repo_name}"),
-                            "created": false,
-                            "private": private,
-                        },
-                        "plugin": {
-                            "name": manifest.plugin.name,
-                            "version": manifest.plugin.version,
-                            "description": desc,
-                        },
-                        "topic": "fledge-plugin",
-                        "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
-                    });
+                    let result = crate::envelope::action(
+                        PLUGINS_PUBLISH_SCHEMA,
+                        "publish",
+                        serde_json::json!({
+                            "cancelled": true,
+                            "repo": {
+                                "owner": owner,
+                                "name": repo_name,
+                                "url": format!("https://github.com/{owner}/{repo_name}"),
+                                "created": false,
+                                "private": private,
+                            },
+                            "plugin": {
+                                "name": manifest.plugin.name,
+                                "version": manifest.plugin.version,
+                                "description": desc,
+                            },
+                            "topic": "fledge-plugin",
+                            "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
+                        }),
+                    );
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 } else {
                     println!("{} Cancelled.", style("*").cyan().bold());
@@ -151,25 +153,27 @@ pub(crate) fn publish_plugin(
     }
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_PUBLISH_SCHEMA,
-            "action": "publish",
-            "cancelled": false,
-            "repo": {
-                "owner": owner,
-                "name": repo_name,
-                "url": format!("https://github.com/{owner}/{repo_name}"),
-                "created": created_repo,
-                "private": private,
-            },
-            "plugin": {
-                "name": manifest.plugin.name,
-                "version": manifest.plugin.version,
-                "description": desc,
-            },
-            "topic": "fledge-plugin",
-            "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
-        });
+        let result = crate::envelope::action(
+            PLUGINS_PUBLISH_SCHEMA,
+            "publish",
+            serde_json::json!({
+                "cancelled": false,
+                "repo": {
+                    "owner": owner,
+                    "name": repo_name,
+                    "url": format!("https://github.com/{owner}/{repo_name}"),
+                    "created": created_repo,
+                    "private": private,
+                },
+                "plugin": {
+                    "name": manifest.plugin.name,
+                    "version": manifest.plugin.version,
+                    "description": desc,
+                },
+                "topic": "fledge-plugin",
+                "install_hint": format!("fledge plugins install {owner}/{repo_name}"),
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!("  {} Pushed plugin files", style("✅").green().bold());

--- a/src/plugin/recommend.rs
+++ b/src/plugin/recommend.rs
@@ -137,13 +137,15 @@ pub(crate) fn recommend_plugins(json: bool) -> Result<()> {
                 })
             })
             .collect();
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_RECOMMEND_SCHEMA,
-            "action": "plugins_recommend",
-            "language": lang,
-            "installed_count": installed_count,
-            "recommendations": entries,
-        });
+        let result = crate::envelope::action(
+            PLUGINS_RECOMMEND_SCHEMA,
+            "plugins_recommend",
+            serde_json::json!({
+                "language": lang,
+                "installed_count": installed_count,
+                "recommendations": entries,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
         return Ok(());
     }

--- a/src/plugin/remove.rs
+++ b/src/plugin/remove.rs
@@ -64,16 +64,18 @@ pub(crate) fn remove_plugin(name: &str, json: bool) -> Result<()> {
     save_registry(&registry)?;
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": PLUGINS_REMOVE_SCHEMA,
-            "action": "remove",
-            "removed": {
-                "name": removed_name,
-                "source": removed_source,
-                "version": removed_version,
-                "commands": removed_commands,
-            },
-        });
+        let result = crate::envelope::action(
+            PLUGINS_REMOVE_SCHEMA,
+            "remove",
+            serde_json::json!({
+                "removed": {
+                    "name": removed_name,
+                    "source": removed_source,
+                    "version": removed_version,
+                    "commands": removed_commands,
+                },
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/plugin/update.rs
+++ b/src/plugin/update.rs
@@ -43,13 +43,15 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
             if json {
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&serde_json::json!({
-                        "schema_version": PLUGINS_UPDATE_SCHEMA,
-                        "action": "update",
-                        "scope": "defaults",
-                        "results": [],
-                        "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
-                    }))?
+                    serde_json::to_string_pretty(&crate::envelope::action(
+                        PLUGINS_UPDATE_SCHEMA,
+                        "update",
+                        serde_json::json!({
+                            "scope": "defaults",
+                            "results": [],
+                            "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
+                        }),
+                    ))?
                 );
             } else {
                 println!(
@@ -84,13 +86,15 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
                     if json {
                         println!(
                             "{}",
-                            serde_json::to_string_pretty(&serde_json::json!({
-                                "schema_version": PLUGINS_UPDATE_SCHEMA,
-                                "action": "update",
-                                "scope": "all",
-                                "results": [],
-                                "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
-                            }))?
+                            serde_json::to_string_pretty(&crate::envelope::action(
+                                PLUGINS_UPDATE_SCHEMA,
+                                "update",
+                                serde_json::json!({
+                                    "scope": "all",
+                                    "results": [],
+                                    "summary": { "total": 0, "updated": 0, "skipped": 0, "failed": 0 },
+                                }),
+                            ))?
                         );
                     } else {
                         println!("{} No plugins installed.", style("*").cyan().bold());
@@ -328,13 +332,15 @@ pub(crate) fn update_plugins(name: Option<&str>, defaults: bool, json: bool) -> 
         };
         println!(
             "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "schema_version": PLUGINS_UPDATE_SCHEMA,
-                "action": "update",
-                "scope": scope,
-                "results": results,
-                "summary": summary,
-            }))?
+            serde_json::to_string_pretty(&crate::envelope::action(
+                PLUGINS_UPDATE_SCHEMA,
+                "update",
+                serde_json::json!({
+                    "scope": scope,
+                    "results": results,
+                    "summary": summary,
+                }),
+            ))?
         );
     }
 

--- a/src/plugin/validate.rs
+++ b/src/plugin/validate.rs
@@ -166,13 +166,7 @@ pub(crate) fn print_plugin_report(
         // schema_version (matches plugins list/audit/search shape).
         // The full report is flattened so existing fields (path,
         // plugin_name, errors, warnings) sit at the same level.
-        let mut value = serde_json::to_value(report)?;
-        if let Some(obj) = value.as_object_mut() {
-            obj.insert(
-                "schema_version".to_string(),
-                serde_json::Value::Number(serde_json::Number::from(1)),
-            );
-        }
+        let value = crate::envelope::versioned(1, serde_json::to_value(report)?);
         println!("{}", serde_json::to_string_pretty(&value)?);
     } else if report.errors.is_empty() && report.warnings.is_empty() {
         let name = if report.plugin_name.is_empty() {


### PR DESCRIPTION
## Summary

Fourth slice of #444 (**batch: `plugin` module**). Migrates all **16** `plugin/` envelope sites:

| Dialect | Sites |
|---|---|
| resource | `plugins list` (×2), `plugins audit` (×2) |
| action | `create` (×2), `install` (×2), `publish` (×2), `update` (×3), `remove`, `recommend` |
| versioned (flat) | `plugins validate` |

**Pure internal refactor, zero output change** — byte-for-byte-identical serialization.

## Verification
- [x] Live `plugins list --json`, `plugins audit --json`, `plugins recommend --json`: **all byte-identical** to the pre-change binary
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] Full suite **906 passing** (167 plugin tests); `fledge spec check` **0/0**
- [x] No AGENTS.md / spec change — no documented shape or export moved

## Progress on #444
search (#471) → work (#472) → lanes (#474) → **plugin (this PR)**. Remaining: `spec/`+`release/` and top-level misc (ai/ask/changelog/doctor/init/review/run/template_cmds/create_template/validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi