### PR TITLE
chore: release v1.7.2

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "sequence": 5,
-  "id": "CHG-0005-fix-parse-source-ref-rejecting-refs-containing-a-slash",
+  "sequence": 6,
+  "id": "CHG-0006-release-v1-7-2-bump-version-files-and-changelog",
   "acknowledged_collisions": []
 }

--- a/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/approvals.json
+++ b/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/approvals.json
@@ -41,6 +41,13 @@
       "timestamp": 1785181249,
       "digest": "904128a81f93156ea0b5e071b995d452542184f88faab5e77e2c2b523ca95ea3",
       "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1785185138,
+      "digest": "8a76a8bb6106a3d953002d5b3b6bf78adf832dc5a5b04b95b3b939781626630f",
+      "note": null
     }
   ],
   "reopenings": [
@@ -256,6 +263,219 @@
       },
       "stale_acceptance_input_digest": "11b37b518969d8f900f3c4dce01e71e1b9a53ec7bb0fa4fc33f96a2090ba9de8",
       "current_acceptance_input_digest": "90cce0adb439e2ede19c7bd6e40079474eacf8fcbf934aa00999e3fd37d170d1"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c",
+      "actor": "0xLeif",
+      "reason": "the v1.7.2 release regenerated Cargo.lock via cargo generate-lockfile, invalidating CHG-0003's exact-pinned lockfile evidence",
+      "timestamp": 1785185073,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "0xLeif",
+        "timestamp": 1785181249,
+        "digest": "904128a81f93156ea0b5e071b995d452542184f88faab5e77e2c2b523ca95ea3",
+        "note": null
+      },
+      "prior_verification": {
+        "timestamp": 1785181235,
+        "commit": "2919effe55c6800765c16dd473ee372970fc0e32",
+        "contract_digest": "cb528f7e828b90f98966d687a2d9bd8fb2eeb0c6ac06de2fc41f8f7f7c706154",
+        "workspace_digest": "8afdc98aae8c704902c1ca45a44a4daf79d0b8783e0bc29dc8a2e4439bfaad5b",
+        "acceptance_input_digest": "90cce0adb439e2ede19c7bd6e40079474eacf8fcbf934aa00999e3fd37d170d1",
+        "acceptance_manifest": {
+          "schema_version": 1,
+          "entries": [
+            {
+              "path": ".specsync/change-sequence.json",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "4948490044de1727d9007a01fa85575a8f25cfafa0053353bd0895bdae766a61",
+              "entry_digest": "7498ab56cab762889e0f21923c200666ce7cfc0c6c628ca6652c3ea8d504c421",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "Cargo.lock",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "fb9234eccd2fdde70beb549193f92b7e04f6ae534f7ad08508a97e9156001271",
+              "entry_digest": "4bd160a3b865ca3eb6471fa8451b86352c92633269a349d73839a22a69a0185c",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "Cargo.toml",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "c5240428ce0904016f94e49d2ed126471c9bd95d2f2ec52bc1a975010bff18d8",
+              "entry_digest": "558005a11d5fe296f1d53c4abef5db7ff5b23246ccd719b74aa916b6940e3e83",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "specs/main/context.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "e8b5d78ef737ace3ea5bfc969bc5f2d8907e06ac84165b79ec3daf4ba76202e3",
+              "entry_digest": "5273e060e93707219601fc42e2e2912c42fea2b48f1320861e15f73b9ae8687a",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "specs/main/main.spec.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "2ee728d59ca9f8be41a2cb6c728f6af8e73ac066efb88030b623a6dfd214a638",
+              "entry_digest": "9e1b04b6410b0c614379d2ae914730efa7a0aff36c778cd35652022a81edf76c",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "specs/main/requirements.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "5b85646ae1df82e5c5d4d838a1408cc426e8a2f475481bc14c982f83e39e636e",
+              "entry_digest": "20da87c0d055f3dc8d6f6dc5f0080811a19b1b621113903936ca90159cdc90be",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "specs/main/tasks.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "d79b3cf6e87c830df8f0e2822d39c5431770d535d175153404d2c4f947288fd7",
+              "entry_digest": "a325fddd1aae00eb9f3c3ec1755e7665ba9aeec6ba066b17ea816286ed377b9e",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "specs/main/testing.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "e6536a58ac81b1d83448a71d29985e071e414e3ac8c40aabafdbf9da8e93c72d",
+              "entry_digest": "19523195cf9045043591ff903c6eecd4ceae10d1d3e930ce43c7ba255f23d2e9",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "specs/utils/context.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "fcef3526b56c81e107de5731db51c680fc78e5946ad2e6db32521f9a783489ab",
+              "entry_digest": "8998112d7d54dd61fbf28406de8c8b2ff2cc08b32cef9723d00f08bbe96998ef",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "specs/utils/requirements.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "fde289465f4008ca3fbf47a4e23ea6ec97f1663afa46e4a1157ca3a5f1c8a33b",
+              "entry_digest": "c3938876bc0058c562cad38b6cbb96ec310c0282cfdb2d55715be70f69940251",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "specs/utils/tasks.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "1967899908191828ad021c5273fae16367434e08ebda54b41637aa3d524c4cfb",
+              "entry_digest": "91da679f66ee3830c48395683aef1caa66cad99e3667be1bbc51409613d1ee81",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "specs/utils/testing.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "5188bce480b6989bd322b6a737d7c05f29b6f63ead7041eca95f9f6e268ed8b4",
+              "entry_digest": "bbca533d24c45fa77eaeaa6f23e0ce6ab58fe195fb88b6c5956f4b8065da47e9",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "specs/utils/utils.spec.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "2b2d9d734c7d354e49a5bbea1d5975fde9d6b8d8587310fc63fde96fbee5300a",
+              "entry_digest": "52e42759906f3a5dd9c33ff84cd67027c5b1dfe39072c964a9de24a03dc6b9ce",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "src/cli.rs",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "caf036a9feec3f7c6c12e2695f7c8d511ec986dd3f56ee3b4e2fe7323ede2699",
+              "entry_digest": "60093a5721b9947dcfd294f4d03847374b1a7e58270c63fac12f0f952de53329",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "src/main.rs",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "9032b92d228702bb6e6bf31c40c59792f8011b1ffe69c242d49052f222dc59e2",
+              "entry_digest": "681233db5785e03774dd9de3aff914a94c04180e5015ca1a48ccd9598c987485",
+              "owners": [
+                "main"
+              ]
+            },
+            {
+              "path": "src/utils.rs",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "1cc420c1b8b8f2281c3f95115d5ef9a100e1a8a9ddbc0923af2082f60ef39c27",
+              "entry_digest": "8b91f5771e27876b94dac7fa77a3c3bde2ad0724dbace3d9a0fc230187aace6f",
+              "owners": [
+                "utils"
+              ]
+            },
+            {
+              "path": "tests/templates.rs",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "320d256919d6c0f0963734b15bd89f06d4f929e5be4a44e956515fd38c3d03d3",
+              "entry_digest": "783226d0332e5099c74a759f2fb40aa616703818f0ac3e89630b7b3d49ba76c8",
+              "owners": [
+                "@exact:test"
+              ]
+            }
+          ]
+        },
+        "passed": true,
+        "commands": [
+          {
+            "command": "fledge lanes run verify-native",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-main-005",
+          "REQ-main-006",
+          "REQ-utils-010"
+        ]
+      },
+      "stale_acceptance_input_digest": "90cce0adb439e2ede19c7bd6e40079474eacf8fcbf934aa00999e3fd37d170d1",
+      "current_acceptance_input_digest": "c2d2659a31dce0ca09ee825a7df3d79a8582bad5082e735ea8cc92cfa7cad700"
     }
   ]
 }

