### PR TITLE
Refactor: decompose main::run — extract CLI-subcommand → action mappings (#446)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,58 +75,8 @@ fn run() -> Result<()> {
         Commands::Config { action } => {
             config_cmds::handle_config(action)?;
         }
-        Commands::Spec { action } => {
-            let action = match action {
-                SpecSubcommand::Check { strict, json } => spec::SpecAction::Check { strict, json },
-                SpecSubcommand::Init => spec::SpecAction::Init,
-                SpecSubcommand::List { json } => spec::SpecAction::List { json },
-                SpecSubcommand::New { name } => spec::SpecAction::New { name },
-                SpecSubcommand::Show { name, json } => spec::SpecAction::Show { name, json },
-            };
-            spec::run(action)?;
-        }
-        Commands::Work { action } => {
-            let action = match action {
-                WorkSubcommand::Start {
-                    name,
-                    branch_type,
-                    issue,
-                    prefix,
-                    base,
-                    json,
-                } => work::WorkAction::Start {
-                    name,
-                    branch_type,
-                    issue,
-                    prefix,
-                    base,
-                    json,
-                },
-                WorkSubcommand::Commit {
-                    message,
-                    commit_type,
-                    scope,
-                    all,
-                    ai,
-                    provider,
-                    model,
-                    json,
-                } => work::WorkAction::Commit {
-                    message,
-                    commit_type,
-                    scope,
-                    all,
-                    ai,
-                    provider,
-                    model,
-                    json,
-                },
-                WorkSubcommand::Push { force, json } => work::WorkAction::Push { force, json },
-                WorkSubcommand::Status { json } => work::WorkAction::Status { json },
-                WorkSubcommand::Pr { _args: _ } => work::WorkAction::DeprecatedPr,
-            };
-            work::run(action)?;
-        }
+        Commands::Spec { action } => spec::run(spec_action_from(action))?,
+        Commands::Work { action } => work::run(work_action_from(action))?,
         Commands::Run {
             task,
             init,
@@ -191,82 +141,7 @@ fn run() -> Result<()> {
                 no_active,
             })?;
         }
-        Commands::Lanes { action } => {
-            let action = match action {
-                LaneSubcommand::Run {
-                    name,
-                    dry_run,
-                    json,
-                    from,
-                } => lanes::LaneAction::Run {
-                    name,
-                    dry_run,
-                    json,
-                    from,
-                },
-                LaneSubcommand::List { json } => lanes::LaneAction::List { json },
-                LaneSubcommand::Init { json } => lanes::LaneAction::Init { json },
-                LaneSubcommand::Search {
-                    query,
-                    author,
-                    json,
-                } => lanes::LaneAction::Search {
-                    query,
-                    author,
-                    json,
-                },
-                LaneSubcommand::Import { source, yes, json } => {
-                    lanes::LaneAction::Import { source, yes, json }
-                }
-                LaneSubcommand::Publish {
-                    path,
-                    org,
-                    private,
-                    description,
-                    yes,
-                    json,
-                } => lanes::LaneAction::Publish {
-                    path,
-                    org,
-                    private,
-                    description,
-                    yes,
-                    json,
-                },
-                LaneSubcommand::Create {
-                    name,
-                    output,
-                    description,
-                    yes,
-                    json,
-                } => lanes::LaneAction::Create {
-                    name,
-                    output,
-                    description,
-                    yes,
-                    json,
-                },
-                LaneSubcommand::Validate { path, strict, json } => {
-                    lanes::LaneAction::Validate { path, strict, json }
-                }
-                LaneSubcommand::External(args) => {
-                    let name = args.first().cloned().unwrap_or_default();
-                    let dry_run = args.iter().any(|a| a == "--dry-run");
-                    let json = args.iter().any(|a| a == "--json");
-                    let from = args
-                        .iter()
-                        .position(|a| a == "--from")
-                        .and_then(|pos| args.get(pos + 1).cloned());
-                    lanes::LaneAction::Run {
-                        name,
-                        dry_run,
-                        json,
-                        from,
-                    }
-                }
-            };
-            lanes::run(action)?;
-        }
+        Commands::Lanes { action } => lanes::run(lane_action_from(action))?,
         Commands::Changelog {
             limit,
             tag,
@@ -288,73 +163,10 @@ fn run() -> Result<()> {
             introspect::run(introspect::IntrospectOptions { json }, cmd)?;
         }
         Commands::Plugins { action, json } => {
-            let action = match action {
-                PluginSubcommand::Install {
-                    source,
-                    force,
-                    yes,
-                    copy,
-                    defaults,
-                } => plugin::PluginAction::Install {
-                    source,
-                    force: force || yes,
-                    copy,
-                    defaults,
-                },
-                PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },
-                PluginSubcommand::Update { name, defaults } => {
-                    plugin::PluginAction::Update { name, defaults }
-                }
-                PluginSubcommand::List => plugin::PluginAction::List,
-                PluginSubcommand::Audit => plugin::PluginAction::Audit,
-                PluginSubcommand::Search {
-                    query,
-                    author,
-                    topic,
-                    trust_tier,
-                    limit,
-                    interactive,
-                } => plugin::PluginAction::Search {
-                    query,
-                    author,
-                    topic,
-                    trust_tier,
-                    limit,
-                    interactive,
-                },
-                PluginSubcommand::Recommend => plugin::PluginAction::Recommend,
-                PluginSubcommand::Run { name, args } => plugin::PluginAction::Run { name, args },
-                PluginSubcommand::Publish {
-                    path,
-                    org,
-                    private,
-                    description,
-                    yes,
-                } => plugin::PluginAction::Publish {
-                    path,
-                    org,
-                    private,
-                    description,
-                    yes,
-                },
-                PluginSubcommand::Create {
-                    name,
-                    output,
-                    description,
-                    yes,
-                    wasm,
-                } => plugin::PluginAction::Create {
-                    name,
-                    output,
-                    description,
-                    yes,
-                    wasm,
-                },
-                PluginSubcommand::Validate { path, strict, json } => {
-                    plugin::PluginAction::Validate { path, strict, json }
-                }
-            };
-            plugin::run(plugin::PluginOptions { action, json })?;
+            plugin::run(plugin::PluginOptions {
+                action: plugin_action_from(action),
+                json,
+            })?;
         }
         Commands::Release {
             bump,
@@ -379,22 +191,7 @@ fn run() -> Result<()> {
                 json,
             })?;
         }
