### PR TITLE
Fix: share one env lock across test modules + isolate config tests (#447)

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -761,10 +761,11 @@ mod tests {
     use super::*;
     use crate::config::{AiConfig, OllamaConfig};
 
+    // Delegates to the crate-wide env lock so `ai` and `llm` env tests (which
+    // touch the same variables) serialize against each other, not just within
+    // their own module.
     fn test_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        crate::test_support::env_lock()
     }
 
     fn clear_env() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -768,12 +768,21 @@ author = "Partial"
 
     #[test]
     fn config_path_ends_with_expected_segments() {
+        let _lock = crate::test_support::env_lock();
+        // Assert the default path shape independent of any ambient
+        // FLEDGE_CONFIG_DIR the developer's shell (or a prior test) may leave set.
+        let _env = crate::test_support::EnvVarGuard::set("FLEDGE_CONFIG_DIR", None);
         let path = Config::config_path();
         assert!(path.ends_with("fledge/config.toml"));
     }
 
     #[test]
     fn load_returns_defaults_when_no_file() {
+        // Isolate to an empty tempdir so this exercises the "no config file"
+        // path, never the developer's real ~/.config/fledge/config.toml (which
+        // would make the assertion depend on the host environment).
+        let _lock = crate::test_support::env_lock();
+        let _config_dir = crate::test_support::ConfigDirGuard::new();
         let config = Config::load().unwrap();
         assert_eq!(config.license(), "MIT");
     }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -533,10 +533,11 @@ mod tests {
     use super::*;
     use crate::config::{AiConfig, AnthropicConfig, OllamaConfig, OpenAiConfig};
 
+    // Delegates to the crate-wide env lock so `llm` and `ai` env tests (which
+    // touch the same variables) serialize against each other, not just within
+    // their own module.
     fn test_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        crate::test_support::env_lock()
     }
 
     fn clear_env() {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -48,3 +48,85 @@ impl Drop for NonInteractiveGuard {
         crate::utils::set_non_interactive(self.prev);
     }
 }
+
+/// Environment variables are process-global; cargo runs unit tests on parallel
+/// threads. Tests in different modules that read or mutate the same variables
+/// (`FLEDGE_AI_PROVIDER`, `OLLAMA_HOST`, `FLEDGE_CONFIG_DIR`, …) must serialize
+/// on one lock. Before this, `ai.rs` and `llm.rs` each defined their own
+/// private `static LOCK`, so an `ai` test and an `llm` test could run at the
+/// same time and clobber each other's env — an intermittent, order-dependent
+/// failure. One lock for the whole test binary removes that race.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the process-wide environment-variable mutex. Hold the returned guard
+/// for the duration of any test that reads or mutates environment variables.
+pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    // Recover from a poisoned lock (a panic in another env test). The protected
+    // state is just "who's currently touching env," which a panic can't corrupt
+    // — every guard below restores what it changed.
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// RAII guard: sets a single environment variable to `value` (or removes it
+/// when `None`) for the test's duration, restoring the previous value on drop —
+/// even on panic. Hold [`env_lock`] alongside it, since env is process-global.
+pub(crate) struct EnvVarGuard {
+    key: String,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    pub(crate) fn set(key: &str, value: Option<&str>) -> Self {
+        let previous = std::env::var(key).ok();
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var(&self.key, v),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+/// RAII guard pointing `FLEDGE_CONFIG_DIR` at a fresh, empty tempdir for the
+/// test's duration, restoring the previous value (or unsetting it) on drop —
+/// even on panic. Keeps config-reading tests off the developer's real
+/// `~/.config/fledge/config.toml`. Hold [`env_lock`] alongside it.
+pub(crate) struct ConfigDirGuard {
+    tmp: tempfile::TempDir,
+    previous: Option<String>,
+}
+
+impl ConfigDirGuard {
+    pub(crate) fn new() -> Self {
+        let previous = std::env::var("FLEDGE_CONFIG_DIR").ok();
+        let tmp = tempfile::tempdir().expect("create tempdir for FLEDGE_CONFIG_DIR");
+        std::env::set_var("FLEDGE_CONFIG_DIR", tmp.path());
+        Self { tmp, previous }
+    }
+
+    /// The isolated config directory (empty until the test writes into it).
+    #[allow(dead_code)]
+    pub(crate) fn path(&self) -> &std::path::Path {
+        self.tmp.path()
+    }
+}
+
+impl Drop for ConfigDirGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var("FLEDGE_CONFIG_DIR", v),
+            None => std::env::remove_var("FLEDGE_CONFIG_DIR"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Environment-isolation slice of #447 — fixes the flaky env-race in the test suite and two tests that read the developer's real config.

### The race

`ai.rs` and `llm.rs` each defined their **own private `static LOCK`** inside `test_lock()`. Both modules' tests mutate the *same* process-global env vars (`FLEDGE_AI_PROVIDER`, `OLLAMA_HOST`, …), but cargo runs tests on parallel threads — so an `ai` test and an `llm` test could run **at the same time on different locks** and clobber each other's env. Intermittent, order-dependent failure.

Fix: a single crate-wide `env_lock()` in `test_support` (alongside the existing `cwd_lock`). `ai` and `llm` `test_lock()` now delegate to it, so every env-touching test across all modules serializes on **one** mutex.

### The real-config leak

- `load_returns_defaults_when_no_file` called `Config::load()` with no isolation — on any machine whose `~/.config/fledge/config.toml` sets a non-default `[defaults].license`, it read that file and failed.
- `config_path_ends_with_expected_segments` asserted the default path shape without guarding against an ambient `FLEDGE_CONFIG_DIR`.

Fix: two RAII guards (`ConfigDirGuard`, `EnvVarGuard`) — panic-safe save/restore — pin these tests to a tempdir / cleared env.

## Proof both directions

With a hostile `FLEDGE_CONFIG_DIR` pointing at a config whose `[defaults].license = "Apache-2.0"`:

- **Old body** (`Config::load()` directly) → reads the ambient config → `Apache-2.0 != MIT` → **FAILS**
- **Guarded body** (`ConfigDirGuard`) → overrides to an empty tempdir → defaults → **PASSES**

## Scope

This is the isolation slice only. Follow-ups from #447: the network/subprocess **mocking harness** and remaining coverage of the LLM/GitHub/git paths. The publish-path coverage gap (#447's third bullet) was already closed by the envelope tests in #443.

## Test Plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --bin fledge` — 909 pass, run twice, deterministic
- [x] `fledge lanes run pre-commit` — fmt + lint + full test (incl. integration) + spec-check, green
- [x] Demonstrated the guard fixes the leak (hostile-`FLEDGE_CONFIG_DIR` before/after)
- [x] Test-only change — no production code or behavior touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