--- a/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/state.json
+++ b/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "fb6260ec05933dc8e11018bf6cfb66d482161078",
   "created_at": 1785170013,
-  "updated_at": 1785181249,
+  "updated_at": 1785185138,
   "affected_specs": [
     "main",
     "utils"

--- a/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/verification-attempts.json
+++ b/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/verification-attempts.json
@@ -152,6 +152,25 @@
         "REQ-main-006",
         "REQ-utils-010"
       ]
+    },
+    {
+      "timestamp": 1785185122,
+      "commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
+      "contract_digest": "cb528f7e828b90f98966d687a2d9bd8fb2eeb0c6ac06de2fc41f8f7f7c706154",
+      "workspace_digest": "3d7d314cbe25d454c9296585a8b246783367fe3a53d857add677790f95a10a73",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify-native",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-main-005",
+        "REQ-main-006",
+        "REQ-utils-010"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/verification.json
+++ b/.specsync/changes/CHG-0003-fix-bare-fledge-exit-code-and-restore-cursor-on-ctrl-c/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1785181235,
-  "commit": "2919effe55c6800765c16dd473ee372970fc0e32",
+  "timestamp": 1785185122,
+  "commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
   "contract_digest": "cb528f7e828b90f98966d687a2d9bd8fb2eeb0c6ac06de2fc41f8f7f7c706154",
-  "workspace_digest": "8afdc98aae8c704902c1ca45a44a4daf79d0b8783e0bc29dc8a2e4439bfaad5b",
-  "acceptance_input_digest": "90cce0adb439e2ede19c7bd6e40079474eacf8fcbf934aa00999e3fd37d170d1",
+  "workspace_digest": "3d7d314cbe25d454c9296585a8b246783367fe3a53d857add677790f95a10a73",
+  "acceptance_input_digest": "c2d2659a31dce0ca09ee825a7df3d79a8582bad5082e735ea8cc92cfa7cad700",
   "acceptance_manifest": {
     "schema_version": 1,
     "entries": [
@@ -21,8 +21,8 @@
         "path": "Cargo.lock",
         "kind": "file",
         "mode": 33188,
-        "payload_digest": "fb9234eccd2fdde70beb549193f92b7e04f6ae534f7ad08508a97e9156001271",
-        "entry_digest": "4bd160a3b865ca3eb6471fa8451b86352c92633269a349d73839a22a69a0185c",
+        "payload_digest": "83367461551b0807e5bc71063be51cd553026ce2fa0475e66cab746a819a0b09",
+        "entry_digest": "49b77a2c4b7712c74ede05f22425a097187852807eda75fc3bf5f1dc119fd262",
         "owners": [
           "@exact:delivery"
         ]
@@ -31,8 +31,8 @@
         "path": "Cargo.toml",
         "kind": "file",
         "mode": 33188,
-        "payload_digest": "c5240428ce0904016f94e49d2ed126471c9bd95d2f2ec52bc1a975010bff18d8",
-        "entry_digest": "558005a11d5fe296f1d53c4abef5db7ff5b23246ccd719b74aa916b6940e3e83",
+        "payload_digest": "b0769772cfb33264e6f6c3b019c6909d0db30d1d62be68030d3033223f25489e",
+        "entry_digest": "9425e72a06292c8c59fda52030cb2eed598b32fe220194cdb5efef7a27a7206b",
         "owners": [
           "@exact:delivery"
         ]

--- a/.specsync/changes/CHG-0004-release-v1-7-1-bump-version-files-and-changelog/approvals.json
+++ b/.specsync/changes/CHG-0004-release-v1-7-1-bump-version-files-and-changelog/approvals.json
@@ -20,7 +20,104 @@
       "timestamp": 1785181197,
       "digest": "72c724246fbd62054d826562e48190c144d05fb081fa052c97abc32dd6ce2bfb",
       "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1785185183,
+      "digest": "1252a150fd7f645dea1a43eee445250015e7889c543618f2be1925fee8bb73c3",
+      "note": null
     }
   ],
-  "reopenings": []
+  "reopenings": [
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0004-release-v1-7-1-bump-version-files-and-changelog",
+      "actor": "0xLeif",
+      "reason": "the v1.7.2 release appended a new CHANGELOG.md entry, invalidating CHG-0004's exact-pinned changelog evidence",
+      "timestamp": 1785185090,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "0xLeif",
+        "timestamp": 1785181197,
+        "digest": "72c724246fbd62054d826562e48190c144d05fb081fa052c97abc32dd6ce2bfb",
+        "note": null
+      },
+      "prior_verification": {
+        "timestamp": 1785181186,
+        "commit": "2919effe55c6800765c16dd473ee372970fc0e32",
+        "contract_digest": "579fccb803c22ff3338ce0411595dbec36be58f0b0dd73ce65071fa88a94ed81",
+        "workspace_digest": "8afdc98aae8c704902c1ca45a44a4daf79d0b8783e0bc29dc8a2e4439bfaad5b",
+        "acceptance_input_digest": "2eee885f6e915bf1fdb8b777b96e63fe33b60b14145890bac30fbf02ad4cb494",
+        "acceptance_manifest": {
+          "schema_version": 1,
+          "entries": [
+            {
+              "path": ".specsync/change-sequence.json",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "0d7c8d73b771f720b758ec1767248626d7785e2e9e50251bba153b3f57b5fc82",
+              "entry_digest": "cfd45ec6e986216f5b5bb770e39b5b18a11a8b10af8dba642b7909a6597c47d2",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "CHANGELOG.md",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "5acdc942089f746bd9b2b65db55dd1d91349f35c22ed88c87c05eb43858a1734",
+              "entry_digest": "a32e33391dd197eaf744af6e5202e4a52bc834cae1ffc0fd8a2729266574d31f",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "Cargo.lock",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "fb9234eccd2fdde70beb549193f92b7e04f6ae534f7ad08508a97e9156001271",
+              "entry_digest": "4bd160a3b865ca3eb6471fa8451b86352c92633269a349d73839a22a69a0185c",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "Cargo.toml",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "c5240428ce0904016f94e49d2ed126471c9bd95d2f2ec52bc1a975010bff18d8",
+              "entry_digest": "558005a11d5fe296f1d53c4abef5db7ff5b23246ccd719b74aa916b6940e3e83",
+              "owners": [
+                "@exact:delivery"
+              ]
+            },
+            {
+              "path": "flake.nix",
+              "kind": "file",
+              "mode": 33188,
+              "payload_digest": "d856f9451fa60e2fd6679bdd559fc790d417abc603532695785bc33c5bd0936d",
+              "entry_digest": "51935a1068dbba4ae7ff8339e06eabc41276209c402b7a2d7040f467569558a9",
+              "owners": [
+                "@exact:delivery"
+              ]
+            }
+          ]
+        },
+        "passed": true,
+        "commands": [
+          {
+            "command": "fledge lanes run verify-native",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": []
+      },
+      "stale_acceptance_input_digest": "2eee885f6e915bf1fdb8b777b96e63fe33b60b14145890bac30fbf02ad4cb494",
+      "current_acceptance_input_digest": "ebc982ef37336caeb9b9c2fc80b2691672d4ab0e05b1bc6630962d0586321e4c"
+    }
+  ]
 }

