### PR TITLE
Refactor: migrate spec/ and release/ --json sites to the envelope builder (#444)

### DIFF
--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -59,18 +59,20 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
         };
 
         if opts.json {
-            let envelope = serde_json::json!({
-                "schema_version": RELEASE_SCHEMA,
-                "action": "release",
-                "dry_run": true,
-                "version": new_version.to_string(),
-                "no_bump": opts.no_bump,
-                "files_to_bump": files_to_bump,
-                "will_changelog": !opts.no_changelog,
-                "will_tag": !opts.no_tag,
-                "will_push": opts.push,
-                "tag": format!("v{}", new_version),
-            });
+            let envelope = crate::envelope::action(
+                RELEASE_SCHEMA,
+                "release",
+                serde_json::json!({
+                    "dry_run": true,
+                    "version": new_version.to_string(),
+                    "no_bump": opts.no_bump,
+                    "files_to_bump": files_to_bump,
+                    "will_changelog": !opts.no_changelog,
+                    "will_tag": !opts.no_tag,
+                    "will_push": opts.push,
+                    "tag": format!("v{}", new_version),
+                }),
+            );
             println!("{}", serde_json::to_string_pretty(&envelope)?);
             return Ok(());
         }
@@ -154,19 +156,21 @@ pub fn run(opts: ReleaseOptions) -> Result<()> {
     }
 
     if opts.json {
-        let envelope = serde_json::json!({
-            "schema_version": RELEASE_SCHEMA,
-            "action": "release",
-            "dry_run": false,
-            "version": new_version.to_string(),
-            "old_version": result.old.to_string(),
-            "files_bumped": result.files_bumped,
-            "changelog_updated": changelog_updated,
-            "commit_created": true,
-            "tag_created": !opts.no_tag,
-            "tag": format!("v{}", new_version),
-            "pushed": opts.push,
-        });
+        let envelope = crate::envelope::action(
+            RELEASE_SCHEMA,
+            "release",
+            serde_json::json!({
+                "dry_run": false,
+                "version": new_version.to_string(),
+                "old_version": result.old.to_string(),
+                "files_bumped": result.files_bumped,
+                "changelog_updated": changelog_updated,
+                "commit_created": true,
+                "tag_created": !opts.no_tag,
+                "tag": format!("v{}", new_version),
+                "pushed": opts.push,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/spec/commands.rs
+++ b/src/spec/commands.rs
@@ -133,13 +133,15 @@ pub(crate) fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
 
     if !specs_dir.exists() {
         if json {
-            let payload = serde_json::json!({
-                "schema_version": SPEC_CHECK_SCHEMA,
-                "action": "spec_check",
-                "specs": [],
-                "totals": { "checked": 0, "errors": 0, "warnings": 0 },
-                "strict": strict,
-            });
+            let payload = crate::envelope::action(
+                SPEC_CHECK_SCHEMA,
+                "spec_check",
+                serde_json::json!({
+                    "specs": [],
+                    "totals": { "checked": 0, "errors": 0, "warnings": 0 },
+                    "strict": strict,
+                }),
+            );
             println!("{}", serde_json::to_string_pretty(&payload)?);
         } else {
             println!(
@@ -157,13 +159,15 @@ pub(crate) fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
 
     if results.is_empty() {
         if json {
-            let payload = serde_json::json!({
-                "schema_version": SPEC_CHECK_SCHEMA,
-                "action": "spec_check",
-                "specs": [],
-                "totals": { "checked": 0, "errors": 0, "warnings": 0 },
-                "strict": strict,
-            });
+            let payload = crate::envelope::action(
+                SPEC_CHECK_SCHEMA,
+                "spec_check",
+                serde_json::json!({
+                    "specs": [],
+                    "totals": { "checked": 0, "errors": 0, "warnings": 0 },
+                    "strict": strict,
+                }),
+            );
             println!("{}", serde_json::to_string_pretty(&payload)?);
         } else {
             println!(
@@ -184,18 +188,20 @@ pub(crate) fn check(root: &Path, strict: bool, json: bool) -> Result<()> {
 
     if json {
         let specs_payload: Vec<serde_json::Value> = results.iter().map(spec_result_json).collect();
-        let payload = serde_json::json!({
-            "schema_version": SPEC_CHECK_SCHEMA,
-            "action": "spec_check",
-            "engine": "structural",
-            "specs": specs_payload,
-            "totals": {
-                "checked": results.len(),
-                "errors": total_errors,
-                "warnings": total_warnings,
-            },
-            "strict": strict,
-        });
+        let payload = crate::envelope::action(
+            SPEC_CHECK_SCHEMA,
+            "spec_check",
+            serde_json::json!({
+                "engine": "structural",
+                "specs": specs_payload,
+                "totals": {
+                    "checked": results.len(),
+                    "errors": total_errors,
+                    "warnings": total_warnings,
+                },
+                "strict": strict,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
         if total_errors > 0 || (strict && total_warnings > 0) {
             bail!(
@@ -348,11 +354,13 @@ pub(crate) fn list_specs(root: &Path, json: bool) -> Result<()> {
     summaries.sort_by(|a, b| a.name.cmp(&b.name));
 
     if json {
-        let envelope = serde_json::json!({
-            "schema_version": SPEC_LIST_SCHEMA,
-            "action": "spec_list",
-            "specs": summaries,
-        });
+        let envelope = crate::envelope::action(
+            SPEC_LIST_SCHEMA,
+            "spec_list",
+            serde_json::json!({
+                "specs": summaries,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
@@ -462,11 +470,13 @@ pub(crate) fn show_spec(root: &Path, name: &str, json: bool) -> Result<()> {
     };
 
     if json {
-        let envelope = serde_json::json!({
-            "schema_version": SPEC_SHOW_SCHEMA,
-            "action": "spec_show",
-            "spec": detail,
-        });
+        let envelope = crate::envelope::action(
+            SPEC_SHOW_SCHEMA,
+            "spec_show",
+            serde_json::json!({
+                "spec": detail,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/spec/engine.rs
+++ b/src/spec/engine.rs
@@ -151,23 +151,25 @@ fn render(
             .iter()
             .map(super::commands::spec_result_json)
             .collect();
-        let payload = serde_json::json!({
-            "schema_version": SPEC_CHECK_SCHEMA,
-            "action": "spec_check",
-            "engine": "specsync",
-            "engine_version": version,
-            "specs": specs,
-            "passed": report.passed,
-            "totals": {
-                "checked": report.specs_checked,
-                "errors": report.errors.len(),
-                "warnings": report.warnings.len(),
-            },
-            "errors": report.errors,
-            "warnings": report.warnings,
-            "stale": report.stale,
-            "strict": strict,
-        });
+        let payload = crate::envelope::action(
+            SPEC_CHECK_SCHEMA,
+            "spec_check",
+            serde_json::json!({
+                "engine": "specsync",
+                "engine_version": version,
+                "specs": specs,
+                "passed": report.passed,
+                "totals": {
+                    "checked": report.specs_checked,
+                    "errors": report.errors.len(),
+                    "warnings": report.warnings.len(),
+                },
+                "errors": report.errors,
+                "warnings": report.warnings,
+                "stale": report.stale,
+                "strict": strict,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
     }


### PR DESCRIPTION
## Summary

Fifth slice of #444 (**batch: `spec` + `release`**). Migrates all **8** action-dialect envelope sites:

- `spec/commands.rs`: `spec_check` (×3), `spec_list`, `spec_show`
- `spec/engine.rs`: `spec_check` (specsync-delegated path)
- `release/mod.rs`: `release` dry-run + real

**Pure internal refactor, zero output change** — byte-for-byte-identical serialization.

## Verification
- [x] Live `spec check --json`, `spec list --json`, `spec show work --json`, `release patch --dry-run --allow-dirty --json`: **all byte-identical** to the pre-change binary
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] Full suite **906 passing**; `fledge spec check` (specsync) **0/0**
- [x] No AGENTS.md / spec change — no documented shape or export moved

## Progress on #444
search (#471) → work (#472) → lanes (#474) → plugin (#475) → **spec+release (this PR)**. Remaining: top-level command surface (ai/ask/changelog/doctor/init/review/run/template_cmds/create_template/validate) — the final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi