### PR TITLE
Add StubLlmProvider and cover review::run_panel fan-out (#447)

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -1131,4 +1131,101 @@ mod tests {
         assert!(get_diff_stats("-rf", None).is_err());
         assert!(get_changed_files("-rf", None).is_err());
     }
+
+    // ── run_panel fan-out, driven by stub providers (no network) ───────────
+
+    #[test]
+    fn run_panel_preserves_order_and_isolates_a_failing_slot() {
+        use crate::llm::ProviderKind;
+        use crate::test_support::StubLlmProvider;
+        // A failing middle slot must not drop or reorder its neighbours.
+        let providers: Vec<Box<dyn llm::LlmProvider>> = vec![
+            Box::new(StubLlmProvider::ok(ProviderKind::Ollama, Some("m1"), "AAA")),
+            Box::new(StubLlmProvider::err(
+                ProviderKind::Anthropic,
+                Some("m2"),
+                "boom",
+            )),
+            Box::new(StubLlmProvider::ok(ProviderKind::OpenAi, None, "CCC")),
+        ];
+        let results = run_panel(providers, "the-diff".to_string()).unwrap();
+
+        assert_eq!(results.len(), 3, "a failing slot must not drop the others");
+        // Order matches the input despite parallel execution.
+        assert_eq!(results[0].provider_kind, "ollama");
+        assert_eq!(results[0].model_name.as_deref(), Some("m1"));
+        assert_eq!(results[0].outcome.as_deref().unwrap(), "AAA");
+        // Middle slot's failure is captured, not propagated.
+        assert_eq!(results[1].provider_kind, "anthropic");
+        assert_eq!(results[1].model_name.as_deref(), Some("m2"));
+        let err = results[1].outcome.as_ref().unwrap_err().to_string();
+        assert!(
+            err.contains("boom"),
+            "captured error should carry the cause: {err}"
+        );
+        assert_eq!(results[2].provider_kind, "openai");
+        assert_eq!(results[2].model_name, None);
+        assert_eq!(results[2].outcome.as_deref().unwrap(), "CCC");
+    }
+
+    #[test]
+    fn run_panel_results_feed_the_multi_model_envelope() {
+        use crate::llm::ProviderKind;
+        use crate::test_support::StubLlmProvider;
+        let providers: Vec<Box<dyn llm::LlmProvider>> = vec![
+            Box::new(StubLlmProvider::ok(
+                ProviderKind::Ollama,
+                Some("m1"),
+                "  spaced review  ",
+            )),
+            Box::new(StubLlmProvider::err(
+                ProviderKind::Anthropic,
+                Some("m2"),
+                "provider exploded",
+            )),
+        ];
+        let results = run_panel(providers, "diff".to_string()).unwrap();
+        let env = build_review_envelope(
+            "main",
+            None,
+            "1 file changed",
+            &["specX".to_string()],
+            &results,
+        );
+
+        assert_eq!(env["base"], "main");
+        assert_eq!(env["spec_context"][0], "specX");
+        let reviews = env["reviews"].as_array().unwrap();
+        assert_eq!(reviews.len(), 2);
+        assert_eq!(reviews[0]["provider"], "ollama");
+        assert_eq!(reviews[0]["model"], "m1");
+        assert_eq!(reviews[0]["review"], "spaced review"); // trimmed by insert_result_fields
+        assert!(reviews[0]["elapsed_seconds"].is_number());
+        assert_eq!(reviews[1]["provider"], "anthropic");
+        assert_eq!(reviews[1]["error"], "provider exploded");
+        assert!(reviews[1].get("review").is_none());
+        // Multi-model panels carry no legacy top-level fields.
+        assert!(env.get("review").is_none());
+        assert!(env.get("provider").is_none());
+    }
+
+    #[test]
+    fn run_panel_single_provider_envelope_keeps_legacy_fields() {
+        use crate::llm::ProviderKind;
+        use crate::test_support::StubLlmProvider;
+        let providers: Vec<Box<dyn llm::LlmProvider>> = vec![Box::new(StubLlmProvider::ok(
+            ProviderKind::Ollama,
+            Some("solo"),
+            "the review",
+        ))];
+        let results = run_panel(providers, "diff".to_string()).unwrap();
+        let env = build_review_envelope("main", None, "", &[], &results);
+
+        // Single-model runs mirror the result into legacy top-level fields.
+        assert_eq!(env["provider"], "ollama");
+        assert_eq!(env["model"], "solo");
+        assert_eq!(env["review"], "the review");
+        // …and still populate the array form.
+        assert_eq!(env["reviews"][0]["review"], "the review");
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -200,3 +200,58 @@ impl TestRepo {
         with_cwd(self.dir.path(), f)
     }
 }
+
+/// The canned result a [`StubLlmProvider`] yields from `invoke`.
+pub(crate) enum StubOutcome {
+    Ok(String),
+    Err(String),
+}
+
+/// A canned [`LlmProvider`](crate::llm::LlmProvider) for exercising code that
+/// fans out over providers (e.g. `review::run_panel`) with no network I/O. It
+/// returns a preset outcome and reports a fixed provider kind / model, so tests
+/// can assert ordering, per-slot error isolation, and metadata capture without
+/// a live endpoint. Shared so the `review` / `ask` / `ai` test modules can all
+/// reuse the same double.
+pub(crate) struct StubLlmProvider {
+    kind: crate::llm::ProviderKind,
+    model: Option<String>,
+    outcome: StubOutcome,
+}
+
+impl StubLlmProvider {
+    /// A provider whose `invoke` succeeds with `response`.
+    pub(crate) fn ok(kind: crate::llm::ProviderKind, model: Option<&str>, response: &str) -> Self {
+        Self {
+            kind,
+            model: model.map(str::to_string),
+            outcome: StubOutcome::Ok(response.to_string()),
+        }
+    }
+
+    /// A provider whose `invoke` fails with `message` (as an `anyhow` error).
+    pub(crate) fn err(kind: crate::llm::ProviderKind, model: Option<&str>, message: &str) -> Self {
+        Self {
+            kind,
+            model: model.map(str::to_string),
+            outcome: StubOutcome::Err(message.to_string()),
+        }
+    }
+}
+
+impl crate::llm::LlmProvider for StubLlmProvider {
+    fn invoke(&self, _prompt: &str) -> anyhow::Result<String> {
+        match &self.outcome {
+            StubOutcome::Ok(s) => Ok(s.clone()),
+            StubOutcome::Err(e) => anyhow::bail!("{e}"),
+        }
+    }
+
+    fn kind(&self) -> crate::llm::ProviderKind {
+        self.kind
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+}


### PR DESCRIPTION
## Summary

The **LLM-HTTP half** of the #447 mocking harness. The git/subprocess half landed in #487 (the `TestRepo` fixture); this adds the network-side counterpart.

`review::run_panel` fans a prompt across N providers on parallel threads, sorts the results back into input order, and captures each slot's outcome so **one broken model doesn't abort the panel**. That behavior had **zero test coverage** — there was no way to drive it without a live endpoint.

**Test-only — no production code changes.**

## What's added

| File | Change |
|---|---|
| `test_support.rs` | `StubLlmProvider` — a canned `LlmProvider` (the trait already exists in `llm.rs`) with `ok()` / `err()` constructors reporting a fixed `ProviderKind` + model. No network, no interior mutability; reusable by the `review` / `ask` / `ai` test modules. |
| `review.rs` | 3 tests for `run_panel` + the envelope pipeline |

### The 3 new tests

- **`run_panel_preserves_order_and_isolates_a_failing_slot`** — `[ok, err, ok]` → 3 results in input order (despite parallel execution), the middle `Err` is *captured* not propagated, neighbours untouched, provider/model metadata correct.
- **`run_panel_results_feed_the_multi_model_envelope`** — the panel results flow into `build_review_envelope`: Ok answers trimmed, the failed slot carries `error` (not `review`), `elapsed_seconds` present, and no legacy top-level fields for a multi-model panel.
- **`run_panel_single_provider_envelope_keeps_legacy_fields`** — a single-model run still mirrors `provider` / `model` / `review` at the top level for pre-panel scripts.

## Verification

- [x] **952 → 955 tests**, 0 fail
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean
- [x] `fledge spec check` — 33 specs, 0/0 (test-only; `test_support.rs` is `cfg(test)`, no governed surface added)

## Follow-up

The remaining harness slice from the design is pure-function extraction in `github.rs` (`build_api_url` / error-message classification) so the request-building and error-mapping halves are testable without HTTP. That one touches production public surface, so it carries a small `specs/github` cost and lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