--- a/.specsync/changes/CHG-0004-release-v1-7-1-bump-version-files-and-changelog/verification-attempts.json
+++ b/.specsync/changes/CHG-0004-release-v1-7-1-bump-version-files-and-changelog/verification-attempts.json
@@ -15,6 +15,21 @@
         }
       ],
       "requirement_ids": []
+    },
+    {
+      "timestamp": 1785185169,
+      "commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
+      "contract_digest": "579fccb803c22ff3338ce0411595dbec36be58f0b0dd73ce65071fa88a94ed81",
+      "workspace_digest": "3d7d314cbe25d454c9296585a8b246783367fe3a53d857add677790f95a10a73",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify-native",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
     }
   ]
 }

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/approvals.json
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/approvals.json
@@ -1,0 +1,19 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1785184922,
+      "digest": "486977c4bc0e603dbd246ee4cb079571b231402f45d3b1ad1d9ab539bd7c2638",
+      "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1785185011,
+      "digest": "57865ee21a7c93ed8b2e7b6ab6feda6bf3b9d22aa489858457a684c3531f8370",
+      "note": null
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/change.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+state: accepted
+type: operations
+base_commit: 06c14e73d71f0ad62bdf3545440d2e9da015d7e3
+---
+
+# Release v1.7.2: bump version files and changelog
+
+## Intent
+
+Release v1.7.2: bump version files and changelog
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Cargo.toml/flake.nix report 1.7.2; CHANGELOG.md has a v1.7.2 entry; fledge lanes run verify-native passes
+
+## No-spec Rationale
+
+Routine version/changelog bump via fledge release patch; no runtime behavior or spec contract changes

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/context.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/context.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+artifact: context
+---
+
+# Context
+
+`fledge release patch` bumps `Cargo.toml`/`flake.nix` to the new version, regenerates
+`Cargo.lock`, and appends a `CHANGELOG.md` entry. This release includes the
+`parse_source_ref` slash-ref fix (#501). Routine release mechanics with no runtime
+behavior change; this change exists purely to give the release commit SpecSync coverage
+(same pattern as CHG-0004 for v1.7.1).

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/design.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/design.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+artifact: design
+---
+
+# Design
+
+No design decisions: `fledge release patch` handles the mechanics (version bump,
+lockfile regeneration, changelog generation) per its existing implementation in
+`src/release/`. This change only registers those already-produced file changes
+with SpecSync so the delivery diff has coverage.

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/plan.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/plan.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+artifact: plan
+---
+
+# Plan
+
+1. Run `fledge release patch` to bump `Cargo.toml`/`flake.nix`, regenerate `Cargo.lock`,
+   and append the `CHANGELOG.md` entry.
+2. Register this SpecSync change to cover the touched paths.
+3. Verify and accept.

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/state.json
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/state.json
@@ -1,15 +1,15 @@
 {
   "schema_version": 1,
-  "id": "CHG-0004-release-v1-7-1-bump-version-files-and-changelog",
-  "slug": "release-v1-7-1-bump-version-files-and-changelog",
-  "title": "Release v1.7.1: bump version files and changelog",
-  "description": "Release v1.7.1: bump version files and changelog",
+  "id": "CHG-0006-release-v1-7-2-bump-version-files-and-changelog",
+  "slug": "release-v1-7-2-bump-version-files-and-changelog",
+  "title": "Release v1.7.2: bump version files and changelog",
+  "description": "Release v1.7.2: bump version files and changelog",
   "kind": "operations",
   "state": "accepted",
   "canonical_applied": true,
-  "base_commit": "2919effe55c6800765c16dd473ee372970fc0e32",
-  "created_at": 1785180915,
-  "updated_at": 1785185183,
+  "base_commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
+  "created_at": 1785184608,
+  "updated_at": 1785185011,
   "affected_specs": [],
   "affected_paths": [
     "Cargo.toml",
@@ -21,7 +21,7 @@
   "no_spec_change": true,
   "no_spec_change_rationale": "Routine version/changelog bump via fledge release patch; no runtime behavior or spec contract changes",
   "acceptance_criteria": [
-    "Cargo.toml/flake.nix report 1.7.1; CHANGELOG.md has a v1.7.1 entry; fledge lanes run verify-native passes"
+    "Cargo.toml/flake.nix report 1.7.2; CHANGELOG.md has a v1.7.2 entry; fledge lanes run verify-native passes"
   ],
   "selected_artifacts": [
     "context",

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/tasks.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/tasks.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Run `fledge release patch` (bumps Cargo.toml/flake.nix, regenerates Cargo.lock, updates CHANGELOG.md)
+- [x] Register this SpecSync change
+- [x] Verify and accept

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/testing.md
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/testing.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0006-release-v1-7-2-bump-version-files-and-changelog
+artifact: testing
+---
+
+# Testing
+
+- `fledge lanes run verify-native` passes (fmt, lint, test-governance, build, validate-templates).
+- `Cargo.toml`/`flake.nix` both report `1.7.2`.
+- `CHANGELOG.md` has a `v1.7.2` entry.

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/verification-attempts.json
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/verification-attempts.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1785184995,
+      "commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
+      "contract_digest": "486977c4bc0e603dbd246ee4cb079571b231402f45d3b1ad1d9ab539bd7c2638",
+      "workspace_digest": "3d7d314cbe25d454c9296585a8b246783367fe3a53d857add677790f95a10a73",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify-native",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/verification.json
+++ b/.specsync/changes/CHG-0006-release-v1-7-2-bump-version-files-and-changelog/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1785185169,
+  "timestamp": 1785184995,
   "commit": "06c14e73d71f0ad62bdf3545440d2e9da015d7e3",
-  "contract_digest": "579fccb803c22ff3338ce0411595dbec36be58f0b0dd73ce65071fa88a94ed81",
+  "contract_digest": "486977c4bc0e603dbd246ee4cb079571b231402f45d3b1ad1d9ab539bd7c2638",
   "workspace_digest": "3d7d314cbe25d454c9296585a8b246783367fe3a53d857add677790f95a10a73",
-  "acceptance_input_digest": "ebc982ef37336caeb9b9c2fc80b2691672d4ab0e05b1bc6630962d0586321e4c",
+  "acceptance_input_digest": "d266aee77cd627576d316486e991e112c57bc2fab2811883a0287cddedbb4f6a",
   "acceptance_manifest": {
     "schema_version": 1,
     "entries": [
@@ -11,8 +11,8 @@
         "path": ".specsync/change-sequence.json",
         "kind": "file",
         "mode": 33188,
-        "payload_digest": "0d7c8d73b771f720b758ec1767248626d7785e2e9e50251bba153b3f57b5fc82",
-        "entry_digest": "cfd45ec6e986216f5b5bb770e39b5b18a11a8b10af8dba642b7909a6597c47d2",
+        "payload_digest": "ecd3b037b4182b45b633ca881f79f1acccad120e29c9712e281309ea51fe990c",
+        "entry_digest": "6cb767226f4656aa161a4ef32674d15c0152bc6abfec92923faa7835d06d9cab",
         "owners": [
           "@exact:delivery"
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.2] - 2026-07-27
+
+### Fixes
+
+- parse_source_ref rejecting refs containing a slash (#501) (1bd04d0)
+
 ## [v1.7.1] - 2026-07-27
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fledge"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fledge"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 authors = ["0xLeif <leif.algo@pm.me>"]
 description = "Dev lifecycle CLI. One tool for the dev loop, any language."

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "fledge";
-          version = "1.7.1";
+          version = "1.7.2";
           src = self;
 
           cargoLock = {


### PR DESCRIPTION
## Summary
- Bumps version to 1.7.2 in Cargo.toml/flake.nix, updates Cargo.lock, and generates the CHANGELOG.md entry via `fledge release patch`
- Includes the parse_source_ref slash-ref fix (#501)

## Test plan
- [x] `fledge lanes run pre-commit` passed
- [x] `fledge trust verify` passed
- [x] `specsync change check --strict --require-coverage 100` passes (6 active changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F4jsbbHAZtUrKf6MmYDM2