-        Commands::Ai { action } => {
-            let action = match action {
-                AiSubcommand::Status { json } => ai::AiAction::Status { json },
-                AiSubcommand::Models {
-                    provider,
-                    search,
-                    json,
-                } => ai::AiAction::Models {
-                    provider,
-                    search,
-                    json,
-                },
-                AiSubcommand::Use { provider, model } => ai::AiAction::Use { provider, model },
-            };
-            ai::run(action)?;
-        }
+        Commands::Ai { action } => ai::run(ai_action_from(action))?,
         Commands::Ask {
             question,
             json,
@@ -459,4 +256,304 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+// ── CLI-subcommand → handler-action translation ─────────────────────────────
+// These map the clap-derived `*Subcommand` enums onto each handler's own action
+// enum. Kept out of `run` so the top-level dispatch stays a flat one-line-per-
+// command match, and so the non-trivial bits (plugin install's force||yes, the
+// external-lane flag parsing) are isolated and unit-testable.
+
+fn spec_action_from(action: SpecSubcommand) -> spec::SpecAction {
+    match action {
+        SpecSubcommand::Check { strict, json } => spec::SpecAction::Check { strict, json },
+        SpecSubcommand::Init => spec::SpecAction::Init,
+        SpecSubcommand::List { json } => spec::SpecAction::List { json },
+        SpecSubcommand::New { name } => spec::SpecAction::New { name },
+        SpecSubcommand::Show { name, json } => spec::SpecAction::Show { name, json },
+    }
+}
+
+fn work_action_from(action: WorkSubcommand) -> work::WorkAction {
+    match action {
+        WorkSubcommand::Start {
+            name,
+            branch_type,
+            issue,
+            prefix,
+            base,
+            json,
+        } => work::WorkAction::Start {
+            name,
+            branch_type,
+            issue,
+            prefix,
+            base,
+            json,
+        },
+        WorkSubcommand::Commit {
+            message,
+            commit_type,
+            scope,
+            all,
+            ai,
+            provider,
+            model,
+            json,
+        } => work::WorkAction::Commit {
+            message,
+            commit_type,
+            scope,
+            all,
+            ai,
+            provider,
+            model,
+            json,
+        },
+        WorkSubcommand::Push { force, json } => work::WorkAction::Push { force, json },
+        WorkSubcommand::Status { json } => work::WorkAction::Status { json },
+        WorkSubcommand::Pr { _args: _ } => work::WorkAction::DeprecatedPr,
+    }
+}
+
+/// Parse the raw args of an external `fledge lanes <name> [flags]` invocation
+/// (the clap `External` catch-all) into `(name, dry_run, json, from)`.
+fn parse_external_lane_args(args: &[String]) -> (String, bool, bool, Option<String>) {
+    let name = args.first().cloned().unwrap_or_default();
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+    let json = args.iter().any(|a| a == "--json");
+    let from = args
+        .iter()
+        .position(|a| a == "--from")
+        .and_then(|pos| args.get(pos + 1).cloned());
+    (name, dry_run, json, from)
+}
+
+fn lane_action_from(action: LaneSubcommand) -> lanes::LaneAction {
+    match action {
+        LaneSubcommand::Run {
+            name,
+            dry_run,
+            json,
+            from,
+        } => lanes::LaneAction::Run {
+            name,
+            dry_run,
+            json,
+            from,
+        },
+        LaneSubcommand::List { json } => lanes::LaneAction::List { json },
+        LaneSubcommand::Init { json } => lanes::LaneAction::Init { json },
+        LaneSubcommand::Search {
+            query,
+            author,
+            json,
+        } => lanes::LaneAction::Search {
+            query,
+            author,
+            json,
+        },
+        LaneSubcommand::Import { source, yes, json } => {
+            lanes::LaneAction::Import { source, yes, json }
+        }
+        LaneSubcommand::Publish {
+            path,
+            org,
+            private,
+            description,
+            yes,
+            json,
+        } => lanes::LaneAction::Publish {
+            path,
+            org,
+            private,
+            description,
+            yes,
+            json,
+        },
+        LaneSubcommand::Create {
+            name,
+            output,
+            description,
+            yes,
+            json,
+        } => lanes::LaneAction::Create {
+            name,
+            output,
+            description,
+            yes,
+            json,
+        },
+        LaneSubcommand::Validate { path, strict, json } => {
+            lanes::LaneAction::Validate { path, strict, json }
+        }
+        LaneSubcommand::External(args) => {
+            let (name, dry_run, json, from) = parse_external_lane_args(&args);
+            lanes::LaneAction::Run {
+                name,
+                dry_run,
+                json,
+                from,
+            }
+        }
+    }
+}
+
+fn plugin_action_from(action: PluginSubcommand) -> plugin::PluginAction {
+    match action {
+        PluginSubcommand::Install {
+            source,
+            force,
+            yes,
+            copy,
+            defaults,
+        } => plugin::PluginAction::Install {
+            source,
+            force: force || yes,
+            copy,
+            defaults,
+        },
+        PluginSubcommand::Remove { name } => plugin::PluginAction::Remove { name },
+        PluginSubcommand::Update { name, defaults } => {
+            plugin::PluginAction::Update { name, defaults }
+        }
+        PluginSubcommand::List => plugin::PluginAction::List,
+        PluginSubcommand::Audit => plugin::PluginAction::Audit,
+        PluginSubcommand::Search {
+            query,
+            author,
+            topic,
+            trust_tier,
+            limit,
+            interactive,
+        } => plugin::PluginAction::Search {
+            query,
+            author,
+            topic,
+            trust_tier,
+            limit,
+            interactive,
+        },
+        PluginSubcommand::Recommend => plugin::PluginAction::Recommend,
+        PluginSubcommand::Run { name, args } => plugin::PluginAction::Run { name, args },
+        PluginSubcommand::Publish {
+            path,
+            org,
+            private,
+            description,
+            yes,
+        } => plugin::PluginAction::Publish {
+            path,
+            org,
+            private,
+            description,
+            yes,
+        },
+        PluginSubcommand::Create {
+            name,
+            output,
+            description,
+            yes,
+            wasm,
+        } => plugin::PluginAction::Create {
+            name,
+            output,
+            description,
+            yes,
+            wasm,
+        },
+        PluginSubcommand::Validate { path, strict, json } => {
+            plugin::PluginAction::Validate { path, strict, json }
+        }
+    }
+}
+
+fn ai_action_from(action: AiSubcommand) -> ai::AiAction {
+    match action {
+        AiSubcommand::Status { json } => ai::AiAction::Status { json },
+        AiSubcommand::Models {
+            provider,
+            search,
+            json,
+        } => ai::AiAction::Models {
+            provider,
+            search,
+            json,
+        },
+        AiSubcommand::Use { provider, model } => ai::AiAction::Use { provider, model },
+    }
+}
+
+#[cfg(test)]
+mod main_tests {
+    use super::*;
+
+    #[test]
+    fn external_lane_args_bare_name() {
+        let (name, dry_run, json, from) = parse_external_lane_args(&["ci".to_string()]);
+        assert_eq!(name, "ci");
+        assert!(!dry_run);
+        assert!(!json);
+        assert_eq!(from, None);
+    }
+
+    #[test]
+    fn external_lane_args_flags_and_from() {
+        let args = vec![
+            "ci".to_string(),
+            "--dry-run".to_string(),
+            "--json".to_string(),
+            "--from".to_string(),
+            "build".to_string(),
+        ];
+        let (name, dry_run, json, from) = parse_external_lane_args(&args);
+        assert_eq!(name, "ci");
+        assert!(dry_run);
+        assert!(json);
+        assert_eq!(from.as_deref(), Some("build"));
+    }
+
+    #[test]
+    fn external_lane_args_from_without_value_is_none() {
+        let args = vec!["ci".to_string(), "--from".to_string()];
+        let (_, _, _, from) = parse_external_lane_args(&args);
+        assert_eq!(from, None);
+    }
+
+    #[test]
+    fn external_lane_args_empty_name_defaults_blank() {
+        let (name, _, _, _) = parse_external_lane_args(&[]);
+        assert_eq!(name, "");
+    }
+
+    #[test]
+    fn plugin_install_yes_implies_force() {
+        // `--yes` is an alias for `--force` on install; the mapping must OR them.
+        let action = plugin_action_from(PluginSubcommand::Install {
+            source: Some("acme/plugin".to_string()),
+            force: false,
+            yes: true,
+            copy: false,
+            defaults: false,
+        });
+        match action {
+            plugin::PluginAction::Install { force, .. } => assert!(force),
+            _ => panic!("expected Install action"),
+        }
+    }
+
+    #[test]
+    fn plugin_install_neither_force_nor_yes_stays_false() {
+        let action = plugin_action_from(PluginSubcommand::Install {
+            source: Some("acme/plugin".to_string()),
+            force: false,
+            yes: false,
+            copy: false,
+            defaults: false,
+        });
+        match action {
+            plugin::PluginAction::Install { force, .. } => assert!(!force),
+            _ => panic!("expected Install action"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fifth of the #446 god-function decompositions (after #481/#482/#483/#484). `main.rs::run` was a **401-line** `match cli.command` dispatch whose bulk was five arms translating a clap `*Subcommand` enum into each handler's own action enum inline.

## What was extracted

| Helper | Was |
|---|---|
| `spec_action_from` / `work_action_from` / `lane_action_from` / `plugin_action_from` / `ai_action_from` | the five inline CLI→action translations (Work ~40, Lanes ~75, Plugins ~68 lines) |
| `parse_external_lane_args(args) -> (name, dry_run, json, from)` | the `External` lane catch-all flag parsing — pulled out as a **testable** unit |

**`main::run`: 401 → 198 lines** — the top-level match is now a flat one-line-per-command dispatch.

## The non-mechanical bits (isolated + tested)

Most fields map by init-shorthand (compiler-guaranteed 1:1). The two places with actual logic are now unit-tested:

- `plugin_action_from`: `PluginSubcommand::Install` maps `force: force || yes` — `--yes` aliases `--force`.
- `parse_external_lane_args`: scans raw args for `--dry-run` / `--json` / `--from <val>`.

6 new tests cover both.

## Verification

- [x] Adversarial review of every variant across all five functions — confirmed each field maps to its identically-named target (hunting specifically for same-type field swaps the compiler can't catch); other arms + run head/tail unchanged
- [x] Dispatch smoke-tested end-to-end: `spec show work` / `spec list` / `plugins list` / `ai status` / `lanes list` / `introspect` `--json` all produce correct output (field-carrying variants pass through)
- [x] 6 new unit tests (`external_lane_args_*`, `plugin_install_*`)
- [x] `cargo test --bin fledge` — 933 pass (+6), 0 fail
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean
- [x] `fledge lanes run pre-commit` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
