### PR TITLE
Add: render the atlas calendar component on Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -69,7 +71,7 @@ jobs:
         with:
           path: .
           output-dir: site/public/badges
-          components: "coverage langmix treemap sunburst"
+          components: "coverage langmix treemap sunburst calendar"
 
       - name: Build site (runs prebuild for plugin registry + redirects)
         working-directory: site


### PR DESCRIPTION
- Adds the atlas `calendar` component to the Pages workflow so a new calendar card is rendered and published alongside the existing coverage, langmix, treemap, and sunburst badges.
- Sets `fetch-depth: 0` on the checkout so the full git history is available — the calendar reconstructs commit cadence from history.
- YAML validated; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)