### PR TITLE
docs: add #490 to the v1.7.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- living atlas spec-coverage badge (#490) (85dfe45)
 - specs for the 3 unclaimed prod modules + enforce reverse coverage (#448) (#480) (6894130)
 - trailing success confirmation with elapsed time to `fledge run` (human output) (#458) (edac3a9)
 


### PR DESCRIPTION
Completes the v1.7.0 release notes. PR #490 (living atlas spec-coverage badge) merged concurrently with the release PR #491, so it ships in v1.7.0 but was absent from the generated CHANGELOG section. Adds it under **Features** (matching fledge's own categorizer, which maps the `Add:` prefix to Features).

Docs-only; `v1.7.0` will be tagged on the commit that merges this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi