### PR TITLE
Add TestRepo git fixture and cover the read-only git helpers (#447)

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -163,4 +163,18 @@ mod tests {
     fn parse_invalid_url_errors() {
         assert!(parse_repo_url("https://gitlab.com/user/repo").is_err());
     }
+
+    #[test]
+    fn ensure_git_repo_ok_inside_repo() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.run_in(|| assert!(ensure_git_repo().is_ok()));
+    }
+
+    #[test]
+    fn ensure_git_repo_errors_outside_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::test_support::with_cwd(tmp.path(), || {
+            assert!(ensure_git_repo().is_err());
+        });
+    }
 }

--- a/src/lanes/tests.rs
+++ b/src/lanes/tests.rs
@@ -311,7 +311,7 @@ description = "Sequential"
 steps = ["a", "b"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "seq",
         &config.lanes["seq"],
@@ -333,7 +333,7 @@ fn execute_inline_step() {
 steps = [{ run = "echo inline-works" }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "inline",
         &config.lanes["inline"],
@@ -357,7 +357,7 @@ b = "echo parallel-b"
 steps = [{ parallel = ["a", "b"] }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "par",
         &config.lanes["par"],
@@ -404,7 +404,7 @@ a = "echo task-a"
 steps = [{ parallel = ["a", { run = "echo inline-b" }] }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "mixed",
         &config.lanes["mixed"],
@@ -426,7 +426,7 @@ fn execute_parallel_all_inline() {
 steps = [{ parallel = [{ run = "echo one" }, { run = "echo two" }] }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "inlines",
         &config.lanes["inlines"],
@@ -489,7 +489,7 @@ fail_fast = true
 steps = ["fail", "ok"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ff",
         &config.lanes["ff"],
@@ -515,7 +515,7 @@ fail_fast = false
 steps = ["fail", "ok"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "noff",
         &config.lanes["noff"],
@@ -543,7 +543,7 @@ cmd = "echo preparing"
 steps = ["build"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1147,7 +1147,7 @@ c = "echo ok-c"
 steps = ["a", "b", "c"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // Step "a" would fail, but --from 2 skips it
     let result = execute_lane(
         "ci",
@@ -1172,7 +1172,7 @@ ok = "echo ok"
 steps = ["fail", "ok"]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // Skip "fail", start from "ok"
     let result = execute_lane(
         "ci",
@@ -1330,7 +1330,7 @@ steps = [
 ]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // First step has when condition that's not met, so it's skipped
     // Second step runs and passes
     let result = execute_lane(
@@ -1355,7 +1355,7 @@ fn execute_when_runs_step() {
 steps = [{ run = "echo conditional-ok", when = "FLEDGE_TEST_RUN=yes" }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1423,7 +1423,7 @@ fn execute_timeout_kills_slow_command() {
 steps = [{ run = "sleep 30", timeout = 1 }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1453,7 +1453,7 @@ fn execute_timeout_fast_command_succeeds() {
 steps = [{ run = "echo fast", timeout = 30 }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1477,7 +1477,7 @@ fn execute_retries_succeed_on_first_try() {
 steps = [{ run = "echo ok", retries = 3 }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1499,7 +1499,7 @@ fn execute_retries_still_fail_after_exhaustion() {
 steps = [{ run = "exit 1", retries = 2 }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "ci",
         &config.lanes["ci"],
@@ -1539,7 +1539,7 @@ fn execute_retry_delay_zero_skips_sleep() {
 steps = [{ run = "exit 1", retries = 2, retry_delay = 0 }]
 "#,
     );
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let start = std::time::Instant::now();
     let result = execute_lane(
         "fast-fail",
@@ -1590,7 +1590,7 @@ steps = [{{ run = "{cmd}", retries = 2 }}]
 "#
     );
     let config = parse_config(&toml_str);
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "flaky",
         &config.lanes["flaky"],
@@ -1826,7 +1826,7 @@ steps = [{{ run = "{cmd}", timeout = 1 }}]
 "#
     );
     let config = parse_config(&toml_str);
-    let project_dir = std::env::current_dir().unwrap();
+    let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let result = execute_lane(
         "timeout",
         &config.lanes["timeout"],

--- a/src/release/tests.rs
+++ b/src/release/tests.rs
@@ -4,20 +4,8 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::test_support::cwd_lock;
+use crate::test_support::with_cwd;
 use crate::versioning::parse_version;
-
-fn with_cwd<F: FnOnce() -> R, R>(dir: &Path, f: F) -> R {
-    let _guard = cwd_lock();
-    let saved = std::env::current_dir().unwrap();
-    std::env::set_current_dir(dir).unwrap();
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-    let _ = std::env::set_current_dir(saved);
-    match result {
-        Ok(r) => r,
-        Err(payload) => std::panic::resume_unwind(payload),
-    }
-}
 
 fn init_git_repo(dir: &Path) {
     Command::new("git")

--- a/src/review.rs
+++ b/src/review.rs
@@ -1060,4 +1060,75 @@ mod tests {
         assert!(env.get("review").is_none());
         assert!(env.get("error").is_none());
     }
+
+    // ── git read helpers, driven against a real temp repo ──────────────────
+
+    #[test]
+    fn default_branch_prefers_origin_head() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        // A symbolic-ref for origin/HEAD wins over the local-branch ladder.
+        repo.git(&[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/develop",
+        ]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "develop");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_main() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        repo.git(&["branch", "-M", "main"]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "main");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_master() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        repo.git(&["branch", "-M", "master"]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "master");
+    }
+
+    #[test]
+    fn default_branch_defaults_to_main_when_none_present() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        // Neither origin/HEAD, main, nor master exists → the "main" fallback.
+        repo.git(&["branch", "-M", "feature"]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "main");
+    }
+
+    #[test]
+    fn get_diff_and_changed_files_report_the_change() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("x.txt", "one\n");
+        repo.commit_file("x.txt", "two\n");
+        let (diff, files) = repo.run_in(|| {
+            (
+                get_diff("HEAD~1", None).unwrap(),
+                get_changed_files("HEAD~1", None).unwrap(),
+            )
+        });
+        assert!(
+            diff.contains("-one"),
+            "diff should show the removed line: {diff}"
+        );
+        assert!(
+            diff.contains("+two"),
+            "diff should show the added line: {diff}"
+        );
+        assert_eq!(files, vec!["x.txt".to_string()]);
+    }
+
+    #[test]
+    fn get_diff_helpers_reject_dash_base() {
+        // The `base.starts_with('-')` guard blocks option-injection; it fires
+        // before any git call, so no repo is needed.
+        assert!(get_diff("-rf", None).is_err());
+        assert!(get_diff_stats("-rf", None).is_err());
+        assert!(get_changed_files("-rf", None).is_err());
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -130,3 +130,73 @@ impl Drop for ConfigDirGuard {
         }
     }
 }
+
+/// Run `f` with the process current directory set to `dir`, serialized on the
+/// shared [`cwd_lock`] and restoring the previous directory afterward — even on
+/// panic. Use to drive production helpers that shell out to `git` (or any tool)
+/// in the current directory. Because the CWD is process-global, this holds
+/// `cwd_lock` for the whole closure; keep `f` short.
+pub(crate) fn with_cwd<F: FnOnce() -> R, R>(dir: &std::path::Path, f: F) -> R {
+    let _guard = cwd_lock();
+    let saved = std::env::current_dir().unwrap();
+    std::env::set_current_dir(dir).unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    let _ = std::env::set_current_dir(saved);
+    match result {
+        Ok(r) => r,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+/// A throwaway git repository in a tempdir, for exercising the git-subprocess
+/// helpers against a real `git` — the same approach `release::tests` already
+/// uses (real git is more faithful than any canned-stdout double). Seed it with
+/// the builder methods, then drive a CWD-bound production helper via
+/// [`TestRepo::run_in`]. The repo is deleted when the `TestRepo` drops.
+pub(crate) struct TestRepo {
+    dir: tempfile::TempDir,
+}
+
+impl TestRepo {
+    /// Initialize a repo (`git init` + a committer identity) in a fresh tempdir.
+    pub(crate) fn init() -> Self {
+        let repo = Self {
+            dir: tempfile::tempdir().expect("create tempdir for TestRepo"),
+        };
+        repo.git(&["init"]);
+        repo.git(&["config", "user.email", "test@test.com"]);
+        repo.git(&["config", "user.name", "Test"]);
+        repo
+    }
+
+    /// The repository's working-directory path.
+    #[allow(dead_code)]
+    pub(crate) fn path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    /// Run a git command in the repo, returning its `Output`. Panics only if
+    /// `git` can't be spawned; the exit status is left for the caller to
+    /// inspect (setup steps like `symbolic-ref` may legitimately be checked).
+    pub(crate) fn git(&self, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(self.dir.path())
+            .output()
+            .expect("spawn git")
+    }
+
+    /// Write `content` to `name` and commit it as "add {name}". Returns `&self`
+    /// for chaining.
+    pub(crate) fn commit_file(&self, name: &str, content: &str) -> &Self {
+        std::fs::write(self.dir.path().join(name), content).expect("write test file");
+        self.git(&["add", name]);
+        self.git(&["commit", "-m", &format!("add {name}")]);
+        self
+    }
+
+    /// Run `f` with the process CWD set to this repo (see [`with_cwd`]).
+    pub(crate) fn run_in<F: FnOnce() -> R, R>(&self, f: F) -> R {
+        with_cwd(self.dir.path(), f)
+    }
+}

--- a/src/work.rs
+++ b/src/work.rs
@@ -990,4 +990,55 @@ test = "cargo test"
             "feat: support http: and https: URLs"
         );
     }
+
+    // ── git read helpers, driven against a real temp repo ──────────────────
+
+    #[test]
+    fn current_branch_reflects_checkout() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        repo.git(&["branch", "-M", "feature-x"]);
+        assert_eq!(repo.run_in(current_branch).unwrap(), "feature-x");
+    }
+
+    #[test]
+    fn has_uncommitted_changes_tracks_worktree_state() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        assert!(!repo.run_in(has_uncommitted_changes).unwrap());
+        std::fs::write(repo.path().join("b.txt"), "new\n").unwrap();
+        assert!(repo.run_in(has_uncommitted_changes).unwrap());
+    }
+
+    #[test]
+    fn default_branch_prefers_origin_head() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        // A symbolic-ref for origin/HEAD wins over the local-branch ladder,
+        // and the `origin/` prefix is stripped.
+        repo.git(&[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/develop",
+        ]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "develop");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_master() {
+        // Isolates the rev-parse ladder: "master" differs from the hardcoded
+        // "main" fallback, so this genuinely exercises branch detection.
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        repo.git(&["branch", "-M", "master"]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "master");
+    }
+
+    #[test]
+    fn default_branch_falls_back_to_main() {
+        let repo = crate::test_support::TestRepo::init();
+        repo.commit_file("a.txt", "1\n");
+        repo.git(&["branch", "-M", "main"]);
+        assert_eq!(repo.run_in(default_branch).unwrap(), "main");
+    }
 }


### PR DESCRIPTION
## Summary

The **#447 mocking-harness follow-up**. A design pass over fledge's network/subprocess seams found that the two seams a harness should reuse already exist: the `LlmProvider` trait, and the real-temp-repo git pattern that `release::tests` already proves green in CI. What was missing was a **shared fixture** — the git-repo helpers were trapped as private functions in `release/tests.rs`, so the many CWD-bound read-only git helpers elsewhere (`review`, `work`, `github`) had no test path.

**This PR is entirely test-side — zero production code changes.**

## What's added

| File | Change |
|---|---|
| `test_support.rs` | `with_cwd(dir, f)` (hoisted) + a `TestRepo` builder — real `git` in a tempdir (`init` / `commit_file` / `git` / `run_in`). No new dependency. |
| `release/tests.rs` | drop its private `with_cwd`, use the shared one (de-dup, verified by the existing release tests) |
| `review.rs` / `work.rs` / `github.rs` | **13 real-git tests** for previously-untested read helpers |
| `lanes/tests.rs` | fix a pre-existing CWD-read race (see below) |

### The 13 new tests

- `review::default_branch` **and** `work::default_branch` (each has its own near-duplicate impl) — the isolating ladder: `origin/HEAD` symbolic-ref → strips `origin/`; `master` (≠ the hardcoded fallback, so it genuinely exercises detection); `main`; and (review) the `"main"` fallback when none exist.
- `review::get_diff` + `get_changed_files` — real diff between two commits; plus the `base.starts_with('-')` option-injection guard on all three diff helpers.
- `work::current_branch` / `has_uncommitted_changes` (clean→false, untracked→true).
- `github::ensure_git_repo` — Ok inside a repo, Err outside one.

## The `lanes/tests.rs` fix

The `execute_*` lane tests read `std::env::current_dir()` **without holding `cwd_lock`**, then run a lane in it. The new chdir'ing git tests exposed this **pre-existing race** (already latent against `release::tests`, which chdir under the lock). Those tests don't need the *live* CWD — only a stable dir — so 19 sites now use `env!("CARGO_MANIFEST_DIR")`, which equals the real CWD in normal runs and is race-proof. The retry test's counter is an absolute temp path, and the line-996 chdir-restore is untouched.

## Verification

- [x] **939 → 952 tests**, 0 fail
- [x] Race fix stress-tested: the lanes `execute_*` + git-fixture tests together, `RUST_TEST_THREADS=16`, **12× with zero flakes** (was failing ~every run before the fix)
- [x] `release::tests` — 57 pass unchanged (de-dup is behavior-preserving)
- [x] Adversarial review of the two refactors + test non-vacuousness
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean
- [x] `fledge lanes run pre-commit` — green; `fledge spec check` unaffected (test-only; `test_support.rs` is `cfg(test)`, no governed surface added)

## Follow-ups (from the design)

- A `StubLlmProvider` in `test_support.rs` (the trait already exists) to test `review::run_panel` fan-out / error-isolation.
- Pure-function extraction in `github.rs` (`build_api_url` / error-message) to test the request/error halves without HTTP — has a small `specs/github` cost, so it lands after the free wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
