### PR TITLE
Add living atlas spec-coverage badge

### DIFF
--- a/.atlasignore
+++ b/.atlasignore
@@ -1,0 +1,9 @@
+# fledge atlas coverage scope: the specs govern the tool's source, not these.
+
+# The marketing + docs site.
+site/
+
+# Tests, benchmarks, and examples are verified against the specs, not governed by them.
+tests/
+benches/
+examples/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+      - 'src/**'
+      - 'specs/**'
+      - '.atlasignore'
   workflow_dispatch:
   schedule:
     # Weekly Monday 08:00 UTC — refreshes plugin registry
@@ -47,6 +50,26 @@ jobs:
       - name: Run unit tests
         working-directory: site
         run: bun test
+
+      - name: Resolve pinned atlas commit (cache key)
+        id: atlasref
+        run: echo "sha=$(git ls-remote https://github.com/CorvidLabs/fledge-plugin-atlas v1 | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the fledge-atlas CLI
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/fledge-atlas
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: fledge-atlas-${{ runner.os }}-${{ steps.atlasref.outputs.sha }}
+
+      - name: Render atlas coverage badges
+        uses: CorvidLabs/fledge-plugin-atlas@v1
+        with:
+          path: .
+          output-dir: site/public/badges
+          components: "coverage langmix treemap sunburst"
 
       - name: Build site (runs prebuild for plugin registry + redirects)
         working-directory: site

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fledge
 
 [![CI](https://github.com/CorvidLabs/fledge/actions/workflows/ci.yml/badge.svg)](https://github.com/CorvidLabs/fledge/actions/workflows/ci.yml)
+[![spec coverage](https://img.shields.io/endpoint?url=https://corvidlabs.github.io/fledge/badges/coverage.json)](https://corvidlabs.github.io/fledge/)
 [![Crates.io](https://img.shields.io/crates/v/fledge)](https://crates.io/crates/fledge)
 [![Downloads](https://img.shields.io/crates/d/fledge)](https://crates.io/crates/fledge)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Living spec-coverage badge for fledge

Dogfoods the atlas GitHub Action (`uses: CorvidLabs/fledge-plugin-atlas@v1`), same as augur/attest:

- **pages.yml**: renders fledge's spec-coverage badge + SVG cards into `site/public/badges` on every deploy (Astro copies them into the published site), and caches the CLI keyed to the pinned `v1` commit.
- **.atlasignore**: scopes coverage to the tool's source, excluding the marketing site, tests, benches, and examples.
- **README**: adds the `spec coverage` endpoint badge.

Coverage reads ~99% with this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01ApSS1xj22zGwbUSkRs3mmE