### PR TITLE
Refactor: migrate top-level command --json sites to the envelope builder (#444)

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -138,19 +138,21 @@ fn status(json: bool) -> Result<()> {
     };
 
     if json {
-        let envelope = serde_json::json!({
-            "schema_version": AI_STATUS_SCHEMA,
-            "action": "ai_status",
-            "provider": report.provider,
-            "provider_source": report.provider_source,
-            "model": report.model,
-            "model_source": report.model_source,
-            "host": report.host,
-            "host_source": report.host_source,
-            "api_key_set": report.api_key_source.is_some(),
-            "api_key_source": report.api_key_source,
-            "cloud_routed": report.cloud_routed,
-        });
+        let envelope = crate::envelope::action(
+            AI_STATUS_SCHEMA,
+            "ai_status",
+            serde_json::json!({
+                "provider": report.provider,
+                "provider_source": report.provider_source,
+                "model": report.model,
+                "model_source": report.model_source,
+                "host": report.host,
+                "host_source": report.host_source,
+                "api_key_set": report.api_key_source.is_some(),
+                "api_key_source": report.api_key_source,
+                "cloud_routed": report.cloud_routed,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }
@@ -422,12 +424,14 @@ fn models(provider: Option<String>, search: Option<String>, json: bool) -> Resul
     };
 
     if json {
-        let envelope = serde_json::json!({
-            "schema_version": AI_MODELS_SCHEMA,
-            "action": "ai_models",
-            "provider": kind.as_str(),
-            "models": filtered,
-        });
+        let envelope = crate::envelope::action(
+            AI_MODELS_SCHEMA,
+            "ai_models",
+            serde_json::json!({
+                "provider": kind.as_str(),
+                "models": filtered,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -58,14 +58,16 @@ pub fn run(options: AskOptions) -> Result<()> {
     let answer = answer?;
 
     if options.json {
-        let response = serde_json::json!({
-            "schema_version": ASK_SCHEMA,
-            "action": "ask",
-            "question": options.question,
-            "answer": answer.trim(),
-            "provider": provider.kind().as_str(),
-            "model": provider.model_name(),
-        });
+        let response = crate::envelope::action(
+            ASK_SCHEMA,
+            "ask",
+            serde_json::json!({
+                "question": options.question,
+                "answer": answer.trim(),
+                "provider": provider.kind().as_str(),
+                "model": provider.model_name(),
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
         println!("{answer}");

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -37,11 +37,13 @@ pub fn run(opts: ChangelogOptions) -> Result<()> {
 
     if tags.is_empty() {
         if opts.json {
-            let envelope = serde_json::json!({
-                "schema_version": CHANGELOG_SCHEMA,
-                "action": "changelog",
-                "releases": [],
-            });
+            let envelope = crate::envelope::action(
+                CHANGELOG_SCHEMA,
+                "changelog",
+                serde_json::json!({
+                    "releases": [],
+                }),
+            );
             println!("{}", serde_json::to_string_pretty(&envelope)?);
             return Ok(());
         }
@@ -83,11 +85,13 @@ pub fn run(opts: ChangelogOptions) -> Result<()> {
     };
 
     if opts.json {
-        let envelope = serde_json::json!({
-            "schema_version": CHANGELOG_SCHEMA,
-            "action": "changelog",
-            "releases": releases,
-        });
+        let envelope = crate::envelope::action(
+            CHANGELOG_SCHEMA,
+            "changelog",
+            serde_json::json!({
+                "releases": releases,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/create_template.rs
+++ b/src/create_template.rs
@@ -49,22 +49,24 @@ pub fn run(mut options: CreateTemplateOptions) -> Result<()> {
     scaffold(&target, &answers)?;
 
     if options.json {
-        let result = serde_json::json!({
-            "schema_version": CREATE_TEMPLATE_SCHEMA,
-            "action": "create",
-            "path": target.display().to_string(),
-            "name": answers.name,
-            "description": answers.description,
-            "render_patterns": answers.render_globs,
-            "include_hooks": answers.include_hooks,
-            "include_prompts": answers.include_prompts,
-            "files_created": [
-                "template.toml",
-                "README.md",
-                "README.md.tera",
-                ".gitignore",
-            ],
-        });
+        let result = crate::envelope::action(
+            CREATE_TEMPLATE_SCHEMA,
+            "create",
+            serde_json::json!({
+                "path": target.display().to_string(),
+                "name": answers.name,
+                "description": answers.description,
+                "render_patterns": answers.render_globs,
+                "include_hooks": answers.include_hooks,
+                "include_prompts": answers.include_prompts,
+                "files_created": [
+                    "template.toml",
+                    "README.md",
+                    "README.md.tera",
+                    ".gitignore",
+                ],
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!(

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -77,13 +77,15 @@ pub fn run(opts: DoctorOptions) -> Result<()> {
             passed,
             failed,
         };
-        let envelope = serde_json::json!({
-            "schema_version": DOCTOR_SCHEMA,
-            "action": "doctor",
-            "sections": report.sections,
-            "passed": report.passed,
-            "failed": report.failed,
-        });
+        let envelope = crate::envelope::action(
+            DOCTOR_SCHEMA,
+            "doctor",
+            serde_json::json!({
+                "sections": report.sections,
+                "passed": report.passed,
+                "failed": report.failed,
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -208,26 +208,28 @@ fn emit_init_envelope(
     git_initialized: bool,
     hooks_run: bool,
 ) -> Result<()> {
-    let result = serde_json::json!({
-        "schema_version": INIT_SCHEMA,
-        "action": "init",
-        "project": {
-            "name": name,
-            "path": target_dir.display().to_string(),
-        },
-        "template": {
-            "name": template.name,
-            "source": remote_ref,
-            "version": template.manifest.template.version,
-        },
-        "variables_used": variables.clone().into_json(),
-        "files_created": created_files
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>(),
-        "git_initialized": git_initialized,
-        "hooks_run": hooks_run,
-    });
+    let result = crate::envelope::action(
+        INIT_SCHEMA,
+        "init",
+        serde_json::json!({
+            "project": {
+                "name": name,
+                "path": target_dir.display().to_string(),
+            },
+            "template": {
+                "name": template.name,
+                "source": remote_ref,
+                "version": template.manifest.template.version,
+            },
+            "variables_used": variables.clone().into_json(),
+            "files_created": created_files
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>(),
+            "git_initialized": git_initialized,
+            "hooks_run": hooks_run,
+        }),
+    );
     println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -291,15 +291,17 @@ pub fn run(options: ReviewOptions) -> Result<()> {
             .collect();
         // Single-model invocations keep the legacy top-level `review` /
         // `provider` / `model` fields so existing scripts don't break.
-        let mut response = serde_json::json!({
-            "schema_version": REVIEW_SCHEMA,
-            "action": "review",
-            "base": base,
-            "file": options.file,
-            "diff_stats": diff_stats,
-            "spec_context": spec_names,
-            "reviews": reviews_json,
-        });
+        let mut response = crate::envelope::action(
+            REVIEW_SCHEMA,
+            "review",
+            serde_json::json!({
+                "base": base,
+                "file": options.file,
+                "diff_stats": diff_stats,
+                "spec_context": spec_names,
+                "reviews": reviews_json,
+            }),
+        );
         if results.len() == 1 {
             let r = &results[0];
             let obj = response.as_object_mut().expect("json object");

--- a/src/run.rs
+++ b/src/run.rs
@@ -267,12 +267,14 @@ fn list_tasks_json(tasks: &BTreeMap<String, TaskDef>, auto_detected: bool) -> Re
             dir: task.dir().map(|s| s.to_string()),
         })
         .collect();
-    let envelope = serde_json::json!({
-        "schema_version": RUN_LIST_SCHEMA,
-        "action": "run_list",
-        "auto_detected": auto_detected,
-        "tasks": task_list,
-    });
+    let envelope = crate::envelope::action(
+        RUN_LIST_SCHEMA,
+        "run_list",
+        serde_json::json!({
+            "auto_detected": auto_detected,
+            "tasks": task_list,
+        }),
+    );
     println!("{}", serde_json::to_string_pretty(&envelope)?);
     Ok(())
 }
@@ -315,16 +317,18 @@ fn execute_task(
             .output()
             .with_context(|| format!("running task '{name}'"))?;
 
-        let mut result = serde_json::json!({
-            "schema_version": RUN_TASK_SCHEMA,
-            "action": "run_task",
-            "task": name,
-            "command": cmd_str,
-            "exit_code": output.status.code().unwrap_or(-1),
-            "success": output.status.success(),
-            "stdout": String::from_utf8_lossy(&output.stdout),
-            "stderr": String::from_utf8_lossy(&output.stderr),
-        });
+        let mut result = crate::envelope::action(
+            RUN_TASK_SCHEMA,
+            "run_task",
+            serde_json::json!({
+                "task": name,
+                "command": cmd_str,
+                "exit_code": output.status.code().unwrap_or(-1),
+                "success": output.status.success(),
+                "stdout": String::from_utf8_lossy(&output.stdout),
+                "stderr": String::from_utf8_lossy(&output.stderr),
+            }),
+        );
         // Only surface `args` when present, so arg-less runs keep their exact
         // existing envelope shape.
         if !args.is_empty() {
@@ -575,13 +579,15 @@ fn init_fledge_toml(lang_override: Option<&str>, json: bool) -> Result<()> {
     std::fs::write(&path, content).context("writing fledge.toml")?;
 
     if json {
-        let envelope = serde_json::json!({
-            "schema_version": RUN_INIT_SCHEMA,
-            "action": "run_init",
-            "file": "fledge.toml",
-            "project_type": project_type,
-            "files_created": ["fledge.toml"],
-        });
+        let envelope = crate::envelope::action(
+            RUN_INIT_SCHEMA,
+            "run_init",
+            serde_json::json!({
+                "file": "fledge.toml",
+                "project_type": project_type,
+                "files_created": ["fledge.toml"],
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&envelope)?);
         return Ok(());
     }

--- a/src/template_cmds.rs
+++ b/src/template_cmds.rs
@@ -194,10 +194,8 @@ pub fn list_templates(json: bool) -> Result<()> {
                 })
             })
             .collect();
-        let mut result = serde_json::json!({
-            "schema_version": templates::TEMPLATES_LIST_SCHEMA,
-            "templates": entries,
-        });
+        let mut result =
+            crate::envelope::resource(templates::TEMPLATES_LIST_SCHEMA, "templates", entries);
         if available.is_empty() {
             result["hint"] = serde_json::Value::String(hint.to_string());
         }
@@ -390,23 +388,25 @@ pub fn publish_template(
                     .interact()?;
             if !confirm {
                 if json {
-                    let result = serde_json::json!({
-                        "schema_version": templates::TEMPLATES_PUBLISH_SCHEMA,
-                        "action": "publish",
-                        "cancelled": true,
-                        "repo": {
-                            "owner": owner,
-                            "name": repo_name,
-                            "url": format!("https://github.com/{owner}/{repo_name}"),
-                            "created": false,
-                            "private": private,
-                        },
-                        "template": {
-                            "description": desc,
-                        },
-                        "topic": "fledge-template",
-                        "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
-                    });
+                    let result = crate::envelope::action(
+                        templates::TEMPLATES_PUBLISH_SCHEMA,
+                        "publish",
+                        serde_json::json!({
+                            "cancelled": true,
+                            "repo": {
+                                "owner": owner,
+                                "name": repo_name,
+                                "url": format!("https://github.com/{owner}/{repo_name}"),
+                                "created": false,
+                                "private": private,
+                            },
+                            "template": {
+                                "description": desc,
+                            },
+                            "topic": "fledge-template",
+                            "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
+                        }),
+                    );
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 } else {
                     println!("{} Cancelled.", style("*").cyan().bold());
@@ -463,23 +463,25 @@ pub fn publish_template(
     }
 
     if json {
-        let result = serde_json::json!({
-            "schema_version": templates::TEMPLATES_PUBLISH_SCHEMA,
-            "action": "publish",
-            "cancelled": false,
-            "repo": {
-                "owner": owner,
-                "name": repo_name,
-                "url": format!("https://github.com/{owner}/{repo_name}"),
-                "created": created_repo,
-                "private": private,
-            },
-            "template": {
-                "description": desc,
-            },
-            "topic": "fledge-template",
-            "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
-        });
+        let result = crate::envelope::action(
+            templates::TEMPLATES_PUBLISH_SCHEMA,
+            "publish",
+            serde_json::json!({
+                "cancelled": false,
+                "repo": {
+                    "owner": owner,
+                    "name": repo_name,
+                    "url": format!("https://github.com/{owner}/{repo_name}"),
+                    "created": created_repo,
+                    "private": private,
+                },
+                "template": {
+                    "description": desc,
+                },
+                "topic": "fledge-template",
+                "use_hint": format!("fledge templates init <name> --template {owner}/{repo_name}"),
+            }),
+        );
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         println!("  {} Pushed template files", style("✅").green().bold());

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -283,10 +283,7 @@ fn extract_variables(content: &str) -> HashSet<String> {
 
 fn print_report(report: &ValidationReport, strict: bool, json: bool) -> Result<()> {
     if json {
-        let result = serde_json::json!({
-            "schema_version": VALIDATE_SCHEMA,
-            "reports": [report],
-        });
+        let result = crate::envelope::resource(VALIDATE_SCHEMA, "reports", [report]);
         println!("{}", serde_json::to_string_pretty(&result)?);
         return check_result(std::slice::from_ref(report), strict);
     }
@@ -318,10 +315,7 @@ fn print_report(report: &ValidationReport, strict: bool, json: bool) -> Result<(
 
 fn print_reports(reports: &[ValidationReport], strict: bool, json: bool) -> Result<()> {
     if json {
-        let result = serde_json::json!({
-            "schema_version": VALIDATE_SCHEMA,
-            "reports": reports,
-        });
+        let result = crate::envelope::resource(VALIDATE_SCHEMA, "reports", reports);
         println!("{}", serde_json::to_string_pretty(&result)?);
         return check_result(reports, strict);
     }


### PR DESCRIPTION
## Summary

**Final slice of #444** (batch: top-level command surface). Migrates all **17** remaining envelope sites:

| Dialect | Sites |
|---|---|
| action | `ai status`, `ai models`, `ask`, `changelog` (×2), `doctor`, `init`, `review`, `run_list`, `run_task`, `run_init`, `create_template`, `templates publish` (×2) |
| resource | `templates list`, `validate` (×2, `reports`) |

**Pure internal refactor, zero output change** — byte-for-byte-identical serialization.

## Verification
- [x] Live `run --list`, `doctor`, `ai status`, `ai models`, `changelog`, `templates list` `--json`: **all byte-identical** to the pre-change binary
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] Full suite **906 passing**; `fledge spec check` **0/0**
- [x] No AGENTS.md / spec change — no documented shape or export moved

## #444 complete

With this + #475 (plugin) + #476 (spec+release), **every** hand-rolled `serde_json::json!` envelope now routes through `envelope::{resource,action,versioned}` — no site can silently drift from its documented shape. (`introspect` already used a typed `#[derive(Serialize)]` struct and needed no change.) That closes the root cause behind the doc-drift class of bugs fixed one-by-one earlier this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